### PR TITLE
Use logging instead of dumping to STDERR or STDOUT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ doc
 
 # bash autocompletion artifacts
 /.ant-targets-build.xml
+/nbproject/private/

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -13,19 +13,19 @@
                 <source-folder>
                     <label>OpenLCB Prototype</label>
                     <location>.</location>
-                    <encoding>MacRoman</encoding>
+                    <encoding>UTF-8</encoding>
                 </source-folder>
                 <source-folder>
                     <label>src</label>
                     <type>java</type>
                     <location>src</location>
-                    <encoding>MacRoman</encoding>
+                    <encoding>UTF-8</encoding>
                 </source-folder>
                 <source-folder>
                     <label>test</label>
                     <type>java</type>
                     <location>test</location>
-                    <encoding>MacRoman</encoding>
+                    <encoding>UTF-8</encoding>
                 </source-folder>
             </folders>
             <ide-actions>
@@ -136,20 +136,20 @@
             </view>
             <subprojects/>
         </general-data>
-        <java-data xmlns="http://www.netbeans.org/ns/freeform-project-java/3">
+        <java-data xmlns="http://www.netbeans.org/ns/freeform-project-java/4">
             <compilation-unit>
                 <package-root>src</package-root>
-                <classpath mode="compile">lib/jdom-2.0.5.jar:lib/jdom.jar:lib/jlfgr-1_0.jar:lib/annotations.jar:lib/jsr305.jar</classpath>
+                <classpath mode="compile">lib/jdom-2.0.5.jar:lib/jdom.jar:lib/jlfgr-1_0.jar:lib/annotations.jar:lib/jsr305.jar:lib/xercesImpl.jar</classpath>
                 <built-to>classes</built-to>
                 <javadoc-built-to>doc</javadoc-built-to>
-                <source-level>1.6</source-level>
+                <source-level>1.8</source-level>
             </compilation-unit>
             <compilation-unit>
                 <package-root>test</package-root>
                 <unit-tests/>
-                <classpath mode="compile">lib/junit.jar:lib/jdom-2.0.5.jar:lib/jdom.jar:lib/jlfgr-1_0.jar:lib/annotations.jar:lib/jsr305.jar:src</classpath>
+                <classpath mode="compile">lib/junit.jar:lib/jdom-2.0.5.jar:lib/jdom.jar:lib/jlfgr-1_0.jar:lib/annotations.jar:lib/jsr305.jar:src:lib/mockito-core-2.2.9.jar</classpath>
                 <built-to>classes</built-to>
-                <source-level>1.6</source-level>
+                <source-level>1.8</source-level>
             </compilation-unit>
         </java-data>
     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -217,19 +217,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
                 <configuration>
                     <show>private</show>
                     <aggregate>true</aggregate>
@@ -263,7 +250,7 @@
                             <name>${project.groupId}</name>
                             <Specification-Title>${project.name}</Specification-Title>
                             <Specification-Version>${specification.version}</Specification-Version>
-                            <Specification-Vendor>${organization.name}</Specification-Vendor>
+                            <Specification-Vendor>${project.organization.name}</Specification-Vendor>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/src/org/openlcb/Interaction.java
+++ b/src/org/openlcb/Interaction.java
@@ -3,21 +3,24 @@ package org.openlcb;
 /**
  * Created by bracz on 12/7/16.
  */
