### PR TITLE
Adds extra features to the BitProducerConsumer

### DIFF
--- a/src/org/openlcb/ConsumerIdentifiedMessage.java
+++ b/src/org/openlcb/ConsumerIdentifiedMessage.java
@@ -12,18 +12,13 @@ import net.jcip.annotations.ThreadSafe;
  */
 @Immutable
 @ThreadSafe
-public class ConsumerIdentifiedMessage extends Message {
+public class ConsumerIdentifiedMessage extends EventMessage {
     
     public ConsumerIdentifiedMessage(NodeID source, EventID eventID, EventState eventState) {
-        super(source);
-        if (eventID == null)
-            throw new IllegalArgumentException("EventID cannot be null");
-        this.eventID = eventID;
+        super(source, eventID);
         this.eventState = eventState;
     }
-        
-    @SuppressWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
-    EventID eventID;
+
     private final EventState eventState;
 
     // because EventID is immutable, can directly return object
@@ -47,19 +42,11 @@ public class ConsumerIdentifiedMessage extends Message {
 
     @Override
     public boolean equals(Object o) {
-        if (o == null) return false;
-        if (! (o instanceof ConsumerIdentifiedMessage))
-            return false;
         if (!super.equals(o)) return false;
         ConsumerIdentifiedMessage p = (ConsumerIdentifiedMessage) o;
-        return eventID.equals(p.eventID);
+        return eventState == p.eventState;
     }
 
-    @Override
-    public int hashCode() {
-        return super.hashCode()+eventID.hashCode();
-    }
-    
     @Override
     public String toString() {
         return super.toString() + " Consumer Identified " + eventState.toString() + " for "+eventID.toString();

--- a/src/org/openlcb/EventMessage.java
+++ b/src/org/openlcb/EventMessage.java
@@ -1,0 +1,32 @@
+package org.openlcb;
+
+/**
+ * Created by bracz on 11/9/16.
+ */
+public abstract class EventMessage extends Message {
+    protected final EventID eventID;
+
+    public EventMessage(NodeID source, EventID eventID) {
+        super(source);
+        if (eventID == null)
+            throw new IllegalArgumentException("EventID cannot be null");
+        this.eventID = eventID;
+    }
+
+    public boolean equals(Object o) {
+        if (!super.equals(o)) return false;
+        if (!(o instanceof EventMessage)) return false;
+        EventMessage p = (EventMessage) o;
+        return (eventID.equals(p.eventID));
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() | eventID.hashCode();
+    }
+
+    // because EventID is immutable, can directly return object
+    public EventID getEventID() {
+        return eventID;
+    }
+}

--- a/src/org/openlcb/IdentifyConsumersMessage.java
+++ b/src/org/openlcb/IdentifyConsumersMessage.java
@@ -12,16 +12,12 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class IdentifyConsumersMessage extends Message {
+public class IdentifyConsumersMessage extends EventMessage {
     
     public IdentifyConsumersMessage(NodeID source, EventID event) {
-        super(source);
-        this.eventID = event;
+        super(source, event);
     }
-    
-    EventID eventID = null;
-    public EventID getEventID() { return eventID; }
-    
+
     /**
      * Implement message-type-specific
      * processing when this message
@@ -32,19 +28,6 @@ public class IdentifyConsumersMessage extends Message {
      @Override
      public void applyTo(MessageDecoder decoder, Connection sender) {
         decoder.handleIdentifyConsumers(this, sender);
-     }
-
-     /**
-      * To be equal, messages have to have the
-      * same type and content
-      */
-     @Override
-     public boolean equals(Object o) {
-        if (!super.equals(o)) return false; // also checks type
-        IdentifyConsumersMessage msg = (IdentifyConsumersMessage) o;
-        if (! this.eventID.equals(msg.eventID))
-            return false;
-        return true;
      }
 
     public String toString() {

--- a/src/org/openlcb/IdentifyProducersMessage.java
+++ b/src/org/openlcb/IdentifyProducersMessage.java
@@ -12,16 +12,11 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class IdentifyProducersMessage extends Message {
-    
+public class IdentifyProducersMessage extends EventMessage {
     public IdentifyProducersMessage(NodeID source, EventID eventID) {
-        super(source);
-        this.eventID = eventID;
+        super(source, eventID);
     }
         
-    EventID eventID;
-    public EventID getEventID() { return eventID; }
-    
     /**
      * Implement message-type-specific
      * processing when this message
@@ -32,19 +27,6 @@ public class IdentifyProducersMessage extends Message {
      @Override
      public void applyTo(MessageDecoder decoder, Connection sender) {
         decoder.handleIdentifyProducers(this, sender);
-     }
-
-     /**
-      * To be equal, messages have to have the
-      * same type and content
-      */
-     @Override
-     public boolean equals(Object o) {
-        if (!super.equals(o)) return false; // also checks type
-        IdentifyProducersMessage msg = (IdentifyProducersMessage) o;
-        if (! this.eventID.equals(msg.eventID))
-            return false;
-        return true;
      }
 
     public String toString() {

--- a/src/org/openlcb/LearnEventMessage.java
+++ b/src/org/openlcb/LearnEventMessage.java
@@ -12,18 +12,9 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class LearnEventMessage extends Message {
-    
+public class LearnEventMessage extends EventMessage {
     public LearnEventMessage(NodeID source, EventID eid) {
-        super(source);
-        this.eventID = eid;
-    }
-        
-    EventID eventID;
-    
-    // because EventID is immutable, can directly return object
-    public EventID getEventID() {
-        return eventID;
+        super(source, eid);
     }
 
     /**
@@ -37,12 +28,6 @@ public class LearnEventMessage extends Message {
      public void applyTo(MessageDecoder decoder, Connection sender) {
         decoder.handleLearnEvent(this, sender);
      }
-
-    public boolean equals(Object o) {
-        if (!super.equals(o)) return false;
-        LearnEventMessage p = (LearnEventMessage) o;
-        return eventID.equals(p.eventID);
-    } 
 
     public String toString() {
         return super.toString()

--- a/src/org/openlcb/OlcbInterface.java
+++ b/src/org/openlcb/OlcbInterface.java
@@ -206,7 +206,8 @@ public class OlcbInterface {
      */
     private class QueuedOutputConnection implements Connection {
         private final Connection realOutput;
-        private final BlockingQueue<Message> outputQueue = new LinkedBlockingQueue<>();
+        private final BlockingQueue<QEntry> outputQueue = new
+                LinkedBlockingQueue<>();
         private int pendingCount = 0;
 
         QueuedOutputConnection(Connection realOutput) {
@@ -218,7 +219,7 @@ public class OlcbInterface {
             synchronized(this) {
                 pendingCount++;
             }
-            outputQueue.add(msg);
+            outputQueue.add(new QEntry(msg, sender));
         }
 
         @Override
@@ -243,9 +244,9 @@ public class OlcbInterface {
         private void run() {
             while (true) {
                 try {
-                    Message m = outputQueue.take();
+                    QEntry m = outputQueue.take();
                     try {
-                        realOutput.put(m, null);
+                        realOutput.put(m.message, m.connection);
                     } catch (Throwable e) {
                         log.warning("Exception while sending message: " + e.toString());
                         e.printStackTrace();
@@ -256,6 +257,15 @@ public class OlcbInterface {
                 } catch (InterruptedException e) {
                     continue;
                 }
+            }
+        }
+
+        private class QEntry {
+            Message message;
+            Connection connection;
+            QEntry(Message m, Connection c) {
+                message = m;
+                connection = c;
             }
         }
     }

--- a/src/org/openlcb/ProducerConsumerEventReportMessage.java
+++ b/src/org/openlcb/ProducerConsumerEventReportMessage.java
@@ -12,20 +12,11 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class ProducerConsumerEventReportMessage extends Message {
+public class ProducerConsumerEventReportMessage extends EventMessage {
     
     public ProducerConsumerEventReportMessage(NodeID source, EventID eventID) {
-        super(source);
-        this.eventID = eventID;
+        super(source, eventID);
     }
-    
-    private EventID eventID;
-    
-    // because EventID is immutable, can directly return object
-    public EventID getEventID() {
-        return eventID;
-    }
-    
     /**
      * Implement message-type-specific
      * processing when this message
@@ -37,13 +28,7 @@ public class ProducerConsumerEventReportMessage extends Message {
     public void applyTo(MessageDecoder decoder, Connection sender) {
         decoder.handleProducerConsumerEventReport(this, sender);
     }
-    
-    public boolean equals(Object o) {
-        if (!super.equals(o)) return false;
-        ProducerConsumerEventReportMessage p = (ProducerConsumerEventReportMessage) o;
-        return eventID.equals(p.eventID);
-    } 
-    
+
     public String toString() {
         return super.toString()
                 +" Producer/Consumer Event Report with "+eventID.toString();     

--- a/src/org/openlcb/ProducerIdentifiedMessage.java
+++ b/src/org/openlcb/ProducerIdentifiedMessage.java
@@ -12,23 +12,13 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class ProducerIdentifiedMessage extends Message {
-
+public class ProducerIdentifiedMessage extends EventMessage {
     public ProducerIdentifiedMessage(NodeID source, EventID eventID, EventState eventState) {
-        super(source);
-        if (eventID == null)
-            throw new IllegalArgumentException("EventID cannot be null");
-        this.eventID = eventID;
+        super(source, eventID);
         this.eventState = eventState;
     }
-        
-    private final EventID eventID;
-    private final EventState eventState;
 
-    // because EventID is immutable, can directly return object
-    public EventID getEventID() {
-        return eventID;
-    }
+    private final EventState eventState;
 
     public EventState getEventState() { return eventState; }
 
@@ -44,10 +34,10 @@ public class ProducerIdentifiedMessage extends Message {
         decoder.handleProducerIdentified(this, sender);
      }
 
+    @Override
     public boolean equals(Object o) {
         if (!super.equals(o)) return false;
         ProducerIdentifiedMessage p = (ProducerIdentifiedMessage) o;
-        if (!eventID.equals(p.eventID)) return false;
         return eventState == p.eventState;
     } 
 

--- a/src/org/openlcb/implementations/BitProducerConsumer.java
+++ b/src/org/openlcb/implementations/BitProducerConsumer.java
@@ -141,6 +141,7 @@ public class BitProducerConsumer extends MessageDecoder {
 
     @Override
     public void handleIdentifyConsumers(IdentifyConsumersMessage msg, Connection sender) {
+        if (sender == this) return;
         EventState st = getEventState(msg.getEventID());
         if (st != null && ((flags & IS_CONSUMER) != 0)) {
             sendMessage(new ConsumerIdentifiedMessage(iface.getNodeId(), msg.getEventID(), st));
@@ -149,6 +150,7 @@ public class BitProducerConsumer extends MessageDecoder {
 
     @Override
     public void handleIdentifyProducers(IdentifyProducersMessage msg, Connection sender) {
+        if (sender == this) return;
         EventState st = getEventState(msg.getEventID());
         if (st != null && ((flags & IS_PRODUCER) != 0)) {
             sendMessage(new ProducerIdentifiedMessage(iface.getNodeId(), msg.getEventID(), st));

--- a/src/org/openlcb/implementations/BitProducerConsumer.java
+++ b/src/org/openlcb/implementations/BitProducerConsumer.java
@@ -26,7 +26,7 @@ public class BitProducerConsumer extends MessageDecoder {
     private final VersionedValueListener<Boolean> valueListener;
     private final int flags;
 
-    private final static EventID nullEvent = new EventID(new byte[]{0, 0, 0, 0, 0, 0, 0, 0});
+    public final static EventID nullEvent = new EventID(new byte[]{0, 0, 0, 0, 0, 0, 0, 0});
 
     /// Flag bit to set default value. (set: true; clear: false).
     public final static int DEFAULT_TRUE = 1;

--- a/src/org/openlcb/implementations/BitProducerConsumer.java
+++ b/src/org/openlcb/implementations/BitProducerConsumer.java
@@ -61,6 +61,7 @@ public class BitProducerConsumer extends MessageDecoder {
         valueListener = new VersionedValueListener<Boolean>(value) {
             @Override
             public void update(Boolean newValue) {
+                if ((flags & IS_PRODUCER) == 0) return;
                 EventID id = newValue ? BitProducerConsumer.this.eventOn :
                         BitProducerConsumer.this.eventOff;
                 sendMessage(new ProducerConsumerEventReportMessage(BitProducerConsumer.this.iface
@@ -71,7 +72,7 @@ public class BitProducerConsumer extends MessageDecoder {
         iface.getOutputConnection().registerStartNotification(new ConnectionListener() {
             @Override
             public void connectionActive(Connection c) {
-                sendIdentifiedMessages(true);
+                sendIdentifiedMessages((flags & QUERY_AT_STARTUP) != 0);
             }
         });
     }
@@ -206,6 +207,7 @@ public class BitProducerConsumer extends MessageDecoder {
     @Override
     public void handleProducerConsumerEventReport(ProducerConsumerEventReportMessage msg,
                                                   Connection sender) {
+        if ((flags & IS_CONSUMER) == 0) return;
         boolean isOn;
         if (msg.getEventID().equals(eventOn)) {
             isOn = true;

--- a/test/org/openlcb/implementations/BitProducerConsumerTest.java
+++ b/test/org/openlcb/implementations/BitProducerConsumerTest.java
@@ -200,9 +200,9 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
     public void setUp() {
         aliasMap.insert(0x444, new NodeID(new byte[]{1,2,3,1,2,3}));
         pc = new BitProducerConsumer(iface, onEvent, offEvent, false);
-        expectFrame(":X19547333N0504030201000708;", times(2));
+        expectFrame(":X19547333N0504030201000708;", times(1));
         expectFrame(":X19547333N0504030201000709;");
-        expectFrame(":X194C7333N0504030201000708;", times(2));
+        expectFrame(":X194C7333N0504030201000708;", times(1));
         expectFrame(":X194C7333N0504030201000709;");
 
         expectFrame(":X19914333N0504030201000708;");

--- a/test/org/openlcb/implementations/BitProducerConsumerTest.java
+++ b/test/org/openlcb/implementations/BitProducerConsumerTest.java
@@ -384,9 +384,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectFrame(":X194C7333N0504030201000709;");
 
         expectNoFrames();
-        // If we set the internal state first, then
         helperNotProducing();
-        // we will not be listening for initial state anymore
         helperInputSetClear(":X194C5333N0504030201000709;",
                 ":X194C5333N0504030201000708;");
         helperInputSetClear(":X195B4333N0504030201000708;",
@@ -395,7 +393,47 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
                 ":X19544333N0504030201000709;");
     }
 
-    @Override
+    public void testOneEventNull() throws Exception {
+        pc = new BitProducerConsumer(iface, onEvent, pc.nullEvent, BitProducerConsumer.IS_PRODUCER | BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.LISTEN_EVENT_IDENTIFIED);
+
+        expectFrame(":X19547333N0504030201000708;");
+        expectFrame(":X194C7333N0504030201000708;");
+
+        expectNoFrames();
+
+        VersionedValue<Boolean> v = pc.getValue();
+        v.set(false);
+        expectNoFrames();
+        v.set(true);
+        expectFrame(":X195B4333N0504030201000708;");
+        expectNoFrames();
+        v.set(false);
+        expectNoFrames();
+        v.set(true);
+        expectFrame(":X195B4333N0504030201000708;");
+        expectNoFrames();
+
+        // on one event we can flipflop
+        helperInputSetClear(":X194C4333N0504030201000708;",
+                ":X194C5333N0504030201000708;");
+        helperInputSetClear(":X19544333N0504030201000708;",
+                ":X19545333N0504030201000708;");
+        // but the other is ignored
+        helperInputNoChange(":X194C4333N0504030201000709;",
+                ":X194C5333N0504030201000709;");
+
+        v.set(true);
+        expectFrame(":X195B4333N0504030201000708;");
+        expectNoFrames();
+
+        // send query and get back the same
+        sendFrame(":X19968444N0333;");
+        expectFrame(":X19544333N0504030201000708;");
+        expectFrame(":X194C4333N0504030201000708;");
+
+    }
+
+        @Override
     protected void tearDown() throws Exception {
         expectNoFrames();
         super.tearDown();

--- a/test/org/openlcb/implementations/BitProducerConsumerTest.java
+++ b/test/org/openlcb/implementations/BitProducerConsumerTest.java
@@ -3,7 +3,10 @@ package org.openlcb.implementations;
 import org.openlcb.EventID;
 import org.openlcb.NodeID;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * Created by bracz on 1/8/16.
@@ -15,6 +18,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
     BitProducerConsumer pc;
 
     public void testHandleIdentifyConsumers() throws Exception {
+        createWithDefaults();
         sendFrameAndExpectResult( //
                 ":X198F4444N0504030201000709;",
                 ":X194C7333N0504030201000709;");
@@ -43,6 +47,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
     }
 
     public void testHandleIdentifyProducers() throws Exception {
+        createWithDefaults();
         sendFrameAndExpectResult( //
                 ":X19914444N0504030201000708;",
                 ":X19547333N0504030201000708;");
@@ -70,19 +75,23 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
     }
 
     public void testHandleProducerIdentified() throws Exception {
+        createWithDefaults();
         helperInputSetClear(":X19544333N0504030201000708;", ":X19545333N0504030201000708;");
     }
 
     public void testHandleProducerIdentifiedOff() throws Exception {
+        createWithDefaults();
         helperInputSetClear(":X19545333N0504030201000709;", ":X19544333N0504030201000709;");
     }
 
     public void testHandleProducerIdentifiedOnOff() throws Exception {
+        createWithDefaults();
         helperInputSetClear(":X19544333N0504030201000708;", ":X19544333N0504030201000709;");
     }
 
     public void helperInputSetClear(String frameOn, String frameOff) {
-        assertTrue(pc.isValueAtDefault());
+        //assertTrue(pc.isValueAtDefault());
+        sendFrame(frameOff);
         assertFalse(pc.getValue().getLatestData());
         sendFrame(frameOn);
         assertFalse(pc.isValueAtDefault());
@@ -114,23 +123,68 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         assertFalse(pc.getValue().getLatestData());
     }
 
+    public void helperInputNoChange(String frameOn, String frameOff) {
+        Boolean data = pc.getValue().getLatestData();
+        boolean atDefault = pc.isValueAtDefault();
+
+        sendFrame(frameOn);
+        assertEquals(data, pc.getValue().getLatestData());
+        assertEquals(atDefault, pc.isValueAtDefault());
+        expectNoFrames();
+
+        sendFrame(frameOff);
+        assertEquals(data, pc.getValue().getLatestData());
+        assertEquals(atDefault, pc.isValueAtDefault());
+        expectNoFrames();
+
+        sendFrame(frameOn);
+        assertEquals(data, pc.getValue().getLatestData());
+        assertEquals(atDefault, pc.isValueAtDefault());
+        expectNoFrames();
+
+        sendFrame(frameOff);
+        assertEquals(data, pc.getValue().getLatestData());
+        assertEquals(atDefault, pc.isValueAtDefault());
+        expectNoFrames();
+    }
+
+    public void helperNotProducing() {
+        VersionedValue<Boolean> v = pc.getValue();
+        v.set(false);
+        expectNoFrames();
+        v.set(true);
+        expectNoFrames();
+        v.set(false);
+        expectNoFrames();
+    }
+
+    void helperNotConsuming() {
+        helperInputNoChange(":X195B4333N0504030201000708;",
+                ":X195B4333N0504030201000709;");
+    }
+
     public void testHandleConsumerIdentified() throws Exception {
+        createWithDefaults();
         helperInputSetClear(":X194C4333N0504030201000708;", ":X194C5333N0504030201000708;");
     }
 
     public void testHandleConsumerIdentifiedOff() throws Exception {
+        createWithDefaults();
         helperInputSetClear(":X194C5333N0504030201000709;", ":X194C4333N0504030201000709;");
     }
 
     public void testHandleConsumerIdentifiedOnOff() throws Exception {
+        createWithDefaults();
         helperInputSetClear(":X194C4333N0504030201000708;", ":X194C4333N0504030201000709;");
     }
 
     public void testHandleProducerConsumerEventReport() throws Exception {
+        createWithDefaults();
         helperInputSetClear(":X195B4333N0504030201000708;", ":X195B4333N0504030201000709;");
     }
 
     public void testHandleIdentifyEventsUnknown() throws Exception {
+        createWithDefaults();
         sendFrame(":X19968444N0333;");
         //sendFrame(":X19970444N;");
         expectFrame(":X19547333N0504030201000708;");
@@ -140,6 +194,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
     }
 
     public void testHandleIdentifyEventsKnown() throws Exception {
+        createWithDefaults();
         sendFrame(":X194C5333N0504030201000709;");
         sendFrame(":X19968444N0333;");
 
@@ -162,6 +217,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
     }
 
     public void testGenerateEvents() throws Exception {
+        createWithDefaults();
         VersionedValue<Boolean> v = pc.getValue();
         sendFrameAndExpectResult( //
                 ":X19914444N0504030201000708;",
@@ -190,15 +246,162 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectNoFrames();
     }
 
+    public void testProducerOnlyNoListen() throws Exception {
+        pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_PRODUCER);
+        // startup
+        expectFrame(":X19547333N0504030201000708;");
+        expectFrame(":X19547333N0504030201000709;");
+
+        expectNoFrames();
+
+        // send query and get back the same
+        sendFrame(":X19968444N0333;");
+        expectFrame(":X19547333N0504030201000708;");
+        expectFrame(":X19547333N0504030201000709;");
+        expectNoFrames();
+
+        helperInputNoChange(":X19545333N0504030201000708;",
+                ":X19545333N0504030201000709;");
+        helperInputNoChange(":X195B4333N0504030201000708;",
+                ":X195B4333N0504030201000709;");
+
+
+        // set the value
+        VersionedValue<Boolean> v = pc.getValue();
+        v.set(false);
+        expectFrame(":X195B4333N0504030201000709;");
+        // now a query tell us different
+        expectNoFrames();
+        assertFalse(pc.isValueAtDefault());
+
+        sendFrameAndExpectResult( //
+                ":X19914444N0504030201000708;",
+                ":X19545333N0504030201000708;");
+        expectNoFrames();
+
+        assertFalse(v.getLatestData());
+        v.set(true);
+        expectFrame(":X195B4333N0504030201000708;");
+        expectNoFrames();
+
+        assertTrue(v.getLatestData());
+
+        helperInputNoChange(":X19545333N0504030201000708;",
+                ":X19545333N0504030201000709;");
+        helperInputNoChange(":X195B4333N0504030201000708;",
+                ":X195B4333N0504030201000709;");
+    }
+
+    public void testConsumerOnlyNoListen() throws Exception {
+        pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_CONSUMER);
+        expectFrame(":X194C7333N0504030201000708;");
+        expectFrame(":X194C7333N0504030201000709;");
+
+        expectNoFrames();
+
+        // send query and get back the same
+        sendFrame(":X19968444N0333;");
+        expectFrame(":X194C7333N0504030201000708;");
+        expectFrame(":X194C7333N0504030201000709;");
+        expectNoFrames();
+
+        helperInputNoChange(":X19545333N0504030201000708;",
+                ":X19545333N0504030201000709;");
+        helperInputNoChange(":X194C5333N0504030201000708;",
+                ":X194C5333N0504030201000709;");
+
+        helperInputSetClear(":X195B4333N0504030201000708;",
+                ":X195B4333N0504030201000709;");
+
+        // set the value
+        helperNotProducing();
+
+        sendFrame(":X19968444N0333;");
+        expectFrame(":X194C5333N0504030201000708;");
+        expectFrame(":X194C4333N0504030201000709;");
+    }
+
+    public void testConsumerOnlyListenFirst() throws Exception {
+        pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.QUERY_AT_STARTUP);
+
+        expectFrame(":X194C7333N0504030201000708;");
+        expectFrame(":X194C7333N0504030201000709;");
+
+        expectFrame(":X19914333N0504030201000708;");
+        expectFrame(":X198F4333N0504030201000708;");
+
+        expectNoFrames();
+
+        sendFrame(":X19968444N0333;");
+        expectFrame(":X194C7333N0504030201000708;");
+        expectFrame(":X194C7333N0504030201000709;");
+        expectNoFrames();
+
+        assertTrue(pc.isValueAtDefault());
+        sendFrame(":X19544333N0504030201000708;");
+        expectNoFrames();
+        assertFalse(pc.isValueAtDefault());
+        assertTrue(pc.getValue().getLatestData());
+
+        sendFrame(":X19968444N0333;");
+        expectFrame(":X194C4333N0504030201000708;");
+        expectFrame(":X194C5333N0504030201000709;");
+        expectNoFrames();
+
+        // after the first query we are not listening anymore.
+        helperInputNoChange(":X19545333N0504030201000708;",
+                ":X19545333N0504030201000709;");
+        helperInputNoChange(":X194C5333N0504030201000708;",
+                ":X194C5333N0504030201000709;");
+
+        helperInputSetClear(":X195B4333N0504030201000708;",
+                ":X195B4333N0504030201000709;");
+
+        helperNotProducing();
+    }
+
+    public void testConsumerOnlyListenFirstSetState() throws Exception {
+        pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.QUERY_AT_STARTUP);
+
+        expectFrame(":X194C7333N0504030201000708;");
+        expectFrame(":X194C7333N0504030201000709;");
+
+        expectFrame(":X19914333N0504030201000708;");
+        expectFrame(":X198F4333N0504030201000708;");
+
+        expectNoFrames();
+        // If we set the internal state first, then
+        helperNotProducing();
+        // we will not be listening for initial state anymore
+        helperInputNoChange(":X194C5333N0504030201000708;",
+                ":X194C5333N0504030201000709;");
+    }
+
+    public void testConsumerOnlyListenAlways() throws Exception {
+        pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.LISTEN_EVENT_IDENTIFIED);
+
+        expectFrame(":X194C7333N0504030201000708;");
+        expectFrame(":X194C7333N0504030201000709;");
+
+        expectNoFrames();
+        // If we set the internal state first, then
+        helperNotProducing();
+        // we will not be listening for initial state anymore
+        helperInputSetClear(":X194C5333N0504030201000709;",
+                ":X194C5333N0504030201000708;");
+        helperInputSetClear(":X195B4333N0504030201000708;",
+                ":X195B4333N0504030201000709;");
+        helperInputSetClear(":X19544333N0504030201000708;",
+                ":X19544333N0504030201000709;");
+    }
+
     @Override
     protected void tearDown() throws Exception {
         expectNoFrames();
         super.tearDown();
     }
 
-    @Override
-    public void setUp() {
-        aliasMap.insert(0x444, new NodeID(new byte[]{1,2,3,1,2,3}));
+    private void createWithDefaults() {
         pc = new BitProducerConsumer(iface, onEvent, offEvent, false);
         expectFrame(":X19547333N0504030201000708;", times(1));
         expectFrame(":X19547333N0504030201000709;");
@@ -208,5 +411,10 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectFrame(":X19914333N0504030201000708;");
         expectFrame(":X198F4333N0504030201000708;");
         expectNoFrames();
+    }
+
+    @Override
+    public void setUp() {
+        aliasMap.insert(0x444, new NodeID(new byte[]{1,2,3,1,2,3}));
     }
 }


### PR DESCRIPTION
- never send out messages with null eventID.
- allows selecting whether the object be a producer or consumer or both.
- allows selecting whether we listen to the layout state messages or only change state on event report.