### PR TITLE
Fix JavaDoc errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 classes
+/.ant-targets-build.xml

--- a/build.xml
+++ b/build.xml
@@ -233,6 +233,7 @@
            version="false"
            use="true"
            windowtitle="OpenLCB">
+      <arg value="-Xdoclint:all,-missing"/> <!-- dropping some 1.8 warnings -->
       <group title="Core" packages="org.openlcb"/>
 	  
       <classpath refid="project.class.path"    />
@@ -259,7 +260,7 @@
            package="yes"
            use="true"
            windowtitle="OpenLCB API">
-            <arg value="-Xdoclint:all,-missing,-accessibility,-html,-syntax"/> <!-- dropping some 1.8 warnings -->
+            <arg value="-Xdoclint:all,-missing"/> <!-- dropping some 1.8 warnings -->
             <doclet name="org.umlgraph.doclet.UmlGraphDoc"
                                   path="lib/UmlGraph-5.7.jar">
                 <param name="-attributes"/>

--- a/build.xml
+++ b/build.xml
@@ -3,14 +3,14 @@
 <!-- Revision $Revision: 370 $ -->
 
 <project name="OpenLCB" default="run" basedir="." xmlns:jacoco="antlib:org.jacoco.ant">
-<!-- basedir="." means all paths are relative to the "java" subdir. -->
+    <!-- basedir="." means all paths are relative to the "java" subdir. -->
 
-  <description>
-  Provides build services for OpenLCB development
-  </description>
+    <description>
+        Provides build services for OpenLCB development
+    </description>
 
-  <!-- options you might want to change during development,   -->
-  <!-- but please change them back before commiting this file -->
+    <!-- options you might want to change during development,   -->
+    <!-- but please change them back before commiting this file -->
   
     <!-- should compiler warn of use of deprecated APIs? (yes/no) -->
     <property name="deprecation" value="no" />
@@ -24,32 +24,32 @@
     <!-- JRE version -->
     <property name="jre_version" value="1.8" />
     
-  <!-- set global properties for this build -->
-  <property name="source" value="src"/>
-  <property name="test" value="test"/>
-  <property name="coveragetarget" value="./coveragereport"/>
-  <property name="target" value="classes"/>
-  <property name="jartarget" value="."/>
-  <property name="doctarget" value="doc"/>
+    <!-- set global properties for this build -->
+    <property name="source" value="src"/>
+    <property name="test" value="test"/>
+    <property name="coveragetarget" value="./coveragereport"/>
+    <property name="target" value="classes"/>
+    <property name="jartarget" value="."/>
+    <property name="doctarget" value="doc"/>
   
-  <path id="project.class.path">
-    <pathelement location="." />
-    <pathelement location="lib/junit.jar" />
-    <pathelement location="lib/xercesImpl.jar" /> <!-- only needed for tests compile and run -->
-    <pathelement location="lib/mockito-core-2.2.9-javadoc.jar" /> <!-- only needed for tests compile and run -->
-    <pathelement location="lib/mockito-core-2.2.9.jar" /> <!-- only needed for tests compile and run -->
-    <pathelement location="lib/hamcrest-core-1.3.jar" /> <!-- only needed for tests compile and run -->
-    <pathelement location="lib/byte-buddy-1.5.0.jar" /> <!-- only needed for tests compile and run -->
-    <pathelement location="lib/byte-buddy-agent-1.5.0.jar" /> <!-- only needed for tests compile and run -->
-    <pathelement location="lib/objenesis-2.4.jar" /> <!-- only needed for tests compile and run -->
-    <pathelement location="lib/jdom-2.0.5.jar" />
-    <pathelement location="lib/jdom.jar" />
-    <pathelement location="lib/jlfgr-1_0.jar" />
-    <pathelement location="lib/annotations.jar" /> <!-- only needed for compile -->
-    <pathelement location="lib/jsr305.jar" /> <!-- only needed for compile -->
-    <pathelement location="/System/Library/Java" /> <!-- MacOS X -->
-    <pathelement location="${target}/" />  <!-- last to check for name collisions -->
-  </path>
+    <path id="project.class.path">
+        <pathelement location="." />
+        <pathelement location="lib/junit.jar" />
+        <pathelement location="lib/xercesImpl.jar" /> <!-- only needed for tests compile and run -->
+        <pathelement location="lib/mockito-core-2.2.9-javadoc.jar" /> <!-- only needed for tests compile and run -->
+        <pathelement location="lib/mockito-core-2.2.9.jar" /> <!-- only needed for tests compile and run -->
+        <pathelement location="lib/hamcrest-core-1.3.jar" /> <!-- only needed for tests compile and run -->
+        <pathelement location="lib/byte-buddy-1.5.0.jar" /> <!-- only needed for tests compile and run -->
+        <pathelement location="lib/byte-buddy-agent-1.5.0.jar" /> <!-- only needed for tests compile and run -->
+        <pathelement location="lib/objenesis-2.4.jar" /> <!-- only needed for tests compile and run -->
+        <pathelement location="lib/jdom-2.0.5.jar" />
+        <pathelement location="lib/jdom.jar" />
+        <pathelement location="lib/jlfgr-1_0.jar" />
+        <pathelement location="lib/annotations.jar" /> <!-- only needed for compile -->
+        <pathelement location="lib/jsr305.jar" /> <!-- only needed for compile -->
+        <pathelement location="/System/Library/Java" /> <!-- MacOS X -->
+        <pathelement location="${target}/" />  <!-- last to check for name collisions -->
+    </path>
 
     <!-- Java Code Coverage -->
     <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml">
