### PR TITLE
Fix rendering of addressed messages

### DIFF
--- a/src/org/openlcb/AddressedPayloadMessage.java
+++ b/src/org/openlcb/AddressedPayloadMessage.java
@@ -21,8 +21,16 @@ public abstract class AddressedPayloadMessage extends AddressedMessage {
     }
 
     public String toString() {
-        return super.toString() + " " + getEMTI().toString() + " with payload " + Utilities
-                .toHexSpaceString(payload);
+        StringBuilder p = new StringBuilder(super.toString());
+        p.append(" ");
+        p.append(getEMTI().toString());
+        if (payload.length > 0) {
+            p.append(" with payload ");
+            p.append(Utilities.toHexSpaceString(payload));
+        } else {
+            p.append(" with no payload");
+        }
+        return p.toString();
     }
 
     public abstract MessageTypeIdentifier getEMTI();

--- a/src/org/openlcb/DatagramAcknowledgedMessage.java
+++ b/src/org/openlcb/DatagramAcknowledgedMessage.java
@@ -50,16 +50,6 @@ public class DatagramAcknowledgedMessage extends AddressedPayloadMessage {
     }
 
     @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
-
-    @Override
-    public String toString() {
-        return super.toString()+" Datagram Acknowledged";
-    }
-
-    @Override
     public MessageTypeIdentifier getEMTI() {
         return MessageTypeIdentifier.DatagramReceivedOK;
     }

--- a/src/org/openlcb/DatagramAcknowledgedMessage.java
+++ b/src/org/openlcb/DatagramAcknowledgedMessage.java
@@ -12,15 +12,15 @@ import net.jcip.annotations.ThreadSafe;
  */
 @Immutable
 @ThreadSafe
