### PR TITLE
Use published version to update JMRI

### DIFF
--- a/RELEASE-JMRI.md
+++ b/RELEASE-JMRI.md
@@ -50,7 +50,7 @@
 
 7. Publish to Maven Central
 
-  ```mvn release```
+  ```mvn deploy -P release```
 
 ## Update JMRI for new OpenLCB
 
@@ -58,7 +58,7 @@ This process is generally defined by
 https://github.com/JMRI/JMRI/blob/master/lib/README.md#updates so it's worth to
 check out if the process changed form what's described below.
 
-1. Verify the version to update JMRI with is published at http://search.maven.org/#search|ga|1|openlcb
+1. Verify the version to update JMRI with is published at http://repo1.maven.org/maven2/org/openlcb/openlcb
 
 2. Update the master branch of your fork by pulling from upstream
 

--- a/RELEASE-JMRI.md
+++ b/RELEASE-JMRI.md
@@ -48,13 +48,19 @@
   Another example:
   https://github.com/openlcb/OpenLCB_Java/commit/80793002a217d6f3cc2f188a532525d875652e0f
 
+7. Publish to Maven Central
+
+  ```mvn release```
+
 ## Update JMRI for new OpenLCB
 
 This process is generally defined by
 https://github.com/JMRI/JMRI/blob/master/lib/README.md#updates so it's worth to
 check out if the process changed form what's described below.
 
-1. Update the master branch of your fork by pulling from upstream
+1. Verify the version to update JMRI with is published at http://search.maven.org/#search|ga|1|openlcb
+
+2. Update the master branch of your fork by pulling from upstream
 
   ```git checkout master```
   
@@ -64,17 +70,17 @@ check out if the process changed form what's described below.
 
   ```git push origin```
 
-2. Create a new branch for your changes
+3. Create a new branch for your changes
 
   ```git checkout -b openlcb-release-update master```
 
-3. Copy the new JAR file into libs
+4. Download the new JAR file into libs
 
-  Copy the new JAR file into the `lib/` subdirectory:
+  Download the new JAR file into the `lib/` subdirectory (replace VERSION with the real version):
   
-  ```cp somewhere/openlcb.jar lib/```
+  ```curl -o lib/openlcb.jar http://repo1.maven.org/maven2/org/openlcb/openlcb/VERSION/openlcb-VERSION.jar```
 
-4. Update the library dependency version number:
+5. Update the library dependency version number:
 
   Edit lib/README.md and update the version number for the openlcb.jar library.
    
@@ -84,29 +90,21 @@ check out if the process changed form what's described below.
   and nbproject/project.xml because these do not refer to the file by version
   number.
   
-5. Push the new JAR to the local maven repository:
-
-    (Replace 0.7.7 with the new version number.)
-
-    ```
-    mvn deploy:deploy-file -DgroupId=org.openlcb -DartifactId=openlcb -Dversion=0.7.7 -Durl=file:./lib/ -DrepositoryId=lib -DupdateReleaseInfo=true -Dfile=./lib/openlcb.jar
-    ```
-
-5. It's a good idea to test JMRI with the new library version.
+6. It's a good idea to test JMRI with the new library version.
 
     ```ant panelpro```
 
     Click around to check a few things related to OpenLCB.
 
-4. Commit your code, binaries and push to github (to your own fork of the
+7. Commit your code, binaries and push to github (to your own fork of the
    project)
 
     Example commits: https://github.com/JMRI/JMRI/pull/2463/commits/a361846a13e6dc84cb43d9b81430b2a9a00418c0
 
-5. Create a pull request for JMRI
+8. Create a pull request for JMRI
 
     Go to github, open your own fork of the JMRI project, select the branch you
     created (github will give you a quick link in yellow) and click "create
     pull request".
 
-6. Wait for a JMRI project member to approve your pull request.
+9. Wait for a JMRI project member to approve your pull request.


### PR DESCRIPTION
Download new version from maven.org instead of copying it from elsewhere on computer to ensure that unpublished version is not included in JMRI.