@@ -81,193 +81,193 @@
         <exclude name="tools/QueueSim*.class" />
         <exclude name="simulations/NodeIDCollisions.class" />
         <exclude name="scenarios/ScenarioRunner*.class" />
-<exclude name="scenarios/TwoBusesFiltered.class" />
-<exclude name="scenarios/ThreeBuses.class" />
-<exclude name="scenarios/NineOnALink.class" />
-<exclude name="scenarios/ConfigDemoApplet*.class" />
-<exclude name="scenarios/BlueGoldCheck*.class" />
-<exclude name="scenarios/TwoBuses.class" />
-<exclude name="scenarios/can/TwoOnASegment.class" />
-<exclude name="scenarios/can/CanScenarios.class" />
-<exclude name="scenarios/can/NineOnASegment.class" />
-<exclude name="scenarios/BlueGoldApplet*.class" />
+        <exclude name="scenarios/TwoBusesFiltered.class" />
+        <exclude name="scenarios/ThreeBuses.class" />
+        <exclude name="scenarios/NineOnALink.class" />
+        <exclude name="scenarios/ConfigDemoApplet*.class" />
+        <exclude name="scenarios/BlueGoldCheck*.class" />
+        <exclude name="scenarios/TwoBuses.class" />
+        <exclude name="scenarios/can/TwoOnASegment.class" />
+        <exclude name="scenarios/can/CanScenarios.class" />
+        <exclude name="scenarios/can/NineOnASegment.class" />
+        <exclude name="scenarios/BlueGoldApplet*.class" />
     </fileset>
 
     <!-- end of definitions -->
 
     <!-- target definitions start here -->
 
-  <target name="init" description="create needed directories">
-    <!-- Create the time stamp -->
-    <tstamp/>
-    <!-- Create the build directory structure used by compile -->
-    <mkdir dir="${target}"/>
-    <mkdir dir="${target}/resources" />
-  </target>
+    <target name="init" description="create needed directories">
+        <!-- Create the time stamp -->
+        <tstamp/>
+        <!-- Create the build directory structure used by compile -->
+        <mkdir dir="${target}"/>
+        <mkdir dir="${target}/resources" />
+    </target>
 
-  <target name="clean" description="remove compilation results to force rebuild">
-    <mkdir dir="${target}"/>
-    <delete includeEmptyDirs="true" quiet="true">
-      <fileset dir="${target}"/>
-      <fileset dir="${coveragetarget}"/>
-      <file file="jacoco.exec"/>
-      <file file="junit-results.xml"/>
-    </delete>
-  </target>
+    <target name="clean" description="remove compilation results to force rebuild">
+        <mkdir dir="${target}"/>
+        <delete includeEmptyDirs="true" quiet="true">
+            <fileset dir="${target}"/>
+            <fileset dir="${coveragetarget}"/>
+            <file file="jacoco.exec"/>
+            <file file="junit-results.xml"/>
+        </delete>
+    </target>
 
-  <target name="copyfiles" depends="init" description="copy resource files">
-    <copy todir="${target}">
-      <fileset dir="src/" includes="**/*.properties"  /> 
-    </copy>
-  </target>
+    <target name="copyfiles" depends="init" description="copy resource files">
+        <copy todir="${target}">
+            <fileset dir="src/" includes="**/*.properties"  /> 
+        </copy>
+    </target>
 
-  <target name="compile" depends="init, copyfiles" description="compile source, omitting tests">
-    <!-- Compile the java code from ${source} into ${target} -->
-    <javac srcdir="${source}" 
-           destdir="${target}" 
-           source="${source_version}" 
-           target="${jre_version}" 
-           fork="true"
-           includeantruntime="false"
-           memoryinitialsize="256m"
-           memorymaximumsize="256m"
-           deprecation="${deprecation}"
-           debug="yes" >
-       <!-- <compilerarg value="-Xlint:{fallthrough,path,finally,-unchecked,-serial} "/> -->
-       <!-- <compilerarg value="-Xlint:unchecked" /> -->
-       <classpath refid="project.class.path"    />
-    </javac>
-  </target>
+    <target name="compile" depends="init, copyfiles" description="compile source, omitting tests">
+        <!-- Compile the java code from ${source} into ${target} -->
+        <javac srcdir="${source}" 
+               destdir="${target}" 
+               source="${source_version}" 
+               target="${jre_version}" 
+               fork="true"
+               includeantruntime="false"
+               memoryinitialsize="256m"
+               memorymaximumsize="256m"
+               deprecation="${deprecation}"
+               debug="yes" >
+            <!-- <compilerarg value="-Xlint:{fallthrough,path,finally,-unchecked,-serial} "/> -->
+            <!-- <compilerarg value="-Xlint:unchecked" /> -->
+            <classpath refid="project.class.path"    />
+        </javac>
+    </target>
 