-public class DatagramAcknowledgedMessage extends AddressedMessage {
+public class DatagramAcknowledgedMessage extends AddressedPayloadMessage {
     
     public DatagramAcknowledgedMessage(NodeID source, NodeID dest) {
-        super(source, dest);
+        super(source, dest, null);
         flags = 0;
     }
 
     public DatagramAcknowledgedMessage(NodeID source, NodeID dest, int flags) {
-        super(source, dest);
+        super(source, dest, flags == 0 ? null : new byte[]{(byte)flags});
         this.flags = flags;
     }
 
@@ -55,10 +55,12 @@ public class DatagramAcknowledgedMessage extends AddressedMessage {
     }
 
     @Override
-    public int getMTI() { return MTI_DATAGRAM_RCV_OK; }
-
-    @Override
     public String toString() {
         return super.toString()+" Datagram Acknowledged";
+    }
+
+    @Override
+    public MessageTypeIdentifier getEMTI() {
+        return MessageTypeIdentifier.DatagramReceivedOK;
     }
 }

--- a/src/org/openlcb/DatagramRejectedMessage.java
+++ b/src/org/openlcb/DatagramRejectedMessage.java
@@ -15,7 +15,7 @@ import net.jcip.annotations.ThreadSafe;
 public class DatagramRejectedMessage extends AddressedPayloadMessage {
     
     public DatagramRejectedMessage(NodeID source, NodeID dest, int code) {
-        super(source, dest, codeToPayload(code));
+        super(source, dest, toPayload(code));
         this.code = code;
     }
         
@@ -24,8 +24,10 @@ public class DatagramRejectedMessage extends AddressedPayloadMessage {
 
     public int getCode() { return code; }
 
-    private static byte[] codeToPayload(int code) {
-        return new byte[]{(byte)((code>>8)&0xFF), (byte)(code&0xFF)};
+    private static byte[] toPayload(int code) {
+        byte[] b = new byte[2];
+        Utilities.HostToNetworkUint16(b, 0, code);
+        return b;
     }
 
     /**
@@ -48,11 +50,6 @@ public class DatagramRejectedMessage extends AddressedPayloadMessage {
         if (this.code != ((DatagramRejectedMessage)o).getCode())
             return false;
         return super.equals(o);
-    }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode();
     }
 
     static final int DATAGRAM_REJECTED                           = 0x000;

--- a/src/org/openlcb/DatagramRejectedMessage.java
+++ b/src/org/openlcb/DatagramRejectedMessage.java
@@ -12,18 +12,22 @@ import net.jcip.annotations.ThreadSafe;
  */
 @Immutable
 @ThreadSafe
-public class DatagramRejectedMessage extends AddressedMessage {
+public class DatagramRejectedMessage extends AddressedPayloadMessage {
     
     public DatagramRejectedMessage(NodeID source, NodeID dest, int code) {
-        super(source, dest);
+        super(source, dest, codeToPayload(code));
         this.code = code;
     }
         
     @SuppressWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
     int code;
-    
+
     public int getCode() { return code; }
-    
+
+    private static byte[] codeToPayload(int code) {
+        return new byte[]{(byte)((code>>8)&0xFF), (byte)(code&0xFF)};
+    }
+
     /**
      * Implement message-type-specific
      * processing when this message
@@ -51,9 +55,6 @@ public class DatagramRejectedMessage extends AddressedMessage {
         return super.hashCode();
     }
 
-    @Override
-    public int getMTI() { return MTI_DATAGRAM_REJECTED; }
-    
     static final int DATAGRAM_REJECTED                           = 0x000;
     static final int DATAGRAM_REJECTED_PERMANENT_ERROR           = 0x100;
     static final int DATAGRAM_REJECTED_INFORMATION_LOGGED        = 0x101;
@@ -73,8 +74,8 @@ public class DatagramRejectedMessage extends AddressedMessage {
     }
 
     @Override
-    public String toString() {
-        return super.toString()+" Datagram Rejected";
+    public MessageTypeIdentifier getEMTI() {
+        return MessageTypeIdentifier.DatagramRejected;
     }
 
 }

--- a/src/org/openlcb/OlcbInterface.java
+++ b/src/org/openlcb/OlcbInterface.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.logging.Logger;
 
 /**
  * Collects all objects necessary to run an OpenLCB standards-compatible interface.
@@ -16,7 +17,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  * Created by bracz on 12/27/15.
  */
 public class OlcbInterface {
-
+    private final static Logger log = Logger.getLogger(OlcbInterface.class.getName());
     /// Object for sending messages to the network.
     protected final Connection internalOutputConnection;
     /// Object we return to the customer when they ask for the output connection
@@ -243,7 +244,12 @@ public class OlcbInterface {
             while (true) {
                 try {
                     Message m = outputQueue.take();
-                    realOutput.put(m, null);
+                    try {
+                        realOutput.put(m, null);
+                    } catch (Throwable e) {
+                        log.warning("Exception while sending message: " + e.toString());
+                        e.printStackTrace();
+                    }
                     synchronized(this) {
                         pendingCount--;
                     }

--- a/src/org/openlcb/OptionalIntRejectedMessage.java
+++ b/src/org/openlcb/OptionalIntRejectedMessage.java
@@ -12,10 +12,10 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class OptionalIntRejectedMessage extends AddressedMessage {
+public class OptionalIntRejectedMessage extends AddressedPayloadMessage {
     
     public OptionalIntRejectedMessage(NodeID source, NodeID dest, int mti, int code) {
-        super(source, dest);
+        super(source, dest, toPayload(mti, code));
         this.mti = mti;
         this.code = code;
     }
@@ -26,7 +26,13 @@ public class OptionalIntRejectedMessage extends AddressedMessage {
     public int getMti() { return mti; }
     
     public int getCode() { return code; }
-    
+
+    private static byte[] toPayload(int mti, int code) {
+        byte[] b = new byte[4];
+        Utilities.HostToNetworkUint16(b, 0, mti);
+        Utilities.HostToNetworkUint16(b, 2, code);
+        return b;
+    }
      /**
       * To be equal, messages have to have the
       * same type and content
@@ -51,8 +57,6 @@ public class OptionalIntRejectedMessage extends AddressedMessage {
      public void applyTo(MessageDecoder decoder, Connection sender) {
         decoder.handleOptionalIntRejected(this, sender);
      }
-    
-    public int getMTI() { return MTI_OPT_INT_REJECTED; }
 
     @Override
     public String toString() {
@@ -62,5 +66,10 @@ public class OptionalIntRejectedMessage extends AddressedMessage {
         value.append(" code 0x");  
         value.append(Integer.toHexString((int)(getCode()&0xFFFF)).toUpperCase());  
         return new String(value);   
+    }
+
+    @Override
+    public MessageTypeIdentifier getEMTI() {
+        return MessageTypeIdentifier.OptionalInteractionRejected;
     }
 }

--- a/src/org/openlcb/ProtocolIdentificationReplyMessage.java
+++ b/src/org/openlcb/ProtocolIdentificationReplyMessage.java
@@ -12,15 +12,21 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class ProtocolIdentificationReplyMessage extends AddressedMessage {
+public class ProtocolIdentificationReplyMessage extends AddressedPayloadMessage {
     
     public ProtocolIdentificationReplyMessage(NodeID source, NodeID dest, long value) {
-        super(source, dest);
+        super(source, dest, toPayload(value));
         this.value = value;
     }
         
     long value;
-    
+
+    private static byte[] toPayload(long value) {
+        byte[] b = new byte[6];
+        Utilities.HostToNetworkUint48(b, 0, value);
+        return b;
+    }
+
     public long getValue() { return value; }
     
      /**
@@ -48,11 +54,10 @@ public class ProtocolIdentificationReplyMessage extends AddressedMessage {
      public void applyTo(MessageDecoder decoder, Connection sender) {
         decoder.handleProtocolIdentificationReply(this, sender);
      }
-    
+
     @Override
-    public String toString() {
-        return super.toString()
-                +" Protocol Identification Reply with value "+String.format("0x%12X",value);
+    public MessageTypeIdentifier getEMTI() {
+        return MessageTypeIdentifier.ProtocolSupportReply;
     }
 
     public int getMTI() { return MTI_PROTOCOL_IDENT_REPLY; }

--- a/src/org/openlcb/ProtocolIdentificationRequestMessage.java
+++ b/src/org/openlcb/ProtocolIdentificationRequestMessage.java
@@ -12,12 +12,12 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class ProtocolIdentificationRequestMessage extends AddressedMessage {
+public class ProtocolIdentificationRequestMessage extends AddressedPayloadMessage {
     
     public ProtocolIdentificationRequestMessage(NodeID source, NodeID dest) {
-        super(source, dest);
+        super(source, dest, null);
     }
-        
+
     /**
      * Implement message-type-specific
      * processing when this message
@@ -29,10 +29,9 @@ public class ProtocolIdentificationRequestMessage extends AddressedMessage {
      public void applyTo(MessageDecoder decoder, Connection sender) {
         decoder.handleProtocolIdentificationRequest(this, sender);
      }
-    public String toString() {
-        return super.toString()
-                +" Protocol Identification Request ";   
-    }
 
-    public int getMTI() { return MTI_PROTOCOL_IDENT_REQUEST; }
+    @Override
+    public MessageTypeIdentifier getEMTI() {
+        return MessageTypeIdentifier.ProtocolSupportInquiry;
+    }
 }

--- a/src/org/openlcb/SimpleNodeIdentInfoReplyMessage.java
+++ b/src/org/openlcb/SimpleNodeIdentInfoReplyMessage.java
@@ -12,19 +12,15 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class SimpleNodeIdentInfoReplyMessage extends AddressedMessage {
+public class SimpleNodeIdentInfoReplyMessage extends AddressedPayloadMessage {
     
     /**
      * @param dataIn the data content without extra wire-protocol bytes
      */
     public SimpleNodeIdentInfoReplyMessage(NodeID source, NodeID dest, byte[] dataIn) {
-        super(source, dest);
-        this.data = new byte[dataIn.length];
-        System.arraycopy(dataIn, 0, this.data, 0, dataIn.length);
+        super(source, dest, dataIn);
     }
-        
-    byte[] data;
-    
+
     /**
      * To be equal, messages have to have the
      * same type and content
@@ -47,7 +43,7 @@ public class SimpleNodeIdentInfoReplyMessage extends AddressedMessage {
     }
     
     public byte[] getData() {
-        return data;
+        return payload;
     }
 
     /**
@@ -64,7 +60,10 @@ public class SimpleNodeIdentInfoReplyMessage extends AddressedMessage {
     
     @Override
     public String toString() {
-        StringBuilder b = new StringBuilder(super.toString());
+        StringBuilder b = new StringBuilder();
+        b.append(getSourceNodeID().toString());
+        b.append(" - ");
+        b.append(getDestNodeID().toString());
         b.append(" Simple Node Ident Info with content '");
         for (byte d : getData()) {
             if (d == 0) {
@@ -80,5 +79,8 @@ public class SimpleNodeIdentInfoReplyMessage extends AddressedMessage {
         return b.toString();
     }
 
-    public int getMTI() { return MTI_SIMPLE_NODE_IDENT_REPLY; }
+    @Override
+    public MessageTypeIdentifier getEMTI() {
+        return MessageTypeIdentifier.SimpleNodeIdentInfoReply;
+    }
 }

--- a/src/org/openlcb/SimpleNodeIdentInfoRequestMessage.java
+++ b/src/org/openlcb/SimpleNodeIdentInfoRequestMessage.java
@@ -12,16 +12,12 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class SimpleNodeIdentInfoRequestMessage extends AddressedMessage {
+public class SimpleNodeIdentInfoRequestMessage extends AddressedPayloadMessage {
     
     public SimpleNodeIdentInfoRequestMessage(NodeID source, NodeID dest) {
-        super(source, dest);
+        super(source, dest, null);
     }
         
-    long value;
-    
-    public long getValue() { return value; }
-    
      /**
       * To be equal, messages have to have the
       * same type and content
@@ -44,11 +40,7 @@ public class SimpleNodeIdentInfoRequestMessage extends AddressedMessage {
      public void applyTo(MessageDecoder decoder, Connection sender) {
         decoder.handleSimpleNodeIdentInfoRequest(this, sender);
      }
-    
-    public String toString() {
-        return super.toString()
-                +" Simple Node Ident Info Request";   
-    }
 
-    public int getMTI() { return MTI_SIMPLE_NODE_IDENT_REQUEST; }
+    @Override
+    public MessageTypeIdentifier getEMTI() { return MessageTypeIdentifier.SimpleNodeIdentInfoRequest; }
 }

--- a/src/org/openlcb/StreamDataCompleteMessage.java
+++ b/src/org/openlcb/StreamDataCompleteMessage.java
@@ -12,11 +12,11 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class StreamDataCompleteMessage extends AddressedMessage {
+public class StreamDataCompleteMessage extends AddressedPayloadMessage {
     
     public StreamDataCompleteMessage(NodeID source, NodeID dest,
                 byte sourceStreamID, byte destStreamID) {
-        super(source, dest);
+        super(source, dest, new byte[] {sourceStreamID, destStreamID});
         this.sourceStreamID = sourceStreamID;
         this.destStreamID = destStreamID;
     }
@@ -50,8 +50,11 @@ public class StreamDataCompleteMessage extends AddressedMessage {
 
     public String toString() {
         return super.toString()
-                +" StreamDataComplete srcId=" + sourceStreamID + " dstId=" + destStreamID;
+                +" srcId=" + sourceStreamID + " dstId=" + destStreamID;
     }
 
-    public int getMTI() { return MTI_STREAM_DATA_COMPLETE; }
+    @Override
+    public MessageTypeIdentifier getEMTI() {
+        return MessageTypeIdentifier.StreamDataComplete;
+    }
 }

--- a/src/org/openlcb/StreamDataProceedMessage.java
+++ b/src/org/openlcb/StreamDataProceedMessage.java
@@ -12,11 +12,11 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class StreamDataProceedMessage extends AddressedMessage {
+public class StreamDataProceedMessage extends AddressedPayloadMessage {
     
     public StreamDataProceedMessage(NodeID source, NodeID dest, 
                         byte sourceStreamID, byte destStreamID) {
-        super(source, dest);
+        super(source, dest, new byte[] {sourceStreamID, destStreamID});
         this.sourceStreamID = sourceStreamID;
         this.destStreamID = destStreamID;
     }
@@ -45,12 +45,15 @@ public class StreamDataProceedMessage extends AddressedMessage {
         if (sourceStreamID != p.sourceStreamID) return false;
         if (destStreamID != p.destStreamID) return false;
         return super.equals(o);
-    } 
+    }
 
     public String toString() {
         return super.toString()
-                +" StreamDataProceed";     
+                +" srcId=" + sourceStreamID + " dstId=" + destStreamID;
     }
 
-    public int getMTI() { return MTI_STREAM_DATA_PROCEED; }
+    @Override
+    public MessageTypeIdentifier getEMTI() {
+        return MessageTypeIdentifier.StreamDataProceed;
+    }
 }

--- a/src/org/openlcb/StreamInitiateReplyMessage.java
+++ b/src/org/openlcb/StreamInitiateReplyMessage.java
@@ -12,11 +12,11 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class StreamInitiateReplyMessage extends AddressedMessage {
+public class StreamInitiateReplyMessage extends AddressedPayloadMessage {
     
     public StreamInitiateReplyMessage(NodeID source, NodeID dest,
             int bufferSize, byte sourceStreamID, byte destStreamID) {
-        super(source, dest);
+        super(source, dest, toPayload(bufferSize, sourceStreamID, destStreamID));
         this.bufferSize = bufferSize;
         this.sourceStreamID = sourceStreamID;
         this.destStreamID = destStreamID;
@@ -25,11 +25,17 @@ public class StreamInitiateReplyMessage extends AddressedMessage {
     int bufferSize;
     byte sourceStreamID;
     byte destStreamID;
-    
+
     public int getBufferSize() { return bufferSize; }
     public byte getDestinationStreamID() { return destStreamID; }
     public byte getSourceStreamID() { return sourceStreamID; } //dph 20151229
-    
+
+    static byte[] toPayload(int bufferSize, byte sourceStreamID, byte destStreamID) {
+        byte[] b = new byte[]{0, 0, sourceStreamID, destStreamID};
+        Utilities.HostToNetworkUint16(b, 0, bufferSize);
+        return b;
+    }
+
     /**
      * Implement message-type-specific
      * processing when this message
@@ -53,11 +59,13 @@ public class StreamInitiateReplyMessage extends AddressedMessage {
 
     public String toString() {
         return super.toString()
-                +" StreamInitiateReply"
                 +" SSID "+sourceStreamID
                 +" DSID "+destStreamID
                 +" bsize "+bufferSize;     
     }
 
-    public int getMTI() { return MTI_STREAM_INIT_REPLY; }
+    @Override
+    public MessageTypeIdentifier getEMTI() {
+        return MessageTypeIdentifier.StreamInitiateReply;
+    }
 }

--- a/src/org/openlcb/StreamInitiateRequestMessage.java
+++ b/src/org/openlcb/StreamInitiateRequestMessage.java
@@ -12,11 +12,11 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class StreamInitiateRequestMessage extends AddressedMessage {
+public class StreamInitiateRequestMessage extends AddressedPayloadMessage {
     
     public StreamInitiateRequestMessage(NodeID source, NodeID dest,
                     int bufferSize, byte sourceStreamID, byte destinationStreamID) {
-        super(source, dest);
+        super(source, dest, toPayload(bufferSize, sourceStreamID, destinationStreamID));
         this.bufferSize = bufferSize;
         this.sourceStreamID = sourceStreamID;
         this.destinationStreamID = destinationStreamID;
@@ -29,7 +29,13 @@ public class StreamInitiateRequestMessage extends AddressedMessage {
     public int getBufferSize() { return bufferSize; }
     public byte getSourceStreamID() { return sourceStreamID; }
     public byte getDestinationStreamID() { return destinationStreamID; }
-    
+
+    static byte[] toPayload(int bufferSize, byte sourceStreamID, byte destStreamID) {
+        byte[] b = new byte[]{0, 0, 0, 0, sourceStreamID, destStreamID};
+        Utilities.HostToNetworkUint16(b, 0, bufferSize);
+        return b;
+    }
+
     /**
      * Implement message-type-specific
      * processing when this message
@@ -47,14 +53,20 @@ public class StreamInitiateRequestMessage extends AddressedMessage {
         StreamInitiateRequestMessage p = (StreamInitiateRequestMessage) o;
         if (bufferSize != p.bufferSize) return false;
         if (sourceStreamID != p.sourceStreamID) return false;
+        if (destinationStreamID != p.destinationStreamID) return false;
         return super.equals(o);
     } 
 
     public String toString() {
         return super.toString()
-                +" StreamInitiateRequest "
                 +" SSID "+sourceStreamID
-                +" bsize "+bufferSize;     
+                +" DSID "+destinationStreamID
+                +" bsize "+bufferSize;
+    }
+
+    @Override
+    public MessageTypeIdentifier getEMTI() {
+        return MessageTypeIdentifier.StreamInitiateRequest;
     }
 
     public int getMTI() { return MTI_STREAM_INIT_REQUEST; }

--- a/src/org/openlcb/Utilities.java
+++ b/src/org/openlcb/Utilities.java
@@ -127,4 +127,80 @@ public class Utilities {
         return b;
     }
 
+    static public int NetworkToHostUint8(byte[] arr, int offset) {
+        if (arr == null || arr.length < offset) {
+            return 0;
+        }
+        int r = arr[offset];
+        r &= 0xff;
+        return r;
+    }
+
+    static public void HostToNetworkUint8(byte[] arr, int offset, int value) {
+        arr[offset] = (byte) (value & 0xff);
+    }
+
+    static public int NetworkToHostUint16(byte[] arr, int offset) {
+        if (arr == null || arr.length < (offset+1)) {
+            return 0;
+        }
+        return ((((int)arr[offset]) & 0xff) << 8) |
+                (((int)arr[offset+1]) & 0xff);
+    }
+
+    static public void HostToNetworkUint16(byte[] arr, int offset, int value) {
+        arr[offset] = (byte) ((value >> 8) & 0xff);
+        arr[offset+1] = (byte) (value & 0xff);
+    }
+
+    static public long NetworkToHostUint32(byte[] arr, int offset) {
+        if (arr == null || arr.length < (offset+3)) {
+            return 0;
+        }
+        long ret = 0;
+        ret |= ((int)arr[offset]) & 0xff;
+        ret <<= 8;
+        ret |= ((int)arr[offset+1]) & 0xff;
+        ret <<= 8;
+        ret |= ((int)arr[offset+2]) & 0xff;
+        ret <<= 8;
+        ret |= ((int)arr[offset+3]) & 0xff;
+        return ret;
+    }
+
+    static public void HostToNetworkUint32(byte[] arr, int offset, long value) {
+        arr[offset] = (byte) ((value >> 24) & 0xff);
+        arr[offset+1] = (byte) ((value >> 16) & 0xff);
+        arr[offset+2] = (byte) ((value >> 8) & 0xff);
+        arr[offset+3] = (byte) ((value) & 0xff);
+    }
+
+    static public long NetworkToHostUint48(byte[] arr, int offset) {
+        if (arr == null || arr.length < (offset+5)) {
+            return 0;
+        }
+        long ret = 0;
+        ret |= ((int)arr[offset]) & 0xff;
+        ret <<= 8;
+        ret |= ((int)arr[offset+1]) & 0xff;
+        ret <<= 8;
+        ret |= ((int)arr[offset+2]) & 0xff;
+        ret <<= 8;
+        ret |= ((int)arr[offset+3]) & 0xff;
+        ret <<= 8;
+        ret |= ((int)arr[offset+4]) & 0xff;
+        ret <<= 8;
+        ret |= ((int)arr[offset+5]) & 0xff;
+        return ret;
+    }
+
+    static public void HostToNetworkUint48(byte[] arr, int offset, long value) {
+        arr[offset] = (byte) ((value >> 40) & 0xff);
+        arr[offset+1] = (byte) ((value >> 32) & 0xff);
+        arr[offset+2] = (byte) ((value >> 24) & 0xff);
+        arr[offset+3] = (byte) ((value >> 16) & 0xff);
+        arr[offset+4] = (byte) ((value >> 8) & 0xff);
+        arr[offset+5] = (byte) ((value) & 0xff);
+    }
+
 }

--- a/src/org/openlcb/cdi/jdom/CdiMemConfigReader.java
+++ b/src/org/openlcb/cdi/jdom/CdiMemConfigReader.java
@@ -5,10 +5,13 @@ package org.openlcb.cdi.jdom;
 import javax.swing.*;
 import javax.swing.text.*;
 import java.beans.PropertyChangeListener;
+import java.util.logging.Logger;
 
 import org.openlcb.*;
 import org.openlcb.Utilities;
 import org.openlcb.implementations.*;
+
+import static java.util.logging.Logger.getLogger;
 
 /**
  * Provide a Reader to the OpenLCB CDI in a node.
@@ -20,7 +23,8 @@ import org.openlcb.implementations.*;
  * @version	$Revision$
  */
 public class CdiMemConfigReader  {
-    
+    private final static Logger log = getLogger(CdiMemConfigReader.class.getName());
+
     final static int LENGTH = 64;
 
     NodeID node;
@@ -62,6 +66,7 @@ public class CdiMemConfigReader  {
             new MemoryConfigurationService.McsReadHandler() {
                 @Override
                 public void handleFailure(int code) {
+                    log.warning("Error reading CDI: " + Integer.toHexString(code));
                     done();
                     // TODO: 5/2/16 proxy error messages to the caller.
                     // don't do next request

--- a/test/org/openlcb/UtilitiesTest.java
+++ b/test/org/openlcb/UtilitiesTest.java
@@ -49,7 +49,28 @@ public class UtilitiesTest extends TestCase {
         Assert.assertTrue(compareArrays(new byte[]{0xA, 0xB, 0x12}, Utilities.bytesFromHexString("0A 0B 12")));
         Assert.assertTrue(compareArrays(new byte[]{0xA, 0xB, 0x12}, Utilities.bytesFromHexString("0A.0B.12")));
     }
-    
+
+    public void testPackByteArray() {
+        byte[] b = new byte[5];
+        Utilities.HostToNetworkUint8(b, 2, 168);
+        Assert.assertEquals("00 00 A8 00 00", Utilities.toHexSpaceString(b));
+        Assert.assertEquals(168, Utilities.NetworkToHostUint8(b, 2));
+        Utilities.HostToNetworkUint16(b, 1, 43766);
+        Assert.assertEquals("00 AA F6 00 00", Utilities.toHexSpaceString(b));
+        Assert.assertEquals(43766, Utilities.NetworkToHostUint16(b, 1));
+        Utilities.HostToNetworkUint32(b, 1, 17);
+        Assert.assertEquals("00 00 00 00 11", Utilities.toHexSpaceString(b));
+        Assert.assertEquals(17, Utilities.NetworkToHostUint32(b, 1));
+        Utilities.HostToNetworkUint32(b, 1, 3000000017L);
+        Assert.assertEquals("00 B2 D0 5E 11", Utilities.toHexSpaceString(b));
+        Assert.assertEquals(3000000017L, Utilities.NetworkToHostUint32(b, 1));
+
+        b = new byte[6];
+        Utilities.HostToNetworkUint48(b, 0, 0x0501010118DAL);
+        Assert.assertEquals("05 01 01 01 18 DA", Utilities.toHexSpaceString(b));
+        Assert.assertEquals(0x0501010118DAL, Utilities.NetworkToHostUint48(b, 0));
+    }
+
     boolean compareArrays(byte[] a, byte[]b) {
         if (a == null && b == null) return true;
         if (a.length != b.length) return false;


### PR DESCRIPTION
Removes a lot of duplicate code in the rendering of addressed messages.
Fixes forgotten addressed messages that JMRI could never send, like SNIP reply.
Minor fixes on the interface send thread and utilities.