### PR TITLE
Fix bug in CDI variable offset calculation.

### DIFF
--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -14,7 +14,7 @@ import org.openlcb.swing.EventIdTextField;
  * Works with a CDI reader.
  *
  * @author  Bob Jacobsen   Copyright 2011
- * @version $Revision: -1 $
+ * @author  Paul Bender Copyright 2016
  */
 public class CdiPanel extends JPanel {
 
@@ -224,6 +224,7 @@ public class CdiPanel extends JPanel {
             setAlignmentX(Component.LEFT_ALIGNMENT);
             String name = (item.getName() != null ? (item.getName()) : "Group");
             setBorder(BorderFactory.createTitledBorder(name));
+            setName(name);
 
             String d = item.getDescription();
             if (d != null) {
@@ -244,6 +245,8 @@ public class CdiPanel extends JPanel {
                 rep = 1;  // default
             }
             JPanel currentPane = this;
+            JTabbedPane tabbedPane = new JTabbedPane();
+            currentPane.add(tabbedPane);
             for (int i = 0; i < rep; i++) {
                 if (rep != 1) {
                     // nesting a pane
@@ -274,6 +277,7 @@ public class CdiPanel extends JPanel {
                         
                         if (it instanceof CdiRep.Group) {
                             pane = createGroupPane((CdiRep.Group) it, origin, space);
+                            pane.setName(name);
                         } else if (it instanceof CdiRep.BitRep) {
                             pane = createBitPane((CdiRep.BitRep) it, origin, space);
                         } else if (it instanceof CdiRep.IntegerRep) {
@@ -284,9 +288,15 @@ public class CdiPanel extends JPanel {
                             pane = createStringPane((CdiRep.StringRep) it, origin,space);
                         }
                         if (pane != null) {
-                            size = size + pane.getVarSize();
-                            origin = pane.getOrigin() + pane.getVarSize();
-                            currentPane.add(pane);
+                            if(it instanceof CdiRep.Group ) {
+                               tabbedPane.add(pane); 
+                               size = size + pane.getVarSize();
+                               origin = pane.getOrigin() + pane.getVarSize();
+                            } else {
+                               size = size + pane.getVarSize();
+                               origin = pane.getOrigin() + pane.getVarSize();
+                               currentPane.add(pane);
+                            }
                         } else { // pane == null, either didn't select a type or something went wrong in creation.
                             System.out.println("could not process type of " + it);
                         }

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -222,7 +222,7 @@ public class CdiPanel extends JPanel {
             setAlignmentX(Component.LEFT_ALIGNMENT);
             String name = (item.getName() != null ? (item.getName()) : "Group");
             setBorder(BorderFactory.createTitledBorder(name));
-            setName(name);
+
             String d = item.getDescription();
             if (d != null) {
                 add(createDescriptionPane(d));
@@ -242,8 +242,6 @@ public class CdiPanel extends JPanel {
                 rep = 1;  // default
             }
             JPanel currentPane = this;
-            JTabbedPane tabbedPane = new JTabbedPane();
-            currentPane.add(tabbedPane);
             for (int i = 0; i < rep; i++) {
                 if (rep != 1) {
                     // nesting a pane
@@ -272,7 +270,6 @@ public class CdiPanel extends JPanel {
                         
                         if (it instanceof CdiRep.Group) {
                             pane = createGroupPane((CdiRep.Group) it, origin, space);
-                            pane.setName(name);
                         } else if (it instanceof CdiRep.BitRep) {
                             pane = createBitPane((CdiRep.BitRep) it, origin, space);
                         } else if (it instanceof CdiRep.IntegerRep) {
@@ -283,13 +280,9 @@ public class CdiPanel extends JPanel {
                             pane = createStringPane((CdiRep.StringRep) it, origin,space);
                         }
                         if (pane != null) {
-                            if(it instanceof CdiRep.Group ) {
-                               tabbedPane.add(pane);
-                            } else {
-                               //size = size + pane.getVarSize();
-                               //origin = pane.getOrigin() + pane.getVarSize();
-                               currentPane.add(pane);
-                            }
+                            size = size + pane.getVarSize();
+                            origin = pane.getOrigin() + pane.getVarSize();
+                            currentPane.add(pane);
                         } else { // pane == null, either didn't select a type or something went wrong in creation.
                             System.out.println("could not process type of " + it);
                         }

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -44,7 +44,9 @@ public class CdiPanel extends JPanel {
     GuiItemFactory factory;
     
     public void loadCDI(CdiRep c) {
-        add(createIdentificationPane(c));
+        if (c.getIdentification() != null) {
+            add(createIdentificationPane(c));
+        }
         
         java.util.List<CdiRep.Segment> segments = c.getSegments();
         for (int i=0; i<segments.size(); i++) {
@@ -263,7 +265,9 @@ public class CdiPanel extends JPanel {
                         
                         origin = origin +it.getOffset();
                         size = size + it.getOffset();
-                        
+                        //System.err.println("Origin " + origin + " csize " + size + " type " + it
+                        //        .getClass().getSimpleName());
+
                         // Following code smells bad.  CdiRep is a representational
                         // class, shouldn't contain a "makeRepresentation" method,
                         // but some sort of dispatch would be better than this.

--- a/test/org/openlcb/cdi/jdom/SampleFactory.java
+++ b/test/org/openlcb/cdi/jdom/SampleFactory.java
@@ -126,11 +126,40 @@ public class SampleFactory {
 
         return root;
     }
-    
+
+    /**
+     *
+     * @return An example configuration with complicated offset computation cases.
+     */
+    public static Element getOffsetSample() {
+        Element root = new Element("cdi");
+
+        root.addContent(new Element("segment").setAttribute("space", "13").setAttribute("origin", "132")
+                .addContent(new Element("int").setAttribute("size", "2").setAttribute("offset","21"))
+                .addContent(new Element("eventid").setAttribute("offset","3"))
+                .addContent(new Element("group").setAttribute("offset", "1"))
+                .addContent(new Element("int").setAttribute("size", "1"))
+                .addContent(new Element("group").setAttribute("replication", "2").setAttribute("offset", "11")
+                        .addContent(new Element("int").setAttribute("size", "2").setAttribute("offset","3"))
+                        .addContent(new Element("group").setAttribute("offset", "-5"))
+                        .addContent(new Element("group").setAttribute("replication", "3")
+                            .addContent(new Element("string").setAttribute("size", "9"))
+                        )
+                )
+                .addContent(new Element("int").setAttribute("size", "2").setAttribute("offset","21"))
+        );
+
+        root.addContent(new Element("segment").setAttribute("space", "14").setAttribute("origin", "0").addContent(new Element("int").setAttribute("size", "2")));
+
+        return root;
+    }
+
+
+
     // Main entry point for standalone run
     static public void main(String[] args) {
         // dump a document to stdout
-        Element root = getBasicSample();
+        Element root = getOffsetSample();
         Document doc = new Document(root);
         
         try {

--- a/test/org/openlcb/cdi/swing/CdiPanelTest.java
+++ b/test/org/openlcb/cdi/swing/CdiPanelTest.java
@@ -11,10 +11,18 @@ import junit.framework.TestSuite;
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+
 import javax.swing.*;
 
 import org.jdom2.*;
 import org.jdom2.input.SAXBuilder;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * @author  Bob Jacobsen   Copyright 2012
@@ -110,7 +118,71 @@ public class CdiPanelTest extends TestCase {
         f.pack();
         f.setVisible(true);        
     }
-    
+
+    public void testOffsets() {
+      /* Annotated CDI:
+<cdi>
+  <segment space="13" origin="132">
+    <int size="2" offset="21" />  // 153
+    <eventid offset="3" />  // 158
+    <group offset="1" />
+    <int size="1" />  // 167
+    <group replication="2" offset="11">  // 179 is first, 206 is second
+      <int size="2" offset="3" />  // 182, 209
+      <group offset="-5" />  // 179 is first
+      <group replication="3">  // 179 is first-first, 209 is second-first
+        <string size="9" /> // 179, 188, 197, 206, 215, 224
+      </group>
+    </group>
+    <int size="2" offset="21" />  // 254
+  </segment>
+  <segment space="14" origin="0">
+    <int size="2" />
+  </segment>
+</cdi>
+
+       */
+        CdiPanel m = new CdiPanel();
+
+        final ArrayList<JButton> readButtons = new ArrayList<>();
+
+        CdiPanel.ReadWriteAccess access = mock(CdiPanel.ReadWriteAccess.class);
+        m.initComponents(access, new CdiPanel.GuiItemFactory() {
+                    public JButton handleReadButton(JButton button) {
+                        readButtons.add(button);
+                        return button;
+                    }});
+
+        m.loadCDI(
+                new org.openlcb.cdi.jdom.JdomCdiRep(
+                        org.openlcb.cdi.jdom.SampleFactory.getOffsetSample())
+        );
+
+        final int[][] readOffsets = {
+                {153, 2, 13},
+                {158, 8, 13},
+                {167, 1, 13},
+                {182, 2, 13},
+                {179, 9, 13},
+                {188, 9, 13},
+                {197, 9, 13},
+                {209, 2, 13},
+                {206, 9, 13},
+                {215, 9, 13},
+                {224, 9, 13},
+                {254, 2, 13},
+                {0, 2, 14}
+        };
+        for (int i = 0; i < readButtons.size() && i < readOffsets.length; ++i) {
+            readButtons.get(i).doClick();
+            verify(access).doRead(eq((long)readOffsets[i][0]), eq(readOffsets[i][2]), eq
+                    (readOffsets[i][1]), any());
+            verifyNoMoreInteractions(access);
+        }
+    }
+
+
+
     // Main entry point
     static public void main(String[] args) {
         String[] testCaseName = {CdiPanelTest.class.getName()};


### PR DESCRIPTION
This reverts commit d251808eea2c93452febfedb7a2e659924306817.

I'm not sure this code was meant to be upstreamed yet. It breaks the CDI configuration dialog; it seems the field offsets have a bug. Performing "Read All" with this commit does not work; also clicking the read button on anything except the first text field just returns zeros. It also has a tendency to lock up the MemoryConfig client in JMRI which is probably a second bug.

From the network log I see the following request:
 20.41.FF.FF.FF.F4.8

which suggests that JMRI is trying to read from a negative offset.

@pabender  any ideas?