### PR TITLE
CDI panel fixes and improvements

### DIFF
--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -6,7 +6,12 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.FlowLayout;
+import java.awt.Toolkit;
 import java.awt.Window;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
@@ -721,6 +726,8 @@ public class CdiPanel extends JPanel {
             add(p3);
         }
 
+        protected void additionalButtons() {}
+
         protected void init() {
             p3.add(textComponent);
             textComponent.setMaximumSize(textComponent.getPreferredSize());
@@ -790,7 +797,9 @@ public class CdiPanel extends JPanel {
                 }
             });
             p3.add(b);
-            // TODO: is this needed?
+
+            additionalButtons();
+
             p3.add(Box.createHorizontalGlue());
         }
 
@@ -843,6 +852,47 @@ public class CdiPanel extends JPanel {
             init();
         }
 
+        @Override
+        protected void additionalButtons() {
+            JButton b = new JButton("Copy");
+            b.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent actionEvent) {
+                    String s = getDisplayText();
+                    SwingUtilities.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            textField.selectAll();
+                        }
+                    });
+                    StringSelection eventToCopy = new StringSelection(s);
+                    Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                    clipboard.setContents(eventToCopy, null);
+                }
+            });
+            p3.add(b);
+
+            b = new JButton("Paste");
+            b.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent actionEvent) {
+                    Clipboard systemClipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                    DataFlavor dataFlavor = DataFlavor.stringFlavor;
+
+                    Object text = null;
+                    try {
+                        text = systemClipboard.getData(dataFlavor);
+                    } catch (UnsupportedFlavorException | IOException e1) {
+                        return;
+                    }
+                    String pasteValue = (String) text;
+                    if (pasteValue != null) {
+                        textField.setText(pasteValue);
+                    }
+                }
+            });
+            p3.add(b);
+        }
 
         @Override
         protected void writeDisplayTextToNode() {

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -100,17 +100,16 @@ public class CdiPanel extends JPanel {
         contentPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
 
-        scrollPane = new JScrollPane(contentPanel, JScrollPane.VERTICAL_SCROLLBAR_NEVER,
-                JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        scrollPane = new JScrollPane(contentPanel);
         Dimension minScrollerDim = new Dimension(800, 12);
         scrollPane.setMinimumSize(minScrollerDim);
         scrollPane.getVerticalScrollBar().setUnitIncrement(30);
 
-        //add(scrollPane);
-        add(contentPanel);
+        add(scrollPane);
+        //add(contentPanel);
 
         buttonBar = new JPanel();
-        buttonBar.setAlignmentX(Component.LEFT_ALIGNMENT);
+        //buttonBar.setAlignmentX(Component.LEFT_ALIGNMENT);
         buttonBar.setLayout(new FlowLayout());
         JButton bb = new JButton("Refresh All");
         bb.setToolTipText("Discards all changes and loads the freshest value from the hardware for all entries.");

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -110,8 +110,6 @@ public class CdiPanel extends JPanel {
         add(scrollPane);
         //add(contentPanel);
 
-        createSensorCreateHelper();
-
         buttonBar = new JPanel();
         //buttonBar.setAlignmentX(Component.LEFT_ALIGNMENT);
         buttonBar.setLayout(new FlowLayout());
@@ -134,6 +132,8 @@ public class CdiPanel extends JPanel {
         bb.setToolTipText("Loads a file with backed-up settings. Does not change the hardware settings, so use \"Save changed\" afterwards.");
         bb.addActionListener(actionEvent -> runRestore());
         buttonBar.add(bb);
+
+        createSensorCreateHelper();
 
         add(buttonBar);
 

--- a/src/org/openlcb/swing/EventIdTextField.java
+++ b/src/org/openlcb/swing/EventIdTextField.java
@@ -25,7 +25,10 @@ public class EventIdTextField extends JFormattedTextField  {
 
     static public JFormattedTextField getEventIdTextField() {
         JFormattedTextField retval = new JFormattedTextField(createFormatter("HH.HH.HH.HH.HH.HH.HH.HH"));
-        
+
+        // Let's size the event ID fields for the longest event ID in pixels.
+        retval.setValue("DD.DD.DD.DD.DD.DD.DD.DD");
+        retval.setPreferredSize(retval.getPreferredSize());
         retval.setValue("00.00.00.00.00.00.00.00");
         retval.setToolTipText("EventID as eight-byte dotted-hex string, e.g. 01.02.0A.AB.34.56.78.00");
         retval.setDragEnabled(true);

--- a/src/util/CollapsiblePanel.java
+++ b/src/util/CollapsiblePanel.java
@@ -100,16 +100,18 @@ public class CollapsiblePanel extends JPanel {
 
 	public void toggleSelection() {
 		selected = !selected;
-
-		if (contentPanel_.isShowing())
-			contentPanel_.setVisible(false);
-		else
-			contentPanel_.setVisible(true);
+		contentPanel_.setVisible(selected);
 
 		validate();
 
 		headerPanel_.repaint();
 	}
+
+	public void setExpanded(boolean isExpanded) {
+        if (selected != isExpanded) {
+            toggleSelection();
+        }
+    }
 
 	@Override
 	public Dimension getMaximumSize() {

--- a/test/org/openlcb/cdi/swing/CdiPanelDemo.java
+++ b/test/org/openlcb/cdi/swing/CdiPanelDemo.java
@@ -24,25 +24,29 @@ public class CdiPanelDemo {
     public CdiPanelDemo() {
     }
 
-    public void displayFile() {
+    public void displayFile(String fileName) {
         JFrame f = new JFrame();
         CdiPanel m = new CdiPanel();
 
-        // find file & load file
-        fci.setDialogTitle("Find desired script file");
-        fci.rescanCurrentDirectory();
+        File file;
+        if (fileName == null) {
+            // find file & load file
+            fci.setDialogTitle("Find desired script file");
+            fci.rescanCurrentDirectory();
 
-        int retVal = fci.showOpenDialog(null);
-        // handle selection or cancel
-        if (retVal != JFileChooser.APPROVE_OPTION) {
-            File file = fci.getSelectedFile();
-            // Run the script from it's filename
-            System.out.println("No file selected");
+            int retVal = fci.showOpenDialog(null);
+            // handle selection or cancel
+            if (retVal != JFileChooser.APPROVE_OPTION) {
+                // Run the script from it's filename
+                System.out.println("No file selected");
+            }
+            file = fci.getSelectedFile();
+        } else {
+            file = new File(fileName);
         }
+        f.setTitle(file.getName());
 
-        f.setTitle(fci.getSelectedFile().getName());
-
-        ConfigRepresentation configRep = demoRepFromFile(fci.getSelectedFile());
+        ConfigRepresentation configRep = demoRepFromFile(file);
 
         m.initComponents(configRep,
                 new CdiPanel.GuiItemFactory() {
@@ -72,6 +76,6 @@ public class CdiPanelDemo {
     // Main entry point
     static public void main(String[] args) {
         CdiPanelDemo d = new CdiPanelDemo();
-        d.displayFile();
+        d.displayFile(null);
     }
 }


### PR DESCRIPTION
- adds the scroll pane internally in CdiPanel (first step to remove the ReadAll bottom panel in JMRI)
- adds copy and paste buttons to event ID lines to allow easy mating
- adds an extra (by default collapsed) panel to the bottom, not scrolling, in order to create JMRI turnouts and sensors in the case when the heuristic does not kick in.