### PR TITLE
Clears the selection of the TreePane after the user action has been c…

### DIFF
--- a/src/org/openlcb/swing/networktree/TreePane.java
+++ b/src/org/openlcb/swing/networktree/TreePane.java
@@ -89,8 +89,14 @@ public class TreePane extends JPanel  {
 
     }
     
-    public void addTreeSelectionListener(TreeSelectionListener listener) {
-        tree.addTreeSelectionListener(listener);
+    public void addTreeSelectionListener(final TreeSelectionListener listener) {
+        tree.addTreeSelectionListener(new TreeSelectionListener() {
+            @Override
+            public void valueChanged(TreeSelectionEvent treeSelectionEvent) {
+                listener.valueChanged(treeSelectionEvent);
+                tree.getSelectionModel().clearSelection();
+            }
+        });
     }
 	
 }


### PR DESCRIPTION
…arried out. This fixes the problem that the user cannot click on "the same CDI" link twice, because between the first and the second click the selection does not change and thus the callback is not executed again.