### PR TITLE
VersionedValue force update

### DIFF
--- a/src/org/openlcb/implementations/VersionedValue.java
+++ b/src/org/openlcb/implementations/VersionedValue.java
@@ -31,7 +31,15 @@ public class VersionedValue<T> {
         }
     }
 
+    public boolean setWithForceNotify(int atVersion, T t) {
+        return setInternal(atVersion, t, true);
+    }
+
     public boolean set(int atVersion, T t) {
+        return setInternal(atVersion, t, false);
+    }
+
+    private boolean setInternal(int atVersion, T t, boolean forceNotify) {
         T old;
         boolean updated = false;
         synchronized (this) {
@@ -41,11 +49,11 @@ public class VersionedValue<T> {
             if (nextVersion <= atVersion) {
                 nextVersion = atVersion + 1;
             }
-            if (data.equals(t) && oldVersion != DEFAULT_VERSION) {
+            if (data.equals(t) && oldVersion != DEFAULT_VERSION && !forceNotify) {
                 return true;
             }
             old = data;
-            if (oldVersion == DEFAULT_VERSION) {
+            if (oldVersion == DEFAULT_VERSION || forceNotify) {
                 old = null;
             }
             data = t;

--- a/src/org/openlcb/implementations/VersionedValueListener.java
+++ b/src/org/openlcb/implementations/VersionedValueListener.java
@@ -38,6 +38,11 @@ public abstract class VersionedValueListener<T> implements PropertyChangeListene
         }
     }
 
+    /**
+     * Sets the value of the shared state as seen from this listener. Will skip callback to this
+     * listener.
+     * @param t new value
+     */
     public void setFromOwner(T t) {
         int newVersion;
         synchronized (this) {
@@ -45,6 +50,20 @@ public abstract class VersionedValueListener<T> implements PropertyChangeListene
             ownerVersion = newVersion;
         }
         parent.set(newVersion, t);
+    }
+
+    /**
+     * Sets the value of the shared state as seen from this listener. Will skip callback to this
+     * listener. Will force callbacks to all other listeners, even if the state has not changed.
+     * @param t new value
+     */
+    public void setFromOwnerWithForceNotify(T t) {
+        int newVersion;
+        synchronized (this) {
+            newVersion = parent.getNewVersion();
+            ownerVersion = newVersion;
+        }
+        parent.setWithForceNotify(newVersion, t);
     }
 
     /** Calls the updater with the latest data. */

--- a/test/org/openlcb/implementations/PackageTest.java
+++ b/test/org/openlcb/implementations/PackageTest.java
@@ -51,6 +51,7 @@ public class PackageTest extends TestCase {
 
         suite.addTest(org.openlcb.implementations.throttle.PackageTest.suite());
         suite.addTest(new TestSuite(BitProducerConsumerTest.class));
+        suite.addTest(new TestSuite(VersionedValueTest.class));
 
         return suite;
     }

--- a/test/org/openlcb/implementations/VersionedValueTest.java
+++ b/test/org/openlcb/implementations/VersionedValueTest.java
@@ -1,0 +1,108 @@
+package org.openlcb.implementations;
+
+import junit.framework.TestCase;
+
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * Created by bracz on 4/3/17.
+ */
+public class VersionedValueTest extends TestCase {
+    VersionedValue<Integer> v = new VersionedValue<>(42);
+
+    public void testDefaultAndSet() throws Exception {
+        assertEquals("default value", Integer.valueOf(42), v.getLatestData());
+        assertEquals(v.DEFAULT_VERSION, v.getVersion());
+
+        v.set(13);
+        assertEquals("set value", Integer.valueOf(13), v.getLatestData());
+        assert(v.DEFAULT_VERSION < v.getVersion());
+    }
+
+
+    public void testSetWithForceNotify() throws Exception {
+        v.set(33); // gets rid of the default value condition
+
+        MockVersionedValueListener<Integer> l1 = new MockVersionedValueListener<>(v);
+        MockVersionedValueListener<Integer> l2 = new MockVersionedValueListener<>(v);
+
+        l1.setFromOwnerWithForceNotify(33);
+        verify(l2.stub).update(33);
+        verifyNoMoreInteractions(l2.stub);
+        verifyNoMoreInteractions(l1.stub);
+        reset(l1.stub, l2.stub);
+
+        l2.setFromOwnerWithForceNotify(33);
+        verify(l1.stub).update(33);
+        verifyNoMoreInteractions(l2.stub);
+        verifyNoMoreInteractions(l1.stub);
+        reset(l1.stub, l2.stub);
+
+        v.setWithForceNotify(v.getNewVersion(), 33);
+        verify(l1.stub).update(33);
+        verify(l2.stub).update(33);
+        verifyNoMoreInteractions(l2.stub);
+        verifyNoMoreInteractions(l1.stub);
+        reset(l1.stub, l2.stub);
+    }
+
+    public void testSet() throws Exception {
+        MockVersionedValueListener<Integer> l1 = new MockVersionedValueListener<>(v);
+        MockVersionedValueListener<Integer> l2 = new MockVersionedValueListener<>(v);
+
+        l1.setFromOwner(42);
+        verify(l2.stub).update(42);
+        verifyNoMoreInteractions(l2.stub);
+        // no callback to the owner
+        verifyNoMoreInteractions(l1.stub);
+        reset(l1.stub, l2.stub);
+
+        // skips duplicate notification
+        l1.setFromOwner(42);
+        verifyNoMoreInteractions(l2.stub);
+        verifyNoMoreInteractions(l1.stub);
+        reset(l1.stub, l2.stub);
+
+        l1.setFromOwner(13);
+        verify(l2.stub).update(13);
+        verifyNoMoreInteractions(l2.stub);
+        verifyNoMoreInteractions(l1.stub);
+        reset(l1.stub, l2.stub);
+
+        l2.setFromOwner(81);
+        verify(l1.stub).update(81);
+        verifyNoMoreInteractions(l2.stub);
+        verifyNoMoreInteractions(l1.stub);
+        reset(l1.stub, l2.stub);
+
+        // Unowned set will trigger callbacks both ways.
+        v.set(33);
+        verify(l1.stub).update(33);
+        verify(l2.stub).update(33);
+        verifyNoMoreInteractions(l2.stub);
+        verifyNoMoreInteractions(l1.stub);
+        reset(l1.stub, l2.stub);
+    }
+
+    public void testOutOfOrder() throws Exception {
+        v.set(33);
+
+        MockVersionedValueListener<Integer> l1 = new MockVersionedValueListener<>(v);
+
+        int ver1 = v.getNewVersion();
+        int ver2 = v.getNewVersion();
+        v.set(ver2, 21);
+
+        verify(l1.stub).update(21);
+        verifyNoMoreInteractions(l1.stub);
+        reset(l1.stub);
+
+        v.set(ver1, 13);
+        // out of order update will be swallowed.
+        verifyNoMoreInteractions(l1.stub);
+        reset(l1.stub);
+    }
+
+}


### PR DESCRIPTION
Adds force update feature to versioned value class and writes a test  for all the functionality.

Fixes the OpenLCB part of https://github.com/openlcb/OpenLCB_Java/issues/80