### PR TITLE
Fix identify global messages

### DIFF
--- a/src/org/openlcb/can/MessageBuilder.java
+++ b/src/org/openlcb/can/MessageBuilder.java
@@ -555,8 +555,12 @@ public class MessageBuilder {
         @Override
         public void handleIdentifyEvents(IdentifyEventsMessage msg, Connection sender){
             OpenLcbCanFrame f = new OpenLcbCanFrame(0x00);
-            f.setOpenLcbMTI(MessageTypeIdentifier.IdentifyEventsGlobal.mti());
-            f.setDestAlias(map.getAlias(msg.getDestNodeID()));
+            if (msg.getDestNodeID() != null) {
+                f.setOpenLcbMTI(MessageTypeIdentifier.IdentifyEventsAddressed.mti());
+                f.setDestAlias(map.getAlias(msg.getDestNodeID()));
+            } else {
+                f.setOpenLcbMTI(MessageTypeIdentifier.IdentifyEventsGlobal.mti());
+            }
             f.setSourceAlias(map.getAlias(msg.getSourceNodeID()));
             retlist.add(f);
         }

--- a/test/org/openlcb/can/MessageBuilderTest.java
+++ b/test/org/openlcb/can/MessageBuilderTest.java
@@ -70,6 +70,37 @@ public class MessageBuilderTest extends TestCase {
         compareContent(source.getContents(), f0);
     }
 
+    public void testIdentifyEventsGlobal() {
+
+        Message m = new IdentifyEventsMessage(source, null);
+        MessageBuilder b = new MessageBuilder(map);
+
+        List<OpenLcbCanFrame> list = b.processMessage(m);
+
+        // looking for [19970123]
+
+        Assert.assertEquals("count", 1, list.size());
+        CanFrame f0 = list.get(0);
+        Assert.assertEquals("header", toHexString(0x19970123), toHexString(f0.getHeader()));
+        Assert.assertEquals("payload", 0, f0.getNumDataElements());
+        compareContent(new byte[]{}, f0);
+    }
+
+    public void testIdentifyEventsAddressed() {
+        Message m = new IdentifyEventsMessage(source, destination);
+        MessageBuilder b = new MessageBuilder(map);
+
+        List<OpenLcbCanFrame> list = b.processMessage(m);
+
+        // looking for [19970123]
+
+        Assert.assertEquals("count", 1, list.size());
+        CanFrame f0 = list.get(0);
+        Assert.assertEquals("header", toHexString(0x19968123), toHexString(f0.getHeader()));
+        Assert.assertEquals("payload", 2, f0.getNumDataElements());
+        compareContent(Utilities.bytesFromHexString("03 21"), f0);
+    }
+
     public void testVerifiedNodeIDNumberMessage() {
         
         Message m = new VerifiedNodeIDNumberMessage(source);


### PR DESCRIPTION
Previously the global (unaddressed) form was used even if there was a destination, and the addressed message was never generated correctly.