### PR TITLE
Revert "Fixes alignment and some stretch issues in the CDIPane"

### DIFF
--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -92,7 +92,6 @@ public class CdiPanel extends JPanel {
         
         JPanel ret = new util.CollapsiblePanel("Identification", p);
         ret.setAlignmentY(Component.TOP_ALIGNMENT);
-        ret.setAlignmentX(Component.LEFT_ALIGNMENT);
         return ret;
     }
     
@@ -164,11 +163,9 @@ public class CdiPanel extends JPanel {
                     if(it instanceof CdiRep.Group) {
                         // groups should collapse.  
                         JPanel colPane = new util.CollapsiblePanel(it.getName(), pane);
-                        colPane.setAlignmentX(Component.LEFT_ALIGNMENT);
                         p.add(colPane);
                     } else {
-                        pane.setAlignmentX(Component.LEFT_ALIGNMENT);
-                        p.add(pane);
+                       p.add(pane);
                     }
                  } else {
                      System.out.println("could not process type of " + it);
@@ -179,7 +176,6 @@ public class CdiPanel extends JPanel {
         JPanel ret = new util.CollapsiblePanel(name, p);
         // ret.setBorder(BorderFactory.createLineBorder(java.awt.Color.RED)); //debugging
         ret.setAlignmentY(Component.TOP_ALIGNMENT);
-        ret.setAlignmentX(Component.LEFT_ALIGNMENT);
         return ret;
     }
 

--- a/src/util/CollapsiblePanel.java
+++ b/src/util/CollapsiblePanel.java
@@ -85,7 +85,6 @@ public class CollapsiblePanel extends JPanel {
 		gbc.weightx = 1.0;
 		gbc.fill = gbc.HORIZONTAL;
 		gbc.gridwidth = gbc.REMAINDER;
-		gbc.anchor = gbc.FIRST_LINE_START;
 
 		selected = true;
 		headerPanel_ = new HeaderPanel(text);
@@ -96,6 +95,11 @@ public class CollapsiblePanel extends JPanel {
 		add(headerPanel_, gbc);
 		add(contentPanel_, gbc);
 		contentPanel_.setVisible(selected);
+
+		JLabel padding = new JLabel();
+		gbc.weighty = 1.0;
+		add(padding, gbc);
+
 	}
 
 	public void toggleSelection() {
@@ -110,13 +114,7 @@ public class CollapsiblePanel extends JPanel {
 
 		headerPanel_.repaint();
 	}
-
-	@Override
-	public Dimension getMaximumSize() {
-		Dimension d = super.getPreferredSize();
-		d.width = Integer.MAX_VALUE;
-		return d;
-	}
+	
 }
 
 


### PR DESCRIPTION
After looking at #23 with the tabbing in place, This breaks some of the behavior we need due to the nature of the CDI.

The CDI tool builds the GUI recursively because the XML data is inherently recursive.  With this PR in place, the items that should be contained within the tabs are no longer contained within the tabs, and that content previously was in the tabs.