-  <target name="tests" depends="compile" description="compile test classes">
-    <!-- Compile the test java code from ${source} into ${target} -->
-    <copy todir="${target}">
-        <fileset dir="test/" includes="**/*.properties"  /> 
-    </copy>
-    <javac srcdir="${test}" 
-           destdir="${target}"
-           source="${source_version}" 
-           target="${jre_version}" 
-           fork="true"
-           includeantruntime="false"
-           memoryinitialsize="256m"
-           memorymaximumsize="256m"
-           deprecation="${deprecation}"
-           debug="yes" >
-       <classpath refid="project.class.path"    />
-    </javac>
-  </target>
+    <target name="tests" depends="compile" description="compile test classes">
+        <!-- Compile the test java code from ${source} into ${target} -->
+        <copy todir="${target}">
+            <fileset dir="test/" includes="**/*.properties"  /> 
+        </copy>
+        <javac srcdir="${test}" 
+               destdir="${target}"
+               source="${source_version}" 
+               target="${jre_version}" 
+               fork="true"
+               includeantruntime="false"
+               memoryinitialsize="256m"
+               memorymaximumsize="256m"
+               deprecation="${deprecation}"
+               debug="yes" >
+            <classpath refid="project.class.path"    />
+        </javac>
+    </target>
   
-  <target name="run" depends="compile, tests" description="build and run test suite">
-    <java classname="AllTest"
-	  fork="yes" >
-       <classpath refid="project.class.path"    />
-       <sysproperty key="java.security.policy" value="lib/security.policy"/> 
-       <sysproperty key="java.library.path" path=".:lib/"/>       
-    </java>
-  </target>
+    <target name="run" depends="compile, tests" description="build and run test suite">
+        <java classname="AllTest"
+              fork="yes" >
+            <classpath refid="project.class.path"    />
+            <sysproperty key="java.security.policy" value="lib/security.policy"/> 
+            <sysproperty key="java.library.path" path=".:lib/"/>       
+        </java>
+    </target>
 
-  <target name="run-travis" depends="compile, tests" description="build and run test suite">
-    <junit haltonerror="false" haltonfailure="false" showoutput="yes" printsummary="yes" fork="yes" dir="." timeout="3600000" errorProperty="test.failed" failureProperty="test.failed">
-       <classpath refid="project.class.path"    />
-       <sysproperty key="java.security.policy" value="lib/security.policy"/> 
-       <sysproperty key="java.library.path" path=".:lib/"/>       
+    <target name="run-travis" depends="compile, tests" description="build and run test suite">
+        <junit haltonerror="false" haltonfailure="false" showoutput="yes" printsummary="yes" fork="yes" dir="." timeout="3600000" errorProperty="test.failed" failureProperty="test.failed">
+            <classpath refid="project.class.path"    />
+            <sysproperty key="java.security.policy" value="lib/security.policy"/> 
+            <sysproperty key="java.library.path" path=".:lib/"/>       
             <test name="AllTest" outfile="junit-results">
                 <formatter type="xml"/>
             </test>
-    </junit>
-    <fail>
-       <condition>
-           <istrue value="${test.failed}" />
-       </condition>
-    </fail>
-  </target>
+        </junit>
+        <fail>
+            <condition>
+                <istrue value="${test.failed}" />
+            </condition>
+        </fail>
+    </target>
 
-  <target name="run-coverage" depends="compile, tests" description="build and run test suite, generating coverage report.">
-    <jacoco:coverage destfile="jacoco.exec" excludes="org.slf4j.*">
-    <junit haltonerror="false" haltonfailure="false" showoutput="yes" printsummary="withOutAndErr" fork="yes" dir="." timeout="3600000">
-       <classpath refid="project.class.path"    />
-       <sysproperty key="java.security.policy" value="lib/security.policy"/> 
-       <sysproperty key="java.library.path" path=".:lib/"/>       
-            <test name="AllTest" outfile="junit-results">
-                <formatter type="xml"/>
-            </test>
-    </junit>
-    </jacoco:coverage>
-       <jacoco:report>
-          <executiondata>
-              <file file="jacoco.exec" />
-          </executiondata>
+    <target name="run-coverage" depends="compile, tests" description="build and run test suite, generating coverage report.">
+        <jacoco:coverage destfile="jacoco.exec" excludes="org.slf4j.*">
+            <junit haltonerror="false" haltonfailure="false" showoutput="yes" printsummary="withOutAndErr" fork="yes" dir="." timeout="3600000">
+                <classpath refid="project.class.path"    />
+                <sysproperty key="java.security.policy" value="lib/security.policy"/> 
+                <sysproperty key="java.library.path" path=".:lib/"/>       
+                <test name="AllTest" outfile="junit-results">
+                    <formatter type="xml"/>
+                </test>
+            </junit>
+        </jacoco:coverage>
+        <jacoco:report>
+            <executiondata>
+                <file file="jacoco.exec" />
+            </executiondata>
 
-          <structure name="AntTestReporting">
-              <classfiles>
-                 <fileset refid="jacocofileset"/>
-              </classfiles>
-          </structure>
+            <structure name="AntTestReporting">
+                <classfiles>
+                    <fileset refid="jacocofileset"/>
+                </classfiles>
+            </structure>
 
-          <html destdir="${coveragetarget}" />
-       </jacoco:report>
+            <html destdir="${coveragetarget}" />
+        </jacoco:report>
 
-  </target>
+    </target>
 
