### PR TITLE
Fix multiple request queueing in MemoryConfigService

### DIFF
--- a/test/org/openlcb/implementations/MemoryConfigurationServiceInterfaceTest.java
+++ b/test/org/openlcb/implementations/MemoryConfigurationServiceInterfaceTest.java
@@ -1,15 +1,11 @@
 package org.openlcb.implementations;
 
-import junit.framework.Assert;
 import junit.framework.AssertionFailedError;
 import junit.framework.Test;
-import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.openlcb.AbstractConnection;
-import org.openlcb.Connection;
 import org.openlcb.DatagramAcknowledgedMessage;
 import org.openlcb.DatagramMessage;
 import org.openlcb.DatagramRejectedMessage;
@@ -24,7 +20,13 @@ import org.openlcb.can.MessageBuilder;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * Tests of MemoryCOnfigurationService using the OlcbInterface output concept and proper mocks.
@@ -134,6 +136,56 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         expectMessageAndNoMore(new DatagramAcknowledgedMessage(hereID, farID));
         verify(hnd).handleFailure(0x1999);
         verifyNoMoreInteractions(hnd);
+    }
+
+    public void testManyWritesQueuesUp() {
+        int space = MemoryConfigurationService.SPACE_CONFIG;
+        long address = 0x12340078;
+
+        int count = 6;
+
+        List<MemoryConfigurationService.McsWriteHandler> hnds = new ArrayList<>();
+
+        // queues up a bunch of requests.
+        for (int i = 0; i < count; ++i) {
+            MemoryConfigurationService.McsWriteHandler mock = mock(
+                    MemoryConfigurationService.McsWriteHandler.class);
+            hnds.add(mock);
+            verifyNoMoreInteractions(mock);
+            iface.getMemoryConfigurationService().requestWrite(farID, space, address + i * 256,
+                    new byte[]{(byte) i, 2}, mock);
+
+            if (i > 0) {
+                assertEquals(i, iface.getMemoryConfigurationService().queuedRequests.get(0).size());
+                MemoryConfigurationService.McsWriteMemo m = (MemoryConfigurationService
+                        .McsWriteMemo) iface.getMemoryConfigurationService().queuedRequests.get
+                        (0).getLast();
+                assertEquals(address + i * 256, m.address);
+            }
+        }
+
+        assertEquals(count - 1, iface.getMemoryConfigurationService().queuedRequests.get(0).size());
+
+        for (int i = 0; i < count; ++i) {
+            MemoryConfigurationService.McsWriteHandler hnd = hnds.get(i);
+
+            expectMessageAndNoMore(new DatagramMessage(hereID, farID, new int[]{
+                    0x20, 0x01, 0x12, 0x34, i, 0x78, i, 2}));
+
+            // datagram reply comes back
+            sendMessage(new DatagramAcknowledgedMessage(farID, hereID, 0x80));
+            verifyNoMoreInteractions(hnd);
+
+            // Incoming reply datagram
+            sendMessage(new DatagramMessage(farID, hereID, new int[]{0x20, 0x11, 0x12, 0x34, i,
+                    0x78}));
+            // which gets ack-ed.
+            expectMessage(new DatagramAcknowledgedMessage(hereID, farID));
+            // note another message will come here as well, the next datagram request.
+            verify(hnd).handleSuccess();
+            verifyNoMoreInteractions(hnd);
+        }
+        expectNoMessages();
     }
 
     public void testSimpleRead() {


### PR DESCRIPTION
Adds a test for multiple write requests being queued up and all sent out.
Fixes major bug when queue didn't work when sending 3 or more requests at the same time.
Makes requests going out in FIFO mode instead of LIFO.