### PR TITLE
Fixes alignment and some stretch issues in the CDIPane

### DIFF
--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -92,6 +92,7 @@ public class CdiPanel extends JPanel {
         
         JPanel ret = new util.CollapsiblePanel("Identification", p);
         ret.setAlignmentY(Component.TOP_ALIGNMENT);
+        ret.setAlignmentX(Component.LEFT_ALIGNMENT);
         return ret;
     }
     
@@ -163,9 +164,11 @@ public class CdiPanel extends JPanel {
                     if(it instanceof CdiRep.Group) {
                         // groups should collapse.  
                         JPanel colPane = new util.CollapsiblePanel(it.getName(), pane);
+                        colPane.setAlignmentX(Component.LEFT_ALIGNMENT);
                         p.add(colPane);
                     } else {
-                       p.add(pane);
+                        pane.setAlignmentX(Component.LEFT_ALIGNMENT);
+                        p.add(pane);
                     }
                  } else {
                      System.out.println("could not process type of " + it);
@@ -176,6 +179,7 @@ public class CdiPanel extends JPanel {
         JPanel ret = new util.CollapsiblePanel(name, p);
         // ret.setBorder(BorderFactory.createLineBorder(java.awt.Color.RED)); //debugging
         ret.setAlignmentY(Component.TOP_ALIGNMENT);
+        ret.setAlignmentX(Component.LEFT_ALIGNMENT);
         return ret;
     }
 

--- a/src/util/CollapsiblePanel.java
+++ b/src/util/CollapsiblePanel.java
@@ -85,6 +85,7 @@ public class CollapsiblePanel extends JPanel {
 		gbc.weightx = 1.0;
 		gbc.fill = gbc.HORIZONTAL;
 		gbc.gridwidth = gbc.REMAINDER;
+		gbc.anchor = gbc.FIRST_LINE_START;
 
 		selected = true;
 		headerPanel_ = new HeaderPanel(text);
@@ -95,11 +96,6 @@ public class CollapsiblePanel extends JPanel {
 		add(headerPanel_, gbc);
 		add(contentPanel_, gbc);
 		contentPanel_.setVisible(selected);
-
-		JLabel padding = new JLabel();
-		gbc.weighty = 1.0;
-		add(padding, gbc);
-
 	}
 
 	public void toggleSelection() {

--- a/src/util/CollapsiblePanel.java
+++ b/src/util/CollapsiblePanel.java
@@ -110,7 +110,13 @@ public class CollapsiblePanel extends JPanel {
 
 		headerPanel_.repaint();
 	}
-	
+
+	@Override
+	public Dimension getMaximumSize() {
+		Dimension d = super.getPreferredSize();
+		d.width = Integer.MAX_VALUE;
+		return d;
+	}
 }
 
 


### PR DESCRIPTION
- adds missing alignment to groups and various members of the GridLayouts. This prevents certain boxes from suddenly being horizontally centered.
- Removes an unnecessary vertical stretch in order to better support collapsing entries and "up" gravity. There should only be one stretchable item at the very bottom of the dialog box, not a bunch of stretchables scattered in the middle.