-  <target name="bg" depends="compile, tests" description="build and run Blue/Gold test">
-    <java classname="scenarios.BlueGoldCheck"
-          dir=".." 
-	  fork="yes" >
-       <classpath refid="project.class.path"    />
-       <sysproperty key="java.security.policy" value="lib/security.policy"/> 
-       <sysproperty key="java.library.path" path=".:lib/"/>       
-    </java>
-  </target>
+    <target name="bg" depends="compile, tests" description="build and run Blue/Gold test">
+        <java classname="scenarios.BlueGoldCheck"
+              dir=".." 
+              fork="yes" >
+            <classpath refid="project.class.path"    />
+            <sysproperty key="java.security.policy" value="lib/security.policy"/> 
+            <sysproperty key="java.library.path" path=".:lib/"/>       
+        </java>
+    </target>
 
 
-  <target name="javadoc" depends="init" description="create JavaDoc for prototype code, omitting tests">
-    <javadoc packagenames="org.*"
-           maxmemory="512m"
-           sourcepath="${source}"
-           overview="src/overview.html"
-           defaultexcludes="yes"
-           destdir="${doctarget}"
-           additionalparam="-breakiterator"
-           author="true"
-           version="false"
-           use="true"
-           windowtitle="OpenLCB">
-      <arg value="-Xdoclint:all,-missing"/> <!-- dropping some 1.8 warnings -->
-      <group title="Core" packages="org.openlcb"/>
+    <target name="javadoc" depends="init" description="create JavaDoc for prototype code, omitting tests">
+        <javadoc packagenames="org.*"
+                 maxmemory="512m"
+                 sourcepath="${source}"
+                 overview="src/overview.html"
+                 defaultexcludes="yes"
+                 destdir="${doctarget}"
+                 additionalparam="-breakiterator"
+                 author="true"
+                 version="false"
+                 use="true"
+                 windowtitle="OpenLCB">
+            <arg value="-Xdoclint:all,-missing"/> <!-- dropping some 1.8 warnings -->
+            <group title="Core" packages="org.openlcb"/>
 	  
-      <classpath refid="project.class.path"    />
-      <doctitle><![CDATA[<h1>OpenLCB API</h1>]]></doctitle>
-      <link href="http://java.sun.com/j2se/1.4.1/docs/api/" />
-    </javadoc>
-  </target>
+            <classpath refid="project.class.path"    />
+            <doctitle><![CDATA[<h1>OpenLCB API</h1>]]></doctitle>
+            <link href="http://java.sun.com/j2se/1.4.1/docs/api/" />
+        </javadoc>
+    </target>
 
-  <!-- The structure of the following should closely follow the  -->
-  <!-- main 'javadoc' target directly above. The only difference -->
-  <!-- is the doclet clause referencing the UML generator, the   -->
-  <!-- use of the public option in the main task definition, and -->
-  <!-- the execution of "dot" at the bottom.                     -->
-  <!-- Requires Graphviz from http://www.graphviz.org            -->
+    <!-- The structure of the following should closely follow the  -->
+    <!-- main 'javadoc' target directly above. The only difference -->
+    <!-- is the doclet clause referencing the UML generator, the   -->
+    <!-- use of the public option in the main task definition, and -->
+    <!-- the execution of "dot" at the bottom.                     -->
+    <!-- Requires Graphviz from http://www.graphviz.org            -->
     <target name="javadoc-uml" depends="init" description="create JavaDocs with UML">
         <javadoc packagenames="org.*"
-           maxmemory="512m"
-           sourcepath="${source}"
-           overview="${source}/overview.html"
-           destdir="${doctarget}"
-           additionalparam="-breakiterator"
-           author="true"
-           version="false"
-           package="yes"
-           use="true"
-           windowtitle="OpenLCB API">
+                 maxmemory="512m"
+                 sourcepath="${source}"
+                 overview="${source}/overview.html"
+                 destdir="${doctarget}"
+                 additionalparam="-breakiterator"
+                 author="true"
+                 version="false"
+                 package="yes"
+                 use="true"
+                 windowtitle="OpenLCB API">
             <arg value="-Xdoclint:all,-missing"/> <!-- dropping some 1.8 warnings -->
             <doclet name="org.umlgraph.doclet.UmlGraphDoc"
-                                  path="lib/UmlGraph-5.7.jar">
+                    path="lib/UmlGraph-5.7.jar">
                 <param name="-attributes"/>
                 <param name="-operations"/>
                 <param name="-qualify"/>
                 <param name="-types"/>
-                                <!-- <param name="-visibility"/> not used, as only showing public visibility -->
+                <!-- <param name="-visibility"/> not used, as only showing public visibility -->
                 <param name="-collapsible"/>  <!-- hide images at first on web pages -->
                 <param name="-inferdepvis" value="public"/> <!-- only show public -->
             </doclet>
@@ -287,7 +287,7 @@
             <link href="http://javacsv.sourceforge.net/"/> <!-- A -->
             <link href="http://fasterxml.github.io/jackson-databind/javadoc/2.0.6"/>
             <link href="http://logging.apache.org/log4j/1.2/apidocs/"/>  
-<!--            <link href="http://java.sun.com/javase/technologies/desktop/java3d/forDevelopers/j3dapi/"/>   failes, so bypassed -->
+            <!--            <link href="http://java.sun.com/javase/technologies/desktop/java3d/forDevelopers/j3dapi/"/>   failes, so bypassed -->
             <link href="https://jogamp.org/deployment/jogamp-next/javadoc/joal/javadoc/"/>
             <link href="https://commons.apache.org/proper/commons-lang/javadocs/api-release"/>
 
@@ -302,39 +302,39 @@
         </apply>
     </target>
 