-
 public abstract class Interaction {
+
     /**
-     * Timeout after each sendRequest for the interaction to be completed before the onTimeout is
-     * called.
+     * Timeout after each sendRequest for the interaction to be completed before
+     * the onTimeout is called.
      */
     int deadlineMsec = 700;
 
     /**
-     * Set to true by the system when a cancel/complete call arrives for this interaction.
+     * Set to true by the system when a cancel/complete call arrives for this
+     * interaction.
      */
     boolean isComplete = false;
 
     /**
      * Called by the system when it is time to send this interaction.
+     *
+     * @param downstream the connection over which to send the request
      */
     abstract void sendRequest(Connection downstream);
 
@@ -27,7 +30,8 @@ public abstract class Interaction {
     abstract NodeID dstNode();
 
     /**
-     * Called by the system if there is no answer from the destination node within the timeout.
+     * Called by the system if there is no answer from the destination node
+     * within the timeout.
      */
     abstract void onTimeout();
 }

--- a/src/org/openlcb/LoaderClient.java
+++ b/src/org/openlcb/LoaderClient.java
@@ -1,16 +1,12 @@
 package org.openlcb;
 
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.logging.Logger;
 import org.openlcb.implementations.DatagramService;
 import org.openlcb.implementations.MemoryConfigurationService;
 import org.openlcb.implementations.MemoryConfigurationService.McsWriteHandler;
 import org.openlcb.implementations.MemoryConfigurationService.McsWriteStreamMemo;
-
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.logging.Logger;
-
-//import org.slf4j.Logger;
-//import org.slf4j.LoggerFactory;
 
 //
 //  LoaderClient.java
@@ -23,7 +19,7 @@ import java.util.logging.Logger;
 //#include "LoaderClient.hpp"
 
 public class LoaderClient extends MessageDecoder {
-    static Logger logger = Logger.getLogger("LoaderClient");
+    private static final Logger logger = Logger.getLogger(LoaderClient.class.getName());
 
     enum State { IDLE, ABORT, FREEZE, INITCOMPL, PIP, PIPREPLY, SETUPSTREAM, STREAM, STREAMDATA, DG, UNFREEEZE, SUCCESS, FAIL };
     Connection connection;

--- a/src/org/openlcb/MimicNodeStore.java
+++ b/src/org/openlcb/MimicNodeStore.java
@@ -4,10 +4,11 @@ import java.util.HashMap;
 import java.util.Collection;
 
 import java.util.Queue;
-import java.util.Random;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.annotation.Nullable;
 
@@ -22,6 +23,7 @@ import javax.annotation.Nullable;
 public class MimicNodeStore extends AbstractConnection {
 
     public static final String ADD_PROP_NODE = "AddNode";
+    private final static Logger logger = Logger.getLogger(MimicNodeStore.class.getName());
 
     public MimicNodeStore(Connection connection, NodeID node) {
         this.connection = connection;
@@ -261,7 +263,7 @@ public class MimicNodeStore extends AbstractConnection {
                 // check for temporary error
                 if ( (msg.getCode() & 0x1000 ) == 0) {
                     // not a temporary error, assume a permanent error
-                    System.out.println("Permanent error geting Simple Node Info for node "+msg.getSourceNodeID()+" code 0x"+Integer.toHexString(msg.getCode()).toUpperCase());
+                    logger.log(Level.SEVERE, "Permanent error geting Simple Node Info for node {0} code 0x{1}", new Object[]{msg.getSourceNodeID(), Integer.toHexString(msg.getCode()).toUpperCase()});
                     return;
                 }
                 // have to resend the SNII request
@@ -271,7 +273,7 @@ public class MimicNodeStore extends AbstractConnection {
                 // check for temporary error
                 if ( (msg.getCode() & 0x1000 ) == 0) {
                     // not a temporary error, assume a permanent error
-                    System.out.println("Permanent error geting Protocol Identification information for node "+msg.getSourceNodeID()+" code 0x"+Integer.toHexString(msg.getCode()).toUpperCase());
+                    logger.log(Level.SEVERE, "Permanent error geting Protocol Identification information for node {0} code 0x{1}", new Object[]{msg.getSourceNodeID(), Integer.toHexString(msg.getCode()).toUpperCase()});
                     return;
                 }
                 // have to resend the PIP request

--- a/src/org/openlcb/can/GridConnect.java
+++ b/src/org/openlcb/can/GridConnect.java
@@ -1,18 +1,15 @@
 package org.openlcb.can;
 
-import org.openlcb.implementations.DatagramUtils;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
+import org.openlcb.implementations.DatagramUtils;
 
 /**
  * Created by bracz on 1/8/16.
  */
 public class GridConnect {
-    private static Logger logger = Logger.getLogger(new Object() {
-    }.getClass().getSuperclass()
-            .getName());
+    private final static Logger logger = Logger.getLogger(GridConnect.class.getName());
 
     public static String format(CanFrame frame) {
         StringBuilder b = new StringBuilder();

--- a/src/org/openlcb/can/MessageBuilder.java
+++ b/src/org/openlcb/can/MessageBuilder.java
@@ -3,6 +3,8 @@ package org.openlcb.can;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.openlcb.*;
 import org.openlcb.implementations.DatagramUtils;
 import org.openlcb.messages.TractionControlReplyMessage;
@@ -23,6 +25,7 @@ import org.openlcb.messages.TractionProxyRequestMessage;
  */
 public class MessageBuilder {
 
+    private final static Logger logger = Logger.getLogger(MessageBuilder.class.getName());
     /**
      * The provided AliasMap will be updated
      * as inbound frames are processed.
@@ -165,7 +168,7 @@ public class MessageBuilder {
             // something bad happened
             String mtiString = "000"+Integer.toHexString(mti).toUpperCase();
             mtiString = mtiString.substring(mtiString.length()-3);
-            System.out.println(" failed to parse MTI 0x"+mtiString);
+            logger.log(Level.SEVERE, " failed to parse MTI 0x{0}", mtiString);
             return retlist;  // nothing in it from this
         }
         
@@ -283,8 +286,7 @@ public class MessageBuilder {
                 return retlist;
                 
             default:
-                System.out.println(String.format(" received unhandled MTI 0x%03X: %s",mti, value
-                        .toString()));
+                logger.warning(String.format(" received unhandled MTI 0x%03X: %s", mti, value.toString()));
                 return null;
         }
     }

--- a/src/org/openlcb/can/NIDaAlgorithm.java
+++ b/src/org/openlcb/can/NIDaAlgorithm.java
@@ -1,12 +1,9 @@
 package org.openlcb.can;
 
-import org.openlcb.*;
-
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.logging.Logger;
-
-import static java.lang.Thread.sleep;
+import org.openlcb.*;
 
 /**
  * Implementation of Node ID Alias assignment computation.
@@ -24,8 +21,7 @@ public class NIDaAlgorithm implements CanFrameListener {
     private CanFrameListener sendInterface;
     private Timer timer;
     private TimerTask task;
-    private static Logger logger = Logger.getLogger(new Object(){}.getClass().getSuperclass()
-            .getName());
+    private final static Logger logger = Logger.getLogger(NIDaAlgorithm.class.getName());
 
     private synchronized void scheduleTimer(long delay) {
         task = new TimerTask() {

--- a/src/org/openlcb/can/impl/GridConnectInput.java
+++ b/src/org/openlcb/can/impl/GridConnectInput.java
@@ -1,13 +1,12 @@
 package org.openlcb.can.impl;
 
-import org.openlcb.can.CanFrame;
-import org.openlcb.can.CanFrameListener;
-import org.openlcb.implementations.DatagramUtils;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.logging.Logger;
+import org.openlcb.can.CanFrame;
+import org.openlcb.can.CanFrameListener;
+import org.openlcb.implementations.DatagramUtils;
 
 /**
  * Parses an input stream according to the GridConnect protocol and forwards a set of CAN frames.
@@ -15,8 +14,7 @@ import java.util.logging.Logger;
  * Created by bracz on 12/23/15.
  */
 public class GridConnectInput {
-    private final static String TAG = "GridConnectInput";
-    private final static Logger logger = Logger.getLogger(TAG);
+    private final static Logger logger = Logger.getLogger(GridConnectInput.class.getName());
     private boolean isExtended;
     private int header;
     private boolean isRtr;

--- a/src/org/openlcb/can/impl/GridConnectOutput.java
+++ b/src/org/openlcb/can/impl/GridConnectOutput.java
@@ -1,12 +1,11 @@
 package org.openlcb.can.impl;
 
-import org.openlcb.can.CanFrame;
-import org.openlcb.can.CanFrameListener;
-
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.logging.Logger;
+import org.openlcb.can.CanFrame;
+import org.openlcb.can.CanFrameListener;
 
 /**
  * Converts the sent CAN framesto gridconnect protocol and writes them ot an output stream.
@@ -15,8 +14,7 @@ import java.util.logging.Logger;
  * Created by bracz on 12/23/15.
  */
 public class GridConnectOutput implements CanFrameListener {
-    private final static String TAG = "GridConnectInput";
-    private final static Logger logger = Logger.getLogger(TAG);
+    private final static Logger logger = Logger.getLogger(GridConnectOutput.class.getName());
 
     private BufferedOutputStream output;
     private final Runnable onError;

--- a/src/org/openlcb/cdi/cmd/RestoreConfig.java
+++ b/src/org/openlcb/cdi/cmd/RestoreConfig.java
@@ -1,25 +1,25 @@
 package org.openlcb.cdi.cmd;
 
-import org.openlcb.EventID;
-import org.openlcb.NodeID;
-import org.openlcb.Utilities;
-import org.openlcb.can.impl.OlcbConnection;
-import org.openlcb.cdi.impl.ConfigRepresentation;
-
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.Nonnull;
+import org.openlcb.EventID;
+import org.openlcb.NodeID;
+import org.openlcb.can.impl.OlcbConnection;
+import org.openlcb.cdi.impl.ConfigRepresentation;
 
 /**
  * Created by bracz on 4/9/16.
  */
 public class RestoreConfig {
 
+    private final static Logger logger = Logger.getLogger(RestoreConfig.class.getName());
+    
     public static interface ConfigCallback {
         void onConfigEntry(String key, String value);
         void onError(String error);
@@ -39,7 +39,7 @@ public class RestoreConfig {
                 if (line.charAt(0) == '#') continue;
                 int pos = line.indexOf('=');
                 if (pos < 0) {
-                    System.out.println("Failed to parse line: " + line);
+                    logger.log(Level.WARNING, "Failed to parse line: {0}", line);
                     continue;
                 }
                 String key = Util.unescapeString(line.substring(0, pos));

--- a/src/org/openlcb/cdi/cmd/Util.java
+++ b/src/org/openlcb/cdi/cmd/Util.java
@@ -1,16 +1,20 @@
 package org.openlcb.cdi.cmd;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.openlcb.NodeID;
 import org.openlcb.PropertyListenerSupport;
 import org.openlcb.can.impl.OlcbConnection;
-
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 
 /**
  * Created by bracz on 4/9/16.
  */
 public class Util {
+    
+    private final static Logger logger = Logger.getLogger(Util.class.getName());
+    
     static void waitForPropertyChange(PropertyListenerSupport tgt, final String propertyName) {
         final Object o = new Object();
         PropertyChangeListener l = new PropertyChangeListener() {
@@ -29,8 +33,7 @@ public class Util {
                 o.wait();
             }
         } catch (InterruptedException e) {
-            System.err.println("Interrupted while waiting for property notification " +
-                    propertyName + " on object of class " + tgt.getClass().getName());
+            logger.log(Level.SEVERE, "Interrupted while waiting for property notification {0} on object of class {1}", new Object[]{propertyName, tgt.getClass().getName()});
         }
         tgt.removePropertyChangeListener(l);
     }
@@ -60,24 +63,24 @@ public class Util {
                 .ConnectionListener() {
             @Override
             public void onConnect() {
-                System.out.println("Connected to " + host + ":" + port);
+                logger.log(Level.FINE, "Connected to {0}:{1}", new Object[]{host, port});
                 s.set(true);
             }
 
             @Override
             public void onDisconnect() {
-                System.out.println("Disconnected.");
+                logger.fine("Disconnected.");
                 s.set(false);
             }
 
             @Override
             public void onStatusChange(String status) {
-                System.out.println(status);
+                logger.fine(status);
             }
 
             @Override
             public void onConnectionPending() {
-                System.out.println("Connecting.");
+                logger.fine("Connecting.");
             }
         };
 

--- a/src/org/openlcb/cdi/impl/ConfigRepresentation.java
+++ b/src/org/openlcb/cdi/impl/ConfigRepresentation.java
@@ -1,5 +1,19 @@
 package org.openlcb.cdi.impl;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import org.openlcb.DefaultPropertyListenerSupport;
 import org.openlcb.EventID;
 import org.openlcb.NodeID;
@@ -11,22 +25,6 @@ import org.openlcb.cdi.jdom.JdomCdiReader;
 import org.openlcb.cdi.jdom.XmlHelper;
 import org.openlcb.cdi.swing.CdiPanel;
 import org.openlcb.implementations.MemoryConfigurationService;
-
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.io.Reader;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.logging.Logger;
-
-import javax.annotation.Nullable;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Maintains a parsed cache of the CDI config of a remote node. Responsible for fetching the CDI,
@@ -47,8 +45,7 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
     public static final String UPDATE_ENTRY_DATA = "UPDATE_ENTRY_DATA";
     // Fired on an CDI entry when the write method completes.
     public static final String UPDATE_WRITE_COMPLETE = "PENDING_WRITE_COMPLETE";
-    private static final String TAG = "ConfigRepresentation";
-    private static final Logger logger = Logger.getLogger(TAG);
+    private static final Logger logger = Logger.getLogger(ConfigRepresentation.class.getName());
     static final Charset UTF8 = Charset.forName("UTF8");
 
     private final OlcbInterface connection;
@@ -254,7 +251,7 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
             } else if (it instanceof CdiRep.StringRep) {
                 entry = new StringEntry(name, (CdiRep.StringRep) it, segment, origin);
             } else {
-                System.err.println("could not process CDI entry type of " + it);
+                logger.log(Level.SEVERE, "could not process CDI entry type of {0}", it);
             }
             if (entry != null) {
                 origin = entry.origin + entry.size;

--- a/src/org/openlcb/cdi/impl/DemoReadWriteAccess.java
+++ b/src/org/openlcb/cdi/impl/DemoReadWriteAccess.java
@@ -1,24 +1,30 @@
 package org.openlcb.cdi.impl;
 
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.openlcb.cdi.swing.CdiPanel;
 import org.openlcb.implementations.MemoryConfigurationService;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-
 /**
- * Helper vlass for various demo and test code to put in as a fake into the ConfigRepresentation constructor.
+ * Helper class for various demo and test code to put in as a fake into the ConfigRepresentation constructor.
  * Created by bracz on 11/20/16.
  */
 public class DemoReadWriteAccess extends CdiPanel.ReadWriteAccess {
+
+    private final static Logger logger = Logger.getLogger(DemoReadWriteAccess.class.getName());
+    
     @Override
     public void doWrite(long address, int space, byte[] data, MemoryConfigurationService.McsWriteHandler handler) {
-        System.out.println(data.length);
-        System.out.println("write " + address + " " + space + ": " + org.openlcb.Utilities.toHexDotsString(data));
+        logger.log(Level.INFO, "Wrote {0} bytes", data.length);
+        logger.log(Level.INFO, "write {0} {1}: {2}", new Object[]{address, space, org.openlcb.Utilities.toHexDotsString(data)});
     }
 
     @Override
@@ -28,7 +34,7 @@ public class DemoReadWriteAccess extends CdiPanel.ReadWriteAccess {
             resp[i] = (byte)i;
         }
         handler.handleReadData(null, space, address, resp);
-        System.out.println("read " + address + " " + space);
+        logger.log(Level.INFO, "read {0} {1}", new Object[]{address, space});
     }
 
     static public ConfigRepresentation demoRepFromSample(Element root) {
@@ -44,7 +50,7 @@ public class DemoReadWriteAccess extends CdiPanel.ReadWriteAccess {
             SAXBuilder builder = new SAXBuilder("org.apache.xerces.parsers.SAXParser", false);  // argument controls validation
             Document doc = builder.build(new BufferedInputStream(new FileInputStream(file)));
             root = doc.getRootElement();
-        } catch (Exception e) { System.out.println("While reading file: "+e);}
+        } catch (IOException | JDOMException e) { logger.log(Level.INFO, "While reading file: {0}", e);}
 
         return demoRepFromSample(root);
     }

--- a/src/org/openlcb/cdi/impl/MemorySpaceCache.java
+++ b/src/org/openlcb/cdi/impl/MemorySpaceCache.java
@@ -27,8 +27,7 @@ public class MemorySpaceCache {
     public static final String UPDATE_LOADING_COMPLETE = "UPDATE_LOADING_COMPLETE";
     // This event will be fired on the registered data listeners.
     public static final String UPDATE_DATA = "UPDATE_DATA";
-    private static final String TAG = "MemorySpaceCache";
-    private static final Logger logger = Logger.getLogger(TAG);
+    private static final Logger logger = Logger.getLogger(MemorySpaceCache.class.getName());
     private final int space;
     private final RangeCacheUtil ranges = new RangeCacheUtil();
     private final NavigableMap<Range, byte[]> dataCache = new TreeMap<>();

--- a/src/org/openlcb/cdi/jdom/CdiMemConfigReader.java
+++ b/src/org/openlcb/cdi/jdom/CdiMemConfigReader.java
@@ -2,16 +2,11 @@
 
 package org.openlcb.cdi.jdom;
 
-import javax.swing.*;
-import javax.swing.text.*;
-import java.beans.PropertyChangeListener;
+import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import org.openlcb.*;
-import org.openlcb.Utilities;
-import org.openlcb.implementations.*;
-
 import static java.util.logging.Logger.getLogger;
+import org.openlcb.*;
+import org.openlcb.implementations.*;
 
 /**
  * Provide a Reader to the OpenLCB CDI in a node.
@@ -23,7 +18,7 @@ import static java.util.logging.Logger.getLogger;
  * @version	$Revision$
  */
 public class CdiMemConfigReader  {
-    private final static Logger log = getLogger(CdiMemConfigReader.class.getName());
+    private final static Logger logger = getLogger(CdiMemConfigReader.class.getName());
 
     final static int LENGTH = 64;
 
@@ -66,7 +61,7 @@ public class CdiMemConfigReader  {
             new MemoryConfigurationService.McsReadHandler() {
                 @Override
                 public void handleFailure(int code) {
-                    log.warning("Error reading CDI: " + Integer.toHexString(code));
+                    logger.warning("Error reading CDI: " + Integer.toHexString(code));
                     done();
                     // TODO: 5/2/16 proxy error messages to the caller.
                     // don't do next request
@@ -97,8 +92,7 @@ public class CdiMemConfigReader  {
         // done, pass back a reader based on the current buffer contents
         if (retval != null) {
             retval.progressNotify(buf.length(), buf.length());
-            System.out.print("Retrieved XML: \n");
-            System.out.print(buf);
+            logger.log(Level.FINE, "Retrieved XML: \n{0}", buf);
             retval.provideReader(new java.io.StringReader(new String(buf)));
         }
     }

--- a/src/org/openlcb/cdi/jdom/JdomCdiReader.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiReader.java
@@ -1,18 +1,21 @@
 package org.openlcb.cdi.jdom;
 
-import org.openlcb.cdi.*;
-
 import java.io.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jdom2.*;
 import org.jdom2.input.SAXBuilder;
+import org.openlcb.cdi.*;
 
 /**
  * JDOM-based OpenLCB loader
  *
- * @author  Bob Jacobsen   Copyright 2011
+ * @author Bob Jacobsen Copyright 2011
  * @version $Revision: -1 $
  */
 public class JdomCdiReader {
+
+    private final static Logger logger = Logger.getLogger(JdomCdiReader.class.getName());
 
     public static Element getHeadFromReader(Reader rdr) throws Exception {
         String parserName = org.apache.xerces.parsers.SAXParser.class.getName();
@@ -20,7 +23,7 @@ public class JdomCdiReader {
 
         try {
             //"org.apache.xerces.parsers.SAXParser";
-            builder = new SAXBuilder(parserName,false);  // argument
+            builder = new SAXBuilder(parserName, false);  // argument
             // controls validation
         } catch (Exception e) {
             builder = new SAXBuilder(false);
@@ -31,7 +34,7 @@ public class JdomCdiReader {
             builder.setFeature("http://apache.org/xml/features/xinclude", true);
             builder.setFeature("http://apache.org/xml/features/xinclude/fixup-base-uris", false);
         } catch (Exception e) {
-            System.err.println("Could not set xinclude feature: "+e);
+            logger.log(Level.SEVERE, "Could not set xinclude feature: {0}", e);
         }
 
         // for schema validation. Not needed for DTDs, so continue if not found now
@@ -42,22 +45,22 @@ public class JdomCdiReader {
             builder.setFeature("http://apache.org/xml/features/validation/schema", false);
             builder.setFeature("http://apache.org/xml/features/validation/schema-full-checking", false);
         } catch (Exception e) {
-            System.err.println("Could not set schema validation feature: "+e);
+            logger.log(Level.SEVERE, "Could not set schema validation feature: {0}", e);
         }
-        
+
         Document doc;
         try {
             doc = builder.build(rdr);
             return doc.getRootElement();
         } catch (JDOMException e) {
-            System.err.println("Could not create Document: "+e);
+            logger.log(Level.SEVERE, "Could not create Document: {0}", e);
             throw e;
         } catch (IOException e) {
-            System.err.println("Could not create Document: "+e);
+            logger.log(Level.SEVERE, "Could not create Document: {0}", e);
             throw new Exception(e);
-        }        
+        }
     }
-    
+
     public CdiRep getRep(Element root) {
         return new JdomCdiRep(root);
     }

--- a/src/org/openlcb/cdi/jdom/XmlHelper.java
+++ b/src/org/openlcb/cdi/jdom/XmlHelper.java
@@ -1,17 +1,21 @@
 package org.openlcb.cdi.jdom;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 
-import java.io.IOException;
-import java.io.Reader;
-
 /**
  * Created by bracz on 3/31/16.
  */
 public class XmlHelper {
+
+    private final static Logger logger = Logger.getLogger(XmlHelper.class.getName());
+
     public static Element parseXmlFromReader(Reader r) throws Exception {
         SAXBuilder builder = new SAXBuilder(false);
 
@@ -23,7 +27,7 @@ public class XmlHelper {
             doc = builder.build(r);
             return doc.getRootElement();
         } catch (JDOMException | IOException e) {
-            System.err.println("Could not create Document: " + e);
+            logger.log(Level.SEVERE, "Could not create Document: {0}", e);
             throw e;
         }
     }

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -1,13 +1,5 @@
 package org.openlcb.cdi.swing;
 
-import org.openlcb.EventID;
-import org.openlcb.cdi.CdiRep;
-import org.openlcb.cdi.cmd.BackupConfig;
-import org.openlcb.cdi.cmd.RestoreConfig;
-import org.openlcb.cdi.impl.ConfigRepresentation;
-import org.openlcb.implementations.MemoryConfigurationService;
-import org.openlcb.swing.EventIdTextField;
-
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -27,8 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.annotation.Nonnull;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -50,11 +42,17 @@ import javax.swing.UIManager;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.JTextComponent;
-
+import org.openlcb.EventID;
+import org.openlcb.cdi.CdiRep;
+import org.openlcb.cdi.cmd.BackupConfig;
+import org.openlcb.cdi.cmd.RestoreConfig;
+import org.openlcb.cdi.impl.ConfigRepresentation;
 import static org.openlcb.cdi.impl.ConfigRepresentation.UPDATE_ENTRY_DATA;
 import static org.openlcb.cdi.impl.ConfigRepresentation.UPDATE_REP;
 import static org.openlcb.cdi.impl.ConfigRepresentation.UPDATE_STATE;
 import static org.openlcb.cdi.impl.ConfigRepresentation.UPDATE_WRITE_COMPLETE;
+import org.openlcb.implementations.MemoryConfigurationService;
+import org.openlcb.swing.EventIdTextField;
 
 /**
  * Simple example CDI display.
@@ -66,8 +64,7 @@ import static org.openlcb.cdi.impl.ConfigRepresentation.UPDATE_WRITE_COMPLETE;
  * @author  Balazs Racz Copyright 2016
  */
 public class CdiPanel extends JPanel {
-    private static final String TAG = "CdiPanel";
-    private static final Logger log = Logger.getLogger(TAG);
+    private static final Logger logger = Logger.getLogger(CdiPanel.class.getName());
 
     private static final Color COLOR_EDITED = new Color(0xffa500); // orange
     private static final Color COLOR_UNFILLED = new Color(0xffff00); // yellow
@@ -192,7 +189,7 @@ public class CdiPanel extends JPanel {
             BackupConfig.writeConfigToFile(fci.getSelectedFile().getPath(), rep);
         } catch (IOException e) {
             e.printStackTrace();
-            System.err.println("Failed to write variables to file " + fci.getSelectedFile().getPath() + ": " + e.toString());
+            logger.severe("Failed to write variables to file " + fci.getSelectedFile().getPath() + ": " + e.toString());
         }
     }
 
@@ -232,13 +229,13 @@ public class CdiPanel extends JPanel {
             @Override
             public void onError(String error) {
                 if (!hasError) {
-                    System.err.println("Error(s) encountered during loading configuration backup.");
+                    logger.severe("Error(s) encountered during loading configuration backup.");
                     hasError = true;
                 }
-                System.err.println(error);
+                logger.severe(error);
             }
         });
-        log.info("Config load done.");
+        logger.info("Config load done.");
     }
 
     GuiItemFactory factory;
@@ -979,11 +976,11 @@ public class CdiPanel extends JPanel {
     public static class ReadWriteAccess {
         public void doWrite(long address, int space, byte[] data, final
                             MemoryConfigurationService.McsWriteHandler handler) {
-            System.out.println("Write to "+address+" in space "+space);
+            logger.log(Level.FINE, "Write to {0} in space {1}", new Object[]{address, space});
         }
         public void doRead(long address, int space, int length, final MemoryConfigurationService
                 .McsReadHandler handler) {
-            System.out.println("Read from "+address+" in space "+space);
+            logger.log(Level.FINE, "Read from {0} in space {1}", new Object[]{address, space});
         }
     }
      

--- a/src/org/openlcb/hub/Hub.java
+++ b/src/org/openlcb/hub/Hub.java
@@ -4,6 +4,8 @@ import java.io.*;
 import java.net.*;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Simple multi-threaded OpenLCB hub implementation.
@@ -24,6 +26,7 @@ import java.util.concurrent.*;
  */
 
 public class Hub {
+    private final static Logger logger = Logger.getLogger(Hub.class.getName());
     public final static int DEFAULT_PORT = 12021;
     final static int CAPACITY = 20;  // not too long, to reduce delay
     
@@ -44,8 +47,8 @@ public class Hub {
                             e.forward(m);
                         }
                     } catch (InterruptedException e) {
-                        System.err.println("Hub: Interrupted in queue handling loop");
-                        System.err.println(e);
+                        logger.severe("Hub: Interrupted in queue handling loop");
+                        logger.log(Level.SEVERE, "", e);
                     }
                 }
             }
@@ -72,8 +75,8 @@ public class Hub {
                 notifyOwner("Connection started with "+getRemoteSocketAddress(clientSocket));
             }
         } catch (IOException e) {
-            System.err.println("Hub: Exception in main loop");
-            System.err.println(e);
+            logger.severe("Hub: Exception in main loop");
+            logger.log(Level.SEVERE, "", e);
         }
     }
     
@@ -83,7 +86,7 @@ public class Hub {
     }
     
     public void notifyOwner(String line) {
-        System.out.println(line);
+        logger.info(line);
     }
     
     // from jmri.util.SocketUtil
@@ -101,7 +104,7 @@ public class Hub {
         try {
             queue.put(new Memo(line, null));
         } catch (InterruptedException e) {
-            System.err.println(e);
+            logger.log(Level.SEVERE, "", e);
         }
     }
     
@@ -131,19 +134,19 @@ public class Hub {
                 }
      
             } catch (IOException e) {
-                System.err.println("Hub: Error while handling input from "+getRemoteSocketAddress(clientSocket));
-                System.err.println(e);
+                logger.log(Level.SEVERE, "Hub: Error while handling input from {0}", getRemoteSocketAddress(clientSocket));
+                logger.log(Level.SEVERE, "", e);
             } catch (InterruptedException e) {
-                System.err.println("Hub: Interrupted while handling input from "+getRemoteSocketAddress(clientSocket));
-                System.err.println(e);
+                logger.log(Level.SEVERE, "Hub: Interrupted while handling input from {0}", getRemoteSocketAddress(clientSocket));
+                logger.log(Level.SEVERE, "", e);
             }
             threads.remove(this);
             notifyOwner("Connection ended with "+getRemoteSocketAddress(clientSocket));
             try {
                 clientSocket.close();
             } catch (IOException e) {
-                System.err.println("Hub: Error while closing socket at end of connection");
-                System.err.println(e);
+                logger.severe("Hub: Error while closing socket at end of connection");
+                logger.log(Level.SEVERE, "", e);
             }
         }
         

--- a/src/org/openlcb/implementations/BlueGoldEngine.java
+++ b/src/org/openlcb/implementations/BlueGoldEngine.java
@@ -1,5 +1,7 @@
 package org.openlcb.implementations;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.openlcb.*;
 
 /**
@@ -27,6 +29,7 @@ import org.openlcb.*;
 public class BlueGoldEngine extends MessageDecoder implements Connection {
 
     int selectedPC = -1;
+    private final static Logger logger = Logger.getLogger(BlueGoldEngine.class.getName());
     
     public void goldClick() {
         if (selectedPC >= 0) {
@@ -35,7 +38,7 @@ public class BlueGoldEngine extends MessageDecoder implements Connection {
             setGoldLightOn(false);
             setBlueLightOn(false);
             selectedPC = -1;
-            System.out.println("send learn event");
+            logger.info("send learn event");
             return;
         }
     }
@@ -56,7 +59,7 @@ public class BlueGoldEngine extends MessageDecoder implements Connection {
             setBlueLightOn(true);
         }
         // and print for now (no GUI for this, add LEDs?)
-        System.out.println("incremented selectedPC to "+selectedPC);
+        logger.log(Level.INFO, "incremented selectedPC to {0}", selectedPC);
         return;
     }
     
@@ -66,7 +69,7 @@ public class BlueGoldEngine extends MessageDecoder implements Connection {
         // learn
         if (selectedPC >= 0) {
             EventID eid = msg.getEventID();
-            System.out.println("Set "+selectedPC+" to "+eid);
+            logger.log(Level.INFO, "Set {0} to {1}", new Object[]{selectedPC, eid});
             setEventID(selectedPC, eid);
         }
         // exit

--- a/src/org/openlcb/implementations/BlueGoldExtendedEngine.java
+++ b/src/org/openlcb/implementations/BlueGoldExtendedEngine.java
@@ -1,5 +1,7 @@
 package org.openlcb.implementations;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.openlcb.*;
 
 /**
@@ -29,6 +31,7 @@ import org.openlcb.*;
 public class BlueGoldExtendedEngine extends BlueGoldEngine {
 
     boolean[] isSelectedPC;
+    private final static Logger logger = Logger.getLogger(BlueGoldExtendedEngine.class.getName());
     
     public void goldClick() {
         if (getGoldLightOn() && getBlueLightOn()) {
@@ -89,7 +92,7 @@ public class BlueGoldExtendedEngine extends BlueGoldEngine {
         for (int i=0; i<isSelectedPC.length; i++) {
             if (isSelectedPC[i]) {
                 EventID eid = msg.getEventID();
-                System.out.println("Set "+i+" to "+eid);
+                logger.log(Level.INFO, "Set {0} to {1}", new Object[]{i, eid});
                 setEventID(i, eid);
             }
             isSelectedPC[i] = false;

--- a/src/org/openlcb/implementations/DatagramMeteringBuffer.java
+++ b/src/org/openlcb/implementations/DatagramMeteringBuffer.java
@@ -4,6 +4,8 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.openlcb.*;
 
 /**
@@ -28,6 +30,7 @@ public class DatagramMeteringBuffer extends MessageDecoder {
 
     //final static int TIMEOUT = 700;
     final static int TIMEOUT = 3000;
+    private final static Logger logger = Logger.getLogger(DatagramMeteringBuffer.class.getName());
     
     public DatagramMeteringBuffer(Connection toDownstream) {
         this.toDownstream = toDownstream;
@@ -134,13 +137,13 @@ public class DatagramMeteringBuffer extends MessageDecoder {
         }
         void endTimeout() {
             if (timer != null) timer.cancel();
-            else System.out.println("Found timer null for datagram "+(message != null ? message.toString() : " == null"));
+            else logger.log(Level.INFO, "Found timer null for datagram {0}", message != null ? message : " == null");
         }
         void timerExpired() {
             // should not happen, but if it does, 
             // fabricate a permanent error and forward up
             DatagramRejectedMessage msg = new DatagramRejectedMessage(message.getDestNodeID(), message.getSourceNodeID(), 0x0100);
-            System.out.println("Never received reply for datagram "+(message != null ? message.toString() : " == null"));
+            logger.log(Level.INFO, "Never received reply for datagram {0}", message != null ? message : " == null");
             handleDatagramRejected(msg, null);
             // Inject message to upstream listener
             toUpstream.put(msg, toUpstream);
@@ -158,8 +161,7 @@ public class DatagramMeteringBuffer extends MessageDecoder {
                 DatagramRejectedMessage rejectedMessage = new DatagramRejectedMessage(message
                         .getDestNodeID(), message.getSourceNodeID(),
                         DatagramRejectedMessage.DATAGRAM_REJECTED_DST_REBOOT);
-                System.out.println("Destination node has rebooted while waiting for datagram " +
-                        "reply "+ (message != null ? message.toString() : " == null"));
+                logger.log(Level.INFO, "Destination node has rebooted while waiting for datagram reply {0}", message != null ? message : " == null");
                 handleDatagramRejected(rejectedMessage, null);
                 // Inject message to upstream listener
                 toUpstream.put(rejectedMessage, toUpstream);

--- a/src/org/openlcb/implementations/DatagramService.java
+++ b/src/org/openlcb/implementations/DatagramService.java
@@ -1,5 +1,7 @@
 package org.openlcb.implementations;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
 import org.openlcb.*;
@@ -30,6 +32,8 @@ import org.openlcb.*;
  */
 public class DatagramService extends MessageDecoder {
 
+    private final static Logger logger = Logger.getLogger(DatagramService.class.getName());
+
     /**
      * @param here       our node ID
      * @param downstream Connection in the direction of the layout
@@ -51,7 +55,7 @@ public class DatagramService extends MessageDecoder {
      */
     public void sendData(DatagramServiceTransmitMemo memo){
         if (xmtMemo != null) {
-            System.err.println("Overriding datagram transmit memo. old " + xmtMemo.toString() + " new " + memo.toString()); //log
+            logger.log(Level.SEVERE, "Overriding datagram transmit memo. old {0} new {1}", new Object[]{xmtMemo, memo}); //log
         }
         xmtMemo = memo;
         Message m = new DatagramMessage(here, memo.dest, memo.data);
@@ -97,7 +101,7 @@ public class DatagramService extends MessageDecoder {
             rcvMemo.handleData(msg.getSourceNodeID(), msg.getData(), replyMemo);
             // check that client replied
             if (! replyMemo.hasReplied())
-                System.err.println("No internal reply received to datagram with contents "+Utilities.toHexDotsString(msg.getData())); //log
+                logger.log(Level.SEVERE, "No internal reply received to datagram with contents {0}", Utilities.toHexDotsString(msg.getData())); //log
         } else {
             // reject
             replyMemo.acceptData(retval);

--- a/src/org/openlcb/implementations/MemoryConfigurationService.java
+++ b/src/org/openlcb/implementations/MemoryConfigurationService.java
@@ -1,25 +1,18 @@
 package org.openlcb.implementations;
 
-import net.jcip.annotations.Immutable; 
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.logging.Logger;
+import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
-
 import org.openlcb.FailureCallback;
 import org.openlcb.NoReturnCallback;
 import org.openlcb.NodeID;
 import org.openlcb.Utilities;
-
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Stack;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.logging.Logger;
-
-import javax.xml.crypto.Data;
 
 /**
  * Service for reading and writing via the Memory Configuration protocol
@@ -34,7 +27,7 @@ import javax.xml.crypto.Data;
  * @version $Revision: -1 $
  */
 public class MemoryConfigurationService {
-    private static final Logger logger = Logger.getLogger("MemoryConfigurationService");
+    private static final Logger logger = Logger.getLogger(MemoryConfigurationService.class.getName());
     private static final int DATAGRAM_TYPE = 0x20;
 
     public static final int SPACE_CDI = 0xFF;

--- a/src/org/openlcb/implementations/throttle/FdiParser.java
+++ b/src/org/openlcb/implementations/throttle/FdiParser.java
@@ -1,13 +1,12 @@
 package org.openlcb.implementations.throttle;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
 import org.jdom2.Attribute;
 import org.jdom2.DataConversionException;
 import org.jdom2.Element;
 import org.openlcb.implementations.MemoryConfigurationService;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Logger;
 
 /**
  * Helper class to parse the FDI XML representation into a useful set of functions.
@@ -15,9 +14,7 @@ import java.util.logging.Logger;
  * Created by bracz on 1/17/16.
  */
 public class FdiParser {
-    private static Logger logger = Logger.getLogger(new Object() {
-    }.getClass().getSuperclass()
-            .getName());
+    private final static Logger logger = Logger.getLogger(FdiParser.class.getName());
     private ArrayList<FunctionInfo> allFunctions;
 
     public FdiParser(Element root) {

--- a/src/org/openlcb/implementations/throttle/Float16.java
+++ b/src/org/openlcb/implementations/throttle/Float16.java
@@ -1,8 +1,9 @@
 package org.openlcb.implementations.throttle;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
-import org.openlcb.*;
 
 /**
  * Represents a 16-bit IEEE float.
@@ -14,6 +15,8 @@ import org.openlcb.*;
 @Immutable
 @ThreadSafe
 public class Float16 {
+
+    private final static Logger logger = Logger.getLogger(Float16.class.getName());
 
     public Float16(float f) {
         this((double)f, (f>=0.0f));
@@ -54,7 +57,7 @@ public class Float16 {
         }
         
         int ch =  ((int)(d*1024.))&0x3FF;
-        if ((((int)(d*1024.))&0x400) != 0x400) System.out.println("normalization failed with d="+d+" exp="+exp);
+        if ((((int)(d*1024.))&0x400) != 0x400) logger.log(Level.WARNING, "normalization failed with d={0} exp={1}", new Object[]{d, exp});
         int bits = ch | (exp<<10);
         if (!positive) bits = bits | 0x8000;
         

--- a/src/org/openlcb/implementations/throttle/RemoteTrainNode.java
+++ b/src/org/openlcb/implementations/throttle/RemoteTrainNode.java
@@ -1,17 +1,15 @@
 package org.openlcb.implementations.throttle;
 
+import java.io.Reader;
+import java.util.logging.Logger;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
-
 import org.jdom2.Element;
 import org.openlcb.NodeID;
 import org.openlcb.OlcbInterface;
 import org.openlcb.cdi.jdom.CdiMemConfigReader;
 import org.openlcb.cdi.jdom.XmlHelper;
 import org.openlcb.implementations.MemoryConfigurationService;
-
-import java.io.Reader;
-import java.util.logging.Logger;
 
 /**
  * Represents local view about a remote Train Node, a node that implements the Traction protocol.
@@ -24,9 +22,7 @@ import java.util.logging.Logger;
 public class RemoteTrainNode {
 
     public static final String UPDATE_PROP_FDI = "fdi";
-    private static Logger logger = Logger.getLogger(new Object() {
-    }.getClass().getSuperclass()
-            .getName());
+    private final static Logger logger = Logger.getLogger(RemoteTrainNode.class.getName());
     private final OlcbInterface iface;
     java.beans.PropertyChangeSupport pcs = new java.beans.PropertyChangeSupport(this);
     private Element fdiRoot;

--- a/src/org/openlcb/implementations/throttle/TractionThrottle.java
+++ b/src/org/openlcb/implementations/throttle/TractionThrottle.java
@@ -36,7 +36,7 @@ public class TractionThrottle extends MessageDecoder {
     public static final String UPDATE_PROP_ENABLED = "updateEnabled";
     public static final String UPDATE_PROP_STATUS = "updateStatus";
     public static final String UPDATE_PROP_CONSISTLIST = "updateConsistList";
-    private static Logger logger = Logger.getLogger("TractionThrottle");
+    private final static Logger logger = Logger.getLogger(TractionThrottle.class.getName());
     private final OlcbInterface iface;
     RemoteTrainNode trainNode;
     boolean assigned = false;

--- a/src/org/openlcb/messages/TractionControlReplyMessage.java
+++ b/src/org/openlcb/messages/TractionControlReplyMessage.java
@@ -1,19 +1,15 @@
 package org.openlcb.messages;
 
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
-
-import org.openlcb.AddressedMessage;
 import org.openlcb.AddressedPayloadMessage;
 import org.openlcb.Connection;
 import org.openlcb.MessageDecoder;
 import org.openlcb.MessageTypeIdentifier;
 import org.openlcb.NodeID;
 import org.openlcb.implementations.throttle.Float16;
-
-import java.util.logging.Logger;
-
-import javax.annotation.Nullable;
 
 /**
  * Traction Control Reply message implementation.
@@ -23,9 +19,7 @@ import javax.annotation.Nullable;
 @Immutable
 @ThreadSafe
 public class TractionControlReplyMessage extends AddressedPayloadMessage {
-    private static Logger logger = Logger.getLogger(new Object() {
-    }.getClass().getSuperclass()
-            .getName());
+    private final static Logger logger = Logger.getLogger(TractionControlReplyMessage.class.getName());
     public final static byte CMD_GET_SPEED = TractionControlRequestMessage.CMD_GET_SPEED;
     public final static byte CMD_GET_FN = TractionControlRequestMessage.CMD_GET_FN;
 

--- a/src/org/openlcb/messages/TractionControlRequestMessage.java
+++ b/src/org/openlcb/messages/TractionControlRequestMessage.java
@@ -1,16 +1,14 @@
 package org.openlcb.messages;
 
+import java.util.logging.Logger;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
-
 import org.openlcb.AddressedPayloadMessage;
 import org.openlcb.Connection;
 import org.openlcb.MessageDecoder;
 import org.openlcb.MessageTypeIdentifier;
 import org.openlcb.NodeID;
 import org.openlcb.implementations.throttle.Float16;
-
-import java.util.logging.Logger;
 
 /**
  * Traction Control Request message implementation.
@@ -20,9 +18,7 @@ import java.util.logging.Logger;
 @Immutable
 @ThreadSafe
 public class TractionControlRequestMessage extends AddressedPayloadMessage {
-    private static Logger logger = Logger.getLogger(new Object() {
-    }.getClass().getSuperclass()
-            .getName());
+    private final static Logger logger = Logger.getLogger(TractionControlRequestMessage.class.getName());
 
     public final static byte CMD_SET_SPEED = 0x00;
     public final static byte CMD_SET_FN = 0x01;

--- a/src/org/openlcb/swing/ConsumerPane.java
+++ b/src/org/openlcb/swing/ConsumerPane.java
@@ -2,10 +2,9 @@
 
 package org.openlcb.swing;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.*;
-import javax.swing.text.*;
-
-import org.openlcb.*;
 import org.openlcb.implementations.*;
 
 /**
@@ -19,6 +18,7 @@ import org.openlcb.implementations.*;
 public class ConsumerPane extends JPanel  {
 
     final static int DELAY = 2000;
+    private final static Logger logger = Logger.getLogger(ConsumerPane.class.getName());
     
     public ConsumerPane(String name, SingleConsumerNode node) {
         this.name = name;
@@ -44,7 +44,7 @@ public class ConsumerPane extends JPanel  {
                     timer.start();
                 } else if (e.getPropertyName().equals("EventID")) {
                     if (ConsumerPane.this.name == null) sendLabel.setText(e.getNewValue().toString());
-                    System.out.println("new "+e.getNewValue().toString());
+                    logger.log(Level.FINE, "new {0}", e.getNewValue());
                 }
             }
         });

--- a/src/org/openlcb/swing/EventIdTextField.java
+++ b/src/org/openlcb/swing/EventIdTextField.java
@@ -3,12 +3,12 @@
 package org.openlcb.swing;
 
 import java.io.*;
-import java.awt.*;
 import java.awt.datatransfer.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.*;
 import javax.swing.text.*;
 
-import org.openlcb.*;
 
 /**
  * Text field for entry of forced-valid EventID string.
@@ -20,6 +20,8 @@ import org.openlcb.*;
  * @version	$Revision$
  */
 public class EventIdTextField extends JFormattedTextField  {
+
+    private final static Logger logger = Logger.getLogger(EventIdTextField.class.getName());
 
     static public JFormattedTextField getEventIdTextField() {
         JFormattedTextField retval = new JFormattedTextField(createFormatter("HH.HH.HH.HH.HH.HH.HH.HH"));
@@ -37,7 +39,7 @@ public class EventIdTextField extends JFormattedTextField  {
         try {
             formatter = new MaskFormatter(s);
         } catch (java.text.ParseException exc) {
-            System.err.println("formatter is bad: " + exc.getMessage());
+            logger.log(Level.SEVERE, "formatter is bad: {0}", exc.getMessage());
         }
         return formatter;
     }

--- a/src/org/openlcb/swing/MonPane.java
+++ b/src/org/openlcb/swing/MonPane.java
@@ -9,7 +9,7 @@ import java.io.PrintStream;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-
+import java.util.logging.Logger;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -20,11 +20,10 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.JToggleButton;
 import javax.swing.text.*;
-
 import org.openlcb.*;
 
 /**
- * Pane for monitoring commmunications.
+ * Pane for monitoring communications.
  *<p>
  * Made in large part from jmri.jmrix.AbstractMonFrame
  *
@@ -48,9 +47,11 @@ public class MonPane extends JPanel  {
 
     javax.swing.JFileChooser logFileChooser;
 
-	// for locking
-	MonPane self;
-	
+    // for locking
+    MonPane self;
+
+    private final static Logger logger = Logger.getLogger(MonPane.class.getName());
+    
     public MonPane() {
 	    super();
     	self = this;
@@ -265,7 +266,7 @@ public class MonPane extends JPanel  {
                 if  (logFileChooser != null)
                     logStream = new PrintStream (new FileOutputStream(logFileChooser.getSelectedFile()));
             } catch (Exception ex) {
-                System.err.println("exception "+ex);
+                logger.severe("exception "+ex);
             }
         }
     }

--- a/src/org/openlcb/swing/NodeIdTextField.java
+++ b/src/org/openlcb/swing/NodeIdTextField.java
@@ -2,10 +2,11 @@
 
 package org.openlcb.swing;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.*;
 import javax.swing.text.*;
 
-import org.openlcb.*;
 
 /**
  * Text field for entry of forced-valid NodeID string.
@@ -17,6 +18,8 @@ import org.openlcb.*;
  * @version	$Revision$
  */
 public class NodeIdTextField extends JFormattedTextField  {
+
+    private final static Logger logger = Logger.getLogger(NodeIdTextField.class.getName());
 
     static public JFormattedTextField getNodeIdTextField() {
         JFormattedTextField retval = new JFormattedTextField(createFormatter("HH.HH.HH.HH.HH.HH"));
@@ -34,7 +37,7 @@ public class NodeIdTextField extends JFormattedTextField  {
         try {
             formatter = new MaskFormatter(s);
         } catch (java.text.ParseException exc) {
-            System.err.println("formatter is bad: " + exc.getMessage());
+            logger.log(Level.SEVERE, "formatter is bad: {0}", exc.getMessage());
         }
         return formatter;
     }

--- a/src/org/openlcb/swing/ProducerPane.java
+++ b/src/org/openlcb/swing/ProducerPane.java
@@ -2,8 +2,9 @@
 
 package org.openlcb.swing;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.*;
-import javax.swing.text.*;
 
 import org.openlcb.*;
 import org.openlcb.implementations.*;
@@ -15,6 +16,8 @@ import org.openlcb.implementations.*;
  * @version	$Revision$
  */
 public class ProducerPane extends JPanel  {
+
+    private final static Logger logger = Logger.getLogger(ProducerPane.class.getName());
 
     public ProducerPane(String name, SingleProducerNode node) {
         this.node = node;
@@ -43,7 +46,7 @@ public class ProducerPane extends JPanel  {
             public void propertyChange(java.beans.PropertyChangeEvent e) {
                 if (e.getPropertyName().equals("EventID")) {
                     if (ProducerPane.this.name == null) sendButton.setText(e.getNewValue().toString());
-                    System.out.println("new "+e.getNewValue().toString());
+                    logger.log(Level.FINE, "new {0}", e.getNewValue());
                 }
             }
         });

--- a/src/org/openlcb/swing/memconfig/MemConfigDescriptionPane.java
+++ b/src/org/openlcb/swing/memconfig/MemConfigDescriptionPane.java
@@ -2,12 +2,10 @@
 
 package org.openlcb.swing.memconfig;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.*;
-import javax.swing.text.*;
-import java.beans.PropertyChangeListener;
-
 import org.openlcb.*;
-import org.openlcb.Utilities;
 import org.openlcb.implementations.*;
 
 /**
@@ -18,6 +16,7 @@ import org.openlcb.implementations.*;
  */
 public class MemConfigDescriptionPane extends JPanel  {
     
+    private final static Logger logger = Logger.getLogger(MemConfigDescriptionPane.class.getName());
     NodeID node;
     MimicNodeStore store;
     MemoryConfigurationService service;
@@ -57,8 +56,7 @@ public class MemConfigDescriptionPane extends JPanel  {
             new MemoryConfigurationService.McsConfigMemo(node) {
                 @Override
                 public void handleFailure(int code) {
-                    System.err.println("Failed to fetch MCS config information from node " + node
-                            + " error 0x" + Integer.toHexString(code));
+                    logger.log(Level.SEVERE, "Failed to fetch MCS config information from node {0} error 0x{1}", new Object[]{node, Integer.toHexString(code)});
                     commandLabel.setText("Failed: 0x" + Integer.toHexString(code));
                 }
 


### PR DESCRIPTION
Use a java.util.logging.Logger in place of most uses of ``System.(err|out).println``` in the sources (but not in the tests) so that consuming applications (mostly JMRI) can manage logging. See JMRI/JMRI#3063