### PR TITLE
Event table

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -345,6 +345,19 @@
              compress="true" />   <!-- compress="true" is default -->
     </target>
 
+    <target name="testrejar" description="re-create working test jar files without clean">
+        <antcall target="compile" />
+        <jar jarfile="${jartarget}/openlcb.jar" 
+             basedir="${target}"
+             manifest="manifest" 
+             compress="true" />   <!-- compress="true" is default -->
+        <antcall target="tests" />
+        <jar jarfile="${jartarget}/openlcb-demo.jar" 
+             basedir="${target}"
+             manifest="manifest" 
+             compress="true" />   <!-- compress="true" is default -->
+    </target>
+    
     <target name="travis-ci-tests" > <!-- tests used on travis CI -->
         <antcall target="compile" />
         <antcall target="run-travis" />

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.openlcb</groupId>
     <artifactId>openlcb</artifactId>
     <packaging>jar</packaging>
-    <version>0.7.11</version>
+    <version>0.7.12</version>
     <name>OpenLCB</name>
     <description>OpenLCB Java Reference Implementation.</description>
     <url>http://openlcb.github.com/OpenLCB_Java</url>

--- a/src/org/openlcb/EventID.java
+++ b/src/org/openlcb/EventID.java
@@ -100,4 +100,14 @@ public class EventID {
                 +Utilities.toHexPair(contents[6])+"."
                 +Utilities.toHexPair(contents[7]);
     }
+
+    public long toLong() {
+        long ret = 0;
+        for (int i = 0; i < 8; ++i) {
+            ret <<= 8;
+            int e = contents[i];
+            ret |= (e & 0xff);
+        }
+        return ret;
+    }
 }

--- a/src/org/openlcb/OlcbInterface.java
+++ b/src/org/openlcb/OlcbInterface.java
@@ -3,6 +3,7 @@ package org.openlcb;
 import org.openlcb.cdi.impl.ConfigRepresentation;
 import org.openlcb.implementations.DatagramMeteringBuffer;
 import org.openlcb.implementations.DatagramService;
+import org.openlcb.implementations.EventTable;
 import org.openlcb.implementations.MemoryConfigurationService;
 import org.openlcb.protocols.VerifyNodeIdHandler;
 
@@ -45,7 +46,9 @@ public class OlcbInterface {
     private MemoryConfigurationService mcs;
     // CDIs for the nodes
     private final Map<NodeID, ConfigRepresentation> nodeConfigs = new HashMap<>();
-
+    // Event Table is a helper for user interfaces to register and retrieve user names for
+    // events. By default this is null, initialized lazily when needed only.
+    private EventTable eventTable = null;
     /**
      * Creates the message-level interface.
      *
@@ -131,6 +134,12 @@ public class OlcbInterface {
         mcs = s;
     }
 
+    public synchronized EventTable getEventTable() {
+        if (eventTable == null) {
+            eventTable = new EventTable();
+        }
+        return eventTable;
+    }
     /**
      * Creates a new or returns a cached CDI representation for the given node.
      * @param remoteNode    target node (on the network)

--- a/src/org/openlcb/cdi/impl/DemoReadWriteAccess.java
+++ b/src/org/openlcb/cdi/impl/DemoReadWriteAccess.java
@@ -31,7 +31,7 @@ public class DemoReadWriteAccess extends CdiPanel.ReadWriteAccess {
     public void doRead(long address, int space, int length, MemoryConfigurationService.McsReadHandler handler) {
         byte[] resp = new byte[length];
         for (int i = 0; i < resp.length; ++i) {
-            resp[i] = (byte)i;
+            resp[i] = (byte)(((address + i) % 91) + 32);
         }
         handler.handleReadData(null, space, address, resp);
         logger.log(Level.INFO, "read {0} {1}", new Object[]{address, space});

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -719,8 +719,7 @@ public class CdiPanel extends JPanel {
             p.setAlignmentY(Component.TOP_ALIGNMENT);
             //p.setBorder(BorderFactory.createTitledBorder(name));
 
-            String d = item.getDescription();
-            if (d != null) p.add(createDescriptionPane(d));
+            createDescriptionPane(this, item.getDescription());
 
             // include map if present
             JPanel p2 = createPropertyPane(item.getMap());
@@ -728,12 +727,9 @@ public class CdiPanel extends JPanel {
         }
     }
 
-    JPanel createDescriptionPane(String d) {
-        if (d == null) return null;
-        JPanel p = new JPanel();
-        p.setAlignmentX(Component.LEFT_ALIGNMENT);
-        /*
-        p.setLayout(new BorderLayout());
+    void createDescriptionPane(JPanel parent, String d) {
+        if (d == null) return;
+        if (d.trim().length() == 0) return;
         JTextArea area = new JTextArea(d);
         area.setAlignmentX(Component.LEFT_ALIGNMENT);
         area.setFont(UIManager.getFont("Label.font"));
@@ -741,8 +737,9 @@ public class CdiPanel extends JPanel {
         area.setOpaque(false);
         area.setWrapStyleWord(true); 
         area.setLineWrap(true);
-        p.add(area);*/
-        return p;
+        area.setMaximumSize(
+                new Dimension(Integer.MAX_VALUE, area.getPreferredSize().height) );
+        parent.add(area);
     }
 
     private void addCopyPasteButtons(JPanel linePanel, JTextField textField) {
@@ -798,10 +795,7 @@ public class CdiPanel extends JPanel {
             setBorder(BorderFactory.createTitledBorder(name));
             setName(name);
 
-            String d = item.getDescription();
-            if (d != null) {
-                add(createDescriptionPane(d));
-            }
+            createDescriptionPane(this, item.getDescription());
 
             // include map if present
             JPanel p2 = createPropertyPane(item.getMap());
@@ -827,10 +821,7 @@ public class CdiPanel extends JPanel {
             String name = (item.getName() != null ? item.getName() : defaultName);
             setBorder(BorderFactory.createTitledBorder(name));
 
-            String d = item.getDescription();
-            if (d != null) {
-                add(createDescriptionPane(d));
-            }
+            createDescriptionPane(this, item.getDescription());
 
             p3 = new JPanel();
             p3.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -982,7 +973,6 @@ public class CdiPanel extends JPanel {
                     }
                 };
             }
-            add(Box.createVerticalGlue());
         }
 
         /**

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -89,6 +89,7 @@ public class CdiPanel extends JPanel {
     private static final Color COLOR_ERROR = new Color(0xff0000); // red
     private static final Pattern segmentPrefixRe = Pattern.compile("^seg[0-9]*[.]");
     private static final Pattern entrySuffixRe = Pattern.compile("[.]child[0-9]*$");
+    private static final Pattern repeatIndexRe = Pattern.compile("[(]([0-9]+)[^0-9]");
 
     /**
      * We always use the same file chooser in this class, so that the user's
@@ -1179,7 +1180,20 @@ public class CdiPanel extends JPanel {
                 b.insert(nodeName.length(), ".");
             }
             // Now we need to translate from zero-based indexes to 1-based indexes.
-
+            m = repeatIndexRe.matcher(b);
+            for (int i = b.length() - 1; i >= 0; --i) {
+                if (b.charAt(i) == '(') {
+                    int j = i+1;
+                    while (j < b.length() && Character.isDigit(b.charAt(j))) {
+                        ++j;
+                    }
+                    if (j > i+1) {
+                        int val = Integer.valueOf(b.substring(i + 1, j));
+                        ++val;
+                        b.replace(i+1,j,Integer.toString(val));
+                    }
+                }
+            }
             return b.toString();
         }
 

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -209,6 +209,8 @@ public class CdiPanel extends JPanel {
         factory.handleGroupPaneEnd(createHelper);
         CollapsiblePanel cp = new CollapsiblePanel("Sensor/Turnout creation", createHelper);
         cp.setExpanded(false);
+        cp.setBorder(BorderFactory.createEmptyBorder(2,2,2,2));
+        //cp.setMinimumSize(new Dimension(0, cp.getPreferredSize().height));
         add(cp);
     }
 

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -89,7 +89,6 @@ public class CdiPanel extends JPanel {
     private static final Color COLOR_ERROR = new Color(0xff0000); // red
     private static final Pattern segmentPrefixRe = Pattern.compile("^seg[0-9]*[.]");
     private static final Pattern entrySuffixRe = Pattern.compile("[.]child[0-9]*$");
-    private static final Pattern repeatIndexRe = Pattern.compile("[(]([0-9]+)[^0-9]");
 
     /**
      * We always use the same file chooser in this class, so that the user's
@@ -1180,7 +1179,6 @@ public class CdiPanel extends JPanel {
                 b.insert(nodeName.length(), ".");
             }
             // Now we need to translate from zero-based indexes to 1-based indexes.
-            m = repeatIndexRe.matcher(b);
             for (int i = b.length() - 1; i >= 0; --i) {
                 if (b.charAt(i) == '(') {
                     int j = i+1;

--- a/src/org/openlcb/implementations/EventTable.java
+++ b/src/org/openlcb/implementations/EventTable.java
@@ -46,7 +46,7 @@ public class EventTable {
      * Collects all registered entries for the same event ID.
      */
     @ThreadSafe
-    class EventInfo extends DefaultPropertyListenerSupport {
+    public class EventInfo extends DefaultPropertyListenerSupport {
         private final EventID eventId;
         private final List<EventTableEntry> entries = new ArrayList<>();
 
@@ -76,7 +76,7 @@ public class EventTable {
             firePropertyChange(UPDATED_EVENT_LIST, null, this);
         }
 
-        EventTableEntry[] getAllEntries() {
+        public EventTableEntry[] getAllEntries() {
             synchronized (entries) {
                 EventTableEntry[] ar = new EventTableEntry[entries.size()];
                 entries.toArray(ar);
@@ -95,6 +95,9 @@ public class EventTable {
 
         public String getDescription() { return description; }
         public EventID getEvent() { return h.event.getEventId(); }
+        public boolean isOwnedBy(EventTableEntryHolder holder) {
+            return holder == h;
+        }
     }
 
     public class EventTableEntryHolder {
@@ -108,6 +111,14 @@ public class EventTable {
 
         public void release() {
             event.remove(this);
+        }
+
+        public EventTableEntry getEntry() {
+            return entry;
+        }
+
+        public EventInfo getList() {
+            return event;
         }
     }
 }

--- a/src/org/openlcb/implementations/EventTable.java
+++ b/src/org/openlcb/implementations/EventTable.java
@@ -65,7 +65,7 @@ public class EventTable {
             synchronized (entries) {
                 entries.add(newEntry);
             }
-            firePropertyChange(UPDATED_EVENT_LIST, null, this);
+            notifyUpdated();
             return h;
         }
 
@@ -73,6 +73,10 @@ public class EventTable {
             synchronized (entries) {
                 entries.removeIf((EventTableEntry e) -> e.h == h);
             }
+            notifyUpdated();
+        }
+
+        void notifyUpdated() {
             firePropertyChange(UPDATED_EVENT_LIST, null, this);
         }
 
@@ -97,6 +101,14 @@ public class EventTable {
         public EventID getEvent() { return h.event.getEventId(); }
         public boolean isOwnedBy(EventTableEntryHolder holder) {
             return holder == h;
+        }
+
+        public void updateDescription(String newDescription) {
+            synchronized (h.event.entries) {
+                if (description.equals(newDescription)) return;
+                description = newDescription;
+            }
+            h.event.notifyUpdated();
         }
     }
 

--- a/src/org/openlcb/implementations/EventTable.java
+++ b/src/org/openlcb/implementations/EventTable.java
@@ -1,0 +1,113 @@
+package org.openlcb.implementations;
+
+import org.openlcb.DefaultPropertyListenerSupport;
+import org.openlcb.EventID;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * EventTable keeps an in-memory representation of all currently known event IDs on the bus. It
+ * allows searching for event IDs by description and looking up descriptions for event IDs. The
+ * entries in EventTable are owned by live Java objects using reference holders and disappear
+ * when requested.
+ * <p>
+ * EventTable is thread-safe.
+ * <p>
+ * Created by bracz on 4/6/17.
+ */
+
+@ThreadSafe
+public class EventTable {
+    private final HashMap<Long, EventInfo> entries = new HashMap<>();
+
+    public final static String UPDATED_EVENT_LIST = "UPDATED_EVENT_LIST";
+
+    public EventInfo getEventInfo(EventID event) {
+        synchronized (entries) {
+            long key = event.toLong();
+            EventInfo entry = entries.get(key);
+            if (entry == null) {
+                entry = new EventInfo(event);
+                entries.put(key, entry);
+            }
+            return entry;
+        }
+    }
+
+    public EventTableEntryHolder addEvent(EventID event, String description) {
+        return getEventInfo(event).add(description);
+    }
+
+    /**
+     * Collects all registered entries for the same event ID.
+     */
+    @ThreadSafe
+    class EventInfo extends DefaultPropertyListenerSupport {
+        private final EventID eventId;
+        private final List<EventTableEntry> entries = new ArrayList<>();
+
+        EventInfo(EventID id) {
+            eventId = id;
+        }
+
+        public EventID getEventId() {
+            return eventId;
+        }
+
+        public EventTableEntryHolder add(String description) {
+            EventTableEntry newEntry = new EventTableEntry(description);
+            EventTableEntryHolder h = new EventTableEntryHolder(this, newEntry);
+            newEntry.h = h;
+            synchronized (entries) {
+                entries.add(newEntry);
+            }
+            firePropertyChange(UPDATED_EVENT_LIST, null, this);
+            return h;
+        }
+
+        void remove(EventTableEntryHolder h) {
+            synchronized (entries) {
+                entries.removeIf((EventTableEntry e) -> e.h == h);
+            }
+            firePropertyChange(UPDATED_EVENT_LIST, null, this);
+        }
+
+        EventTableEntry[] getAllEntries() {
+            synchronized (entries) {
+                EventTableEntry[] ar = new EventTableEntry[entries.size()];
+                entries.toArray(ar);
+                return ar;
+            }
+        }
+    }
+
+    public class EventTableEntry {
+        String description;
+        EventTableEntryHolder h;
+
+        EventTableEntry(String d) {
+            description = d;
+        }
+
+        public String getDescription() { return description; }
+        public EventID getEvent() { return h.event.getEventId(); }
+    }
+
+    public class EventTableEntryHolder {
+        final EventTableEntry entry;
+        final EventInfo event;
+
+        EventTableEntryHolder(EventInfo event, EventTableEntry e) {
+            this.event = event;
+            entry = e;
+        }
+
+        public void release() {
+            event.remove(this);
+        }
+    }
+}

--- a/test/org/openlcb/EventIDTest.java
+++ b/test/org/openlcb/EventIDTest.java
@@ -104,6 +104,21 @@ public class EventIDTest extends TestCase {
         Assert.assertEquals(e1.toString(), "EventID:00.00.01.10.13.0D.D0.AB");
     }
 
+    public void testToLong() {
+        EventID e1 = new EventID(new byte[]{0,0,0,0,0,0,0,0});
+        assertEquals(0L, e1.toLong());
+        assertEquals(1L, new EventID(new byte[]{0,0,0,0,0,0,0,1}).toLong());
+        assertEquals(256L, new EventID(new byte[]{0,0,0,0,0,0,1,0}).toLong());
+        assertEquals(1L<<32, new EventID(new byte[]{0,0,0,1,0,0,0,0}).toLong());
+        assertEquals(150L<<32, new EventID(new byte[]{0,0,0,(byte)150,0,0,0,0}).toLong());
+
+        assertEquals(127L<<56, new EventID(new byte[]{127,0,0,0,0,0,0,0}).toLong());
+        assertEquals(-1L, new EventID(new byte[]{(byte)0xff,(byte)0xff,(byte)0xff,(byte)0xff,
+                (byte)0xff,(byte)0xff,(byte)0xff,(byte)0xff}).toLong());
+        assertEquals(-2L, new EventID(new byte[]{(byte)0xff,(byte)0xff,(byte)0xff,(byte)0xff,
+                (byte)0xff,(byte)0xff,(byte)0xff,(byte)0xfe}).toLong());
+    }
+
     // from here down is testing infrastructure
     
     public EventIDTest(String s) {

--- a/test/org/openlcb/cdi/swing/CdiPanelDemo.java
+++ b/test/org/openlcb/cdi/swing/CdiPanelDemo.java
@@ -10,6 +10,7 @@ import org.jdom2.input.SAXBuilder;
 import org.openlcb.cdi.impl.ConfigRepresentation;
 import org.openlcb.cdi.impl.DemoReadWriteAccess;
 import org.openlcb.cdi.jdom.JdomCdiRep;
+import org.openlcb.implementations.EventTable;
 
 import static org.openlcb.cdi.impl.DemoReadWriteAccess.demoRepFromFile;
 
@@ -27,7 +28,7 @@ public class CdiPanelDemo {
     public void displayFile(String fileName) {
         JFrame f = new JFrame();
         CdiPanel m = new CdiPanel();
-
+        EventTable t = new EventTable();
         File file;
         if (fileName == null) {
             // find file & load file
@@ -38,7 +39,7 @@ public class CdiPanelDemo {
             // handle selection or cancel
             if (retVal != JFileChooser.APPROVE_OPTION) {
                 // Run the script from it's filename
-                System.out.println("No file selected");
+                System.out.println("No file selectedd");
             }
             file = fci.getSelectedFile();
         } else {
@@ -47,7 +48,7 @@ public class CdiPanelDemo {
         f.setTitle(file.getName());
 
         ConfigRepresentation configRep = demoRepFromFile(file);
-
+        m.setEventTable("Demo node", t);
         m.initComponents(configRep,
                 new CdiPanel.GuiItemFactory() {
                     public JButton handleReadButton(JButton button) {
@@ -58,9 +59,7 @@ public class CdiPanelDemo {
                 }
         );
 
-        JScrollPane sp = new JScrollPane(m);
-        f.add( sp );
-        //f.add(m);
+        f.add(m);
 
         // show
         f.pack();
@@ -76,6 +75,11 @@ public class CdiPanelDemo {
     // Main entry point
     static public void main(String[] args) {
         CdiPanelDemo d = new CdiPanelDemo();
-        d.displayFile(null);
+        String fname = null;
+        if (args.length > 0) {
+            fname = args[0];
+            System.out.println("Using input file " + fname);
+        }
+        d.displayFile(fname);
     }
 }

--- a/test/org/openlcb/implementations/EventTableTest.java
+++ b/test/org/openlcb/implementations/EventTableTest.java
@@ -1,0 +1,98 @@
+package org.openlcb.implementations;
+
+import junit.framework.TestCase;
+
+import org.openlcb.EventID;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+/**
+ * Created by bracz on 4/6/17.
+ */
+public class EventTableTest extends TestCase {
+    EventTable tbl = new EventTable();
+
+    EventID e1 = new EventID("01.02.03.04.05.06.07.08");
+    EventID e2 = new EventID("01.02.03.04.05.06.07.09");
+    EventID e3 = new EventID("01.02.03.04.05.06.07.0a");
+
+    public void setUp() throws Exception {
+        super.setUp();
+
+    }
+
+    public void testAddRemove() {
+        EventTable.EventTableEntryHolder h1 = tbl.addEvent(e1, "teste1");
+        EventTable.EventTableEntryHolder h2 = tbl.addEvent(e2, "teste2");
+        EventTable.EventTableEntryHolder h1alt = tbl.addEvent(e1, "teste1alt");
+
+        EventTable.EventInfo einfo1 = tbl.getEventInfo(e1);
+        assertTrue(einfo1 == h1.event);
+        assertTrue(einfo1 == h1alt.event);
+        assertTrue(einfo1 != h2.event);
+        assertEquals("teste1", h1.entry.getDescription());
+        assertEquals("teste2", h2.entry.getDescription());
+        assertEquals("teste1alt", h1alt.entry.getDescription());
+
+        EventTable.EventTableEntry[] elist = einfo1.getAllEntries();
+        assertEquals(2, elist.length);
+        assertTrue(elist[0].h == h1);
+        assertTrue(elist[1].h == h1alt);
+
+        elist = tbl.getEventInfo(e2).getAllEntries();
+        assertEquals(1, elist.length);
+        assertTrue(elist[0].h == h2);
+
+        h1.release();
+        elist = tbl.getEventInfo(e1).getAllEntries();
+        assertEquals(1, elist.length);
+        assertTrue(elist[0].h == h1alt);
+
+        h1alt.release();
+        elist = tbl.getEventInfo(e1).getAllEntries();
+        assertEquals(0, elist.length);
+    }
+
+    class FakeListener implements PropertyChangeListener {
+        EventTable.EventInfo newValue = null;
+        @Override
+        public void propertyChange(PropertyChangeEvent propertyChangeEvent) {
+            assertEquals(EventTable.UPDATED_EVENT_LIST, propertyChangeEvent.getPropertyName());
+            assertNull(propertyChangeEvent.getOldValue());
+
+            assertNull("duplicate listener call", newValue);
+            newValue = (EventTable.EventInfo) propertyChangeEvent.getNewValue();
+            assertNotNull(newValue);
+        }
+
+        public void reset() { newValue = null; }
+
+        public void verifyCall(EventTable.EventInfo expected) {
+            assertNotNull("Expected call, but did not happen.", newValue);
+            assertTrue("Incorrect newValue passed to property listener", newValue == expected);
+            reset();
+        }
+
+        public void verifyNoInteraction() {
+            assertNull("Expected no call, got one.", newValue);
+        }
+    }
+
+    public void testNotify() {
+        EventTable.EventInfo elist = tbl.getEventInfo(e3);
+        FakeListener l = new FakeListener();
+
+        elist.addPropertyChangeListener(l);
+        l.verifyNoInteraction();
+        EventTable.EventTableEntryHolder h1 = elist.add("teste3");
+        l.verifyCall(elist);
+
+        elist.add("teste3alt");
+        l.verifyCall(elist);
+
+        h1.release();
+        l.verifyCall(elist);
+    }
+
+}


### PR DESCRIPTION
Creates an inmemory list of known uses of event IDs, associating one or more string descriptions with each Event ID. Allows infrastructure components to register as a user of an event ID and provide a description for themselves. This registration can be revoked when the infrastructure component is changed (e.g. to a different event ID) or deleted, or updated in case its name changes.
Allows UIs to register as listener and get notifications when the known users or descriptions of an event ID change.
Adds a user interface component to the CDI window that lists all other users of the currently set event ID.