-  <target name="javadocall" depends="init" description="create JavaDoc for all code including tests">
-    <javadoc packagenames="org.*, tools.*, simulations.*, scenarios.*"
-           maxmemory="512m"
-           sourcepath="${source}:${test}"
-           overview="src/overview.html"
-           defaultexcludes="yes"
-           destdir="${doctarget}"
-           additionalparam="-breakiterator"
-           author="true"
-           version="false"
-           use="true"
-           windowtitle="OpenLCB">
-      <group title="Core" packages="org.openlcb"/>
+    <target name="javadocall" depends="init" description="create JavaDoc for all code including tests">
+        <javadoc packagenames="org.*, tools.*, simulations.*, scenarios.*"
+                 maxmemory="512m"
+                 sourcepath="${source}:${test}"
+                 overview="src/overview.html"
+                 defaultexcludes="yes"
+                 destdir="${doctarget}"
+                 additionalparam="-breakiterator"
+                 author="true"
+                 version="false"
+                 use="true"
+                 windowtitle="OpenLCB">
+            <group title="Core" packages="org.openlcb"/>
 	  
-      <classpath refid="project.class.path"    />
-      <doctitle><![CDATA[<h1>OpenLCB API</h1>]]></doctitle>
-      <link href="http://java.sun.com/j2se/1.4.1/docs/api/" />
-    </javadoc>
-  </target>
+            <classpath refid="project.class.path"    />
+            <doctitle><![CDATA[<h1>OpenLCB API</h1>]]></doctitle>
+            <link href="http://java.sun.com/j2se/1.4.1/docs/api/" />
+        </javadoc>
+    </target>
 
-  <target name="jars" description="create working jar files with current contents">
-    <antcall target="clean" />
-    <antcall target="compile" />
-    <jar jarfile="${jartarget}/openlcb.jar" 
-         basedir="${target}"
-         manifest="manifest" 
-         compress="true" />   <!-- compress="true" is default -->
-    <antcall target="tests" />
-    <jar jarfile="${jartarget}/openlcb-demo.jar" 
-         basedir="${target}"
-         manifest="manifest" 
-         compress="true" />   <!-- compress="true" is default -->
-  </target>
+    <target name="jars" description="create working jar files with current contents">
+        <antcall target="clean" />
+        <antcall target="compile" />
+        <jar jarfile="${jartarget}/openlcb.jar" 
+             basedir="${target}"
+             manifest="manifest" 
+             compress="true" />   <!-- compress="true" is default -->
+        <antcall target="tests" />
+        <jar jarfile="${jartarget}/openlcb-demo.jar" 
+             basedir="${target}"
+             manifest="manifest" 
+             compress="true" />   <!-- compress="true" is default -->
+    </target>
 
 </project>
 

--- a/build.xml
+++ b/build.xml
@@ -314,6 +314,7 @@
                  version="false"
                  use="true"
                  windowtitle="OpenLCB">
+            <arg value="-Xdoclint:all,-missing"/> <!-- dropping some 1.8 warnings -->
             <group title="Core" packages="org.openlcb"/>
 	  
             <classpath refid="project.class.path"    />

--- a/src/org/openlcb/OlcbInterface.java
+++ b/src/org/openlcb/OlcbInterface.java
@@ -12,7 +12,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * Collects all objects necessary to run an OpenLCB standards-compatible interface.
- * <p/>
+ * <p>
  * Created by bracz on 12/27/15.
  */
 public class OlcbInterface {
@@ -200,7 +200,7 @@ public class OlcbInterface {
     /**
      * This class keeps an output connection operating using an internal queue. It keeps
      * messages in an internal thread-safe queue and sends them on a separate thread.
-     * <p/>
+     * <p>
      * The caller must donate a thread to this connection by calling the run() method.
      */
     private class QueuedOutputConnection implements Connection {

--- a/src/org/openlcb/can/CanInterface.java
+++ b/src/org/openlcb/can/CanInterface.java
@@ -1,14 +1,13 @@
 package org.openlcb.can;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Semaphore;
 import org.openlcb.Connection;
 import org.openlcb.Connection.ConnectionListener;
 import org.openlcb.Message;
 import org.openlcb.NodeID;
 import org.openlcb.OlcbInterface;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Semaphore;
 
 /**
  * CanInterface collects all objects necessary to operate a standards-compliant node that connects
@@ -96,7 +95,7 @@ public class CanInterface {
         } catch(InterruptedException e) {}
         // Stores local node alias.
         aliasMap.insert(aliasWatcher.getNIDa(), nodeId);
-        /// @TODO(balazs.racz): If the alias changes, we need to update the local alias map.
+        /// TODO(balazs.racz): If the alias changes, we need to update the local alias map.
 
         // Notify all listeners waiting for init. Call them outside of the lock.
         List<ConnectionListener> listeners_copy = new ArrayList<>();

--- a/src/org/openlcb/can/impl/GridConnectInput.java
+++ b/src/org/openlcb/can/impl/GridConnectInput.java
@@ -11,7 +11,7 @@ import java.util.logging.Logger;
 
 /**
  * Parses an input stream according to the GridConnect protocol and forwards a set of CAN frames.
- * <p/>
+ * <p>
  * Created by bracz on 12/23/15.
  */
 public class GridConnectInput {

--- a/src/org/openlcb/can/impl/GridConnectOutput.java
+++ b/src/org/openlcb/can/impl/GridConnectOutput.java
@@ -11,7 +11,7 @@ import java.util.logging.Logger;
 /**
  * Converts the sent CAN framesto gridconnect protocol and writes them ot an output stream.
  * Performs internal buffering.
- * <p/>
+ * <p>
  * Created by bracz on 12/23/15.
  */
 public class GridConnectOutput implements CanFrameListener {

--- a/src/org/openlcb/can/impl/OlcbConnection.java
+++ b/src/org/openlcb/can/impl/OlcbConnection.java
@@ -1,14 +1,6 @@
 package org.openlcb.can.impl;
 
 
-import org.openlcb.Connection;
-import org.openlcb.NodeID;
-import org.openlcb.OlcbInterface;
-import org.openlcb.can.CanFrame;
-import org.openlcb.can.CanFrameListener;
-import org.openlcb.can.CanInterface;
-import org.openlcb.cdi.impl.ConfigRepresentation;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -18,12 +10,19 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openlcb.Connection;
+import org.openlcb.NodeID;
+import org.openlcb.OlcbInterface;
+import org.openlcb.can.CanFrame;
+import org.openlcb.can.CanFrameListener;
+import org.openlcb.can.CanInterface;
+import org.openlcb.cdi.impl.ConfigRepresentation;
 
 /**
  * Created by bracz on 12/23/15.
  */
 public class OlcbConnection {
-    // @TODO: 3/31/16 balazs.racz: THis should be migrated into a singleton class like
+    // TODO: 3/31/16 balazs.racz: THis should be migrated into a singleton class like
     // ConnectionManager.
     public static OlcbConnection lastConnection = null;
     private final NodeID nodeId;
@@ -154,7 +153,7 @@ public class OlcbConnection {
     /**
      * @return the CAN frame hub processing the incoming messages (from the network; sent by
      * other nodes).
-     * <p/>
+     * <p>
      * This can be used for two purposes:
      * - get a copy of all frames arriving from the network;
      * - inject fake messages as if they were coming from the network (not super useful).
@@ -166,7 +165,7 @@ public class OlcbConnection {
     /**
      * @return the CAN frame hub processing outgoing messages (to the network; originating from
      * this node).
-     * <p/>
+     * <p>
      * This can be used for two purposes:
      * - send packets to the network
      * - get a copy of (aka sniff) all outgoing packets before they are sent.

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -65,14 +65,18 @@ public interface CdiRep {
         public String getKey(String entry);
 
         /**
-         * Gets valid values (returned array is parallel to @ref getValues() )
-         * @return a list of all valid stored values (usually a list of decimal formatted
-         * integers).
+         * Gets valid values (returned array is parallel to {@link #getValues()}
+         * )
+         *
+         * @return a list of all valid stored values (usually a list of decimal
+         * formatted integers).
          */
         public java.util.List<String> getKeys();
 
         /**
-         * Gets all user-visible string explanations (returned array is parallel to @ref getKeys() )
+         * Gets all user-visible string explanations (returned array is parallel
+         * to {@link #getKeys()} )
+         *
          * @return a list of all user-visible values.
          */
         public java.util.List<String> getValues();

--- a/src/org/openlcb/cdi/impl/ConfigRepresentation.java
+++ b/src/org/openlcb/cdi/impl/ConfigRepresentation.java
@@ -1,15 +1,6 @@
 package org.openlcb.cdi.impl;
 
-import org.openlcb.EventID;
-import org.openlcb.NodeID;
-import org.openlcb.OlcbInterface;
-import org.openlcb.DefaultPropertyListenerSupport;
-import org.openlcb.cdi.CdiRep;
-import org.openlcb.cdi.jdom.CdiMemConfigReader;
-import org.openlcb.cdi.jdom.JdomCdiReader;
-import org.openlcb.cdi.jdom.XmlHelper;
-import org.openlcb.implementations.MemoryConfigurationService;
-
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.Reader;
@@ -20,10 +11,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
-
 import javax.annotation.Nullable;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
+import org.openlcb.DefaultPropertyListenerSupport;
+import org.openlcb.EventID;
+import org.openlcb.NodeID;
+import org.openlcb.OlcbInterface;
+import org.openlcb.cdi.CdiRep;
+import org.openlcb.cdi.jdom.CdiMemConfigReader;
+import org.openlcb.cdi.jdom.JdomCdiReader;
+import org.openlcb.cdi.jdom.XmlHelper;
+import org.openlcb.implementations.MemoryConfigurationService;
 
 /**
  * Maintains a parsed cache of the CDI config of a remote node. Responsible for fetching the CDI,
@@ -353,7 +350,7 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
 
         /**
          * Parses the root of the CdiRep into an internal representation that is a container.
-         * @param rep
+         * @param rep the CDI representation
          */
         public Root(CdiRep rep) {
             items = new ArrayList<>();

--- a/src/org/openlcb/cdi/impl/MemorySpaceCache.java
+++ b/src/org/openlcb/cdi/impl/MemorySpaceCache.java
@@ -292,8 +292,8 @@ public class MemorySpaceCache {
 
     /**
      * Performs a refresh of some data. Calls the data update listeners when done.
-     * @param origin address of first device to reload
-     * @param size number of addresses to reload
+     * @param origin address of first byte in memory space to reload
+     * @param size number of bytes to reload
      */
     public void reload(long origin, int size) {
         rangesToLoad.add(new Range(origin, origin + size));

--- a/src/org/openlcb/cdi/impl/MemorySpaceCache.java
+++ b/src/org/openlcb/cdi/impl/MemorySpaceCache.java
@@ -1,10 +1,5 @@
 package org.openlcb.cdi.impl;
 
-import org.openlcb.NodeID;
-import org.openlcb.OlcbInterface;
-import org.openlcb.cdi.impl.RangeCacheUtil.Range;
-import org.openlcb.implementations.MemoryConfigurationService;
-
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
@@ -15,11 +10,15 @@ import java.util.NavigableMap;
 import java.util.Queue;
 import java.util.TreeMap;
 import java.util.logging.Logger;
+import org.openlcb.NodeID;
+import org.openlcb.OlcbInterface;
+import org.openlcb.cdi.impl.RangeCacheUtil.Range;
+import org.openlcb.implementations.MemoryConfigurationService;
 
 /**
  * Maintains the connection to a specific remote node's specific memory space, and maintains a
  * cache of the information retrieved from there.
- * <p/>
+ * <p>
  * Created by bracz on 4/2/16.
  */
 public class MemorySpaceCache {
@@ -287,14 +286,14 @@ public class MemorySpaceCache {
                     }
                 }
         );
-        // @TODO: 4/2/16 Handle write errors and report to user somehow.
+        // TODO: 4/2/16 Handle write errors and report to user somehow.
         notifyAfterWrite(offset, offset + data.length);
     }
 
     /**
      * Performs a refresh of some data. Calls the data update listeners when done.
-     * @param origin
-     * @param size
+     * @param origin address of first device to reload
+     * @param size number of addresses to reload
      */
     public void reload(long origin, int size) {
         rangesToLoad.add(new Range(origin, origin + size));

--- a/src/org/openlcb/cdi/impl/RangeCacheUtil.java
+++ b/src/org/openlcb/cdi/impl/RangeCacheUtil.java
@@ -9,7 +9,7 @@ import javax.annotation.Nullable;
 /**
  * Helper class to get a sequence of ranges and merges them into larger chunks to read from the
  * config space so that fewer reads suffice.
- * <p/>
+ * <p>
  * Created by bracz on 4/2/16.
  */
 public class RangeCacheUtil {

--- a/src/org/openlcb/hub/Hub.java
+++ b/src/org/openlcb/hub/Hub.java
@@ -1,7 +1,7 @@
 package org.openlcb.hub;
 
-import java.net.*;
 import java.io.*;
+import java.net.*;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -15,7 +15,7 @@ import java.util.concurrent.*;
  * main() directly invokes an object of the class.
  * <p>
  * Current threading model does all the sending from a
- * a single thread.  If this is observed to back up &
+ * a single thread.  If this is observed to back up &amp;
  * halt all flow, individual transmit queues and threads
  * may be needed.
  *

--- a/src/org/openlcb/implementations/BitProducerConsumer.java
+++ b/src/org/openlcb/implementations/BitProducerConsumer.java
@@ -15,7 +15,7 @@ import org.openlcb.ProducerIdentifiedMessage;
 
 /**
  * Maintains a bit represented by two event IDs: one off, one on.
- * <p/>
+ * <p>
  * Created by bracz on 1/6/16.
  */
 public class BitProducerConsumer extends MessageDecoder {

--- a/src/org/openlcb/implementations/BlueGoldEngine.java
+++ b/src/org/openlcb/implementations/BlueGoldEngine.java
@@ -5,7 +5,6 @@ import org.openlcb.*;
 /**
  * Example of a OpenLCB algorithm for doing configuration with
  * small number of buttons.
- *<p>
  *<ul>
  *<li>On learners, push blue to choose a C/P and put that C/P in learn mode 
  * (complete cycle turns off blue light and starts over)

--- a/src/org/openlcb/implementations/BlueGoldExtendedEngine.java
+++ b/src/org/openlcb/implementations/BlueGoldExtendedEngine.java
@@ -6,7 +6,6 @@ import org.openlcb.*;
  * Example of a OpenLCB algorithm for doing configuration with
  * small number of buttons. This an extended form that allows 
  * multiple selection and deselection.
- *<p>
  *<ul>
  *<li>On learners, push blue to choose a C/P, then gold to put that C/P in learn mode 
  * (complete cycle turns off blue light and starts over)

--- a/src/org/openlcb/implementations/DatagramMeteringBuffer.java
+++ b/src/org/openlcb/implementations/DatagramMeteringBuffer.java
@@ -1,10 +1,9 @@
 package org.openlcb.implementations;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.Timer;
 import java.util.TimerTask;
-
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import org.openlcb.*;
 
 /**
@@ -16,7 +15,6 @@ import org.openlcb.*;
  *<p>
  * Datagram negative replies cause a local retransmission. Positive
  * replies are reflected upstream to original source of the datagram.
- *<p>
  *<ul>
  *<li>Does not parallelize Datagrams to separate nodes
  *<li>Needs to timeout and resume operation if no reply received

--- a/src/org/openlcb/implementations/MemoryConfigSpaceRetriever.java
+++ b/src/org/openlcb/implementations/MemoryConfigSpaceRetriever.java
@@ -5,7 +5,7 @@ import org.openlcb.OlcbInterface;
 
 /**
  * Downloads the entire contents of a Memory Config space. Useful for CDI-style situations.
- * <p/>
+ * <p>
  * Created by bracz on 1/17/16.
  */
 public class MemoryConfigSpaceRetriever {

--- a/src/org/openlcb/implementations/throttle/AbstractNodeCache.java
+++ b/src/org/openlcb/implementations/throttle/AbstractNodeCache.java
@@ -5,17 +5,17 @@ import java.util.HashMap;
 import java.util.List;
 import org.openlcb.Connection;
 import org.openlcb.EventID;
-import org.openlcb.NodeID;
 import org.openlcb.MessageDecoder;
+import org.openlcb.NodeID;
 import org.openlcb.ProducerConsumerEventReportMessage;
 import org.openlcb.ProducerIdentifiedMessage;
 
 /**
  * Maintains a cache of nodes seen to emit a particular EventID.
  *
- * @TODO:  Type of node needs to be made generic T
+ * TODO:  Type of node needs to be made generic T
  *
- * @TODO: make sure name and semantics of contained property are correct for a Bean, e.g.
+ * TODO: make sure name and semantics of contained property are correct for a Bean, e.g.
  * it has the right name and related methods are present.
  *     http://docs.oracle.com/javase/tutorial/javabeans/writing/properties.html
  * How are indexed properties handled in Events?

--- a/src/org/openlcb/implementations/throttle/FdiParser.java
+++ b/src/org/openlcb/implementations/throttle/FdiParser.java
@@ -11,7 +11,7 @@ import java.util.logging.Logger;
 
 /**
  * Helper class to parse the FDI XML representation into a useful set of functions.
- * <p/>
+ * <p>
  * Created by bracz on 1/17/16.
  */
 public class FdiParser {

--- a/src/org/openlcb/implementations/throttle/TractionThrottle.java
+++ b/src/org/openlcb/implementations/throttle/TractionThrottle.java
@@ -1,5 +1,11 @@
 package org.openlcb.implementations.throttle;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import org.openlcb.Connection;
 import org.openlcb.Message;
 import org.openlcb.MessageDecoder;
@@ -10,19 +16,13 @@ import org.openlcb.implementations.VersionedValueListener;
 import org.openlcb.messages.TractionControlReplyMessage;
 import org.openlcb.messages.TractionControlRequestMessage;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
-
-import javax.annotation.Nullable;
-
 /**
- * Traction protocol based implementation of the throttle. This differs from {@ref
- * ThrottleImplementation} in that it uses the {@ref TractionControlRequest} messages for talking
- * to the train nodes, including proper allocation and deallocation of throttles.
- * <p/>
+ * Traction protocol based implementation of the throttle. This differs from
+ * {@link org.openlcb.implementations.throttle.ThrottleImplementation} in that
+ * it uses the {@link org.openlcb.messages.TractionControlRequestMessage} for
+ * talking to the train nodes, including proper allocation and deallocation of
+ * throttles.
+ * <p>
  * Created by bracz on 12/30/15.
  */
 public class TractionThrottle extends MessageDecoder {

--- a/src/org/openlcb/messages/TractionControlReplyMessage.java
+++ b/src/org/openlcb/messages/TractionControlReplyMessage.java
@@ -17,7 +17,7 @@ import javax.annotation.Nullable;
 
 /**
  * Traction Control Reply message implementation.
- * <p/>
+ * <p>
  * Created by bracz on 12/29/15.
  */
 @Immutable

--- a/src/org/openlcb/messages/TractionControlRequestMessage.java
+++ b/src/org/openlcb/messages/TractionControlRequestMessage.java
@@ -14,7 +14,7 @@ import java.util.logging.Logger;
 
 /**
  * Traction Control Request message implementation.
- * <p/>
+ * <p>
  * Created by bracz on 12/29/15.
  */
 @Immutable

--- a/src/org/openlcb/messages/TractionProxyReplyMessage.java
+++ b/src/org/openlcb/messages/TractionProxyReplyMessage.java
@@ -12,7 +12,7 @@ import org.openlcb.NodeID;
 
 /**
  * Traction Proxy Reply message implementation.
- * <p/>
+ * <p>
  * Created by bracz on 12/29/15.
  */
 @Immutable

--- a/src/org/openlcb/messages/TractionProxyRequestMessage.java
+++ b/src/org/openlcb/messages/TractionProxyRequestMessage.java
@@ -12,7 +12,7 @@ import org.openlcb.NodeID;
 
 /**
  * Traction Proxy Request message implementation.
- * <p/>
+ * <p>
  * Created by bracz on 12/29/15.
  */
 @Immutable

--- a/src/org/openlcb/protocols/VerifyNodeIdHandler.java
+++ b/src/org/openlcb/protocols/VerifyNodeIdHandler.java
@@ -10,7 +10,7 @@ import org.openlcb.VerifyNodeIDNumberMessage;
 
 /**
  * Handler for verify node ID requests to the local node.
- * <p/>
+ * <p>
  * Created by bracz on 12/28/15.
  */
 public class VerifyNodeIdHandler extends MessageDecoder {
@@ -33,7 +33,7 @@ public class VerifyNodeIdHandler extends MessageDecoder {
     public void handleVerifyNodeIDNumber(VerifyNodeIDNumberMessage msg, Connection sender) {
         /* This is the Verify Node ID number "global" message.
         *
-        * @TODO: we need to add VerifyNode ID number "addressed" message to the list of
+        * TODO: we need to add VerifyNode ID number "addressed" message to the list of
         * supported MTIs et al.
         */
 

--- a/test/org/openlcb/cdi/swing/CdiPanelDemo.java
+++ b/test/org/openlcb/cdi/swing/CdiPanelDemo.java
@@ -1,23 +1,15 @@
 package org.openlcb.cdi.swing;
 
 import javax.swing.JFrame;
-import org.openlcb.*;
-
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
 
 import java.io.*;
-import java.net.MalformedURLException;
-import java.net.URL;
 import javax.swing.*;
 
 import org.jdom2.*;
 import org.jdom2.input.SAXBuilder;
 
 /**
- * Provide some demo & development tools for CDI
+ * Provide some demo &amp; development tools for CDI
  *
  * @author  Bob Jacobsen   Copyright 2012, 2015
  * @version $Revision: 2175 $


### PR DESCRIPTION
- Fix all errors flagged by running ```ant javadocall``` as well as all warnings except for missing tags (there are still more than 100 missing tags in JavaDoc comments).
- Have all three JavaDoc targets run the same doclint parameters.
- Consistent indentations in build.xml