### PR TITLE
Option to send Unknown event identify responses.

### DIFF
--- a/src/org/openlcb/implementations/BitProducerConsumer.java
+++ b/src/org/openlcb/implementations/BitProducerConsumer.java
@@ -39,6 +39,8 @@ public class BitProducerConsumer extends MessageDecoder {
     public final static int QUERY_AT_STARTUP = 8;
     /// Flag bit to always listen to event identified messages.
     public final static int LISTEN_EVENT_IDENTIFIED = 16;
+    /// Flag bit to always send UNKNOWN response for event identified messages.
+    public final static int SEND_UNKNOWN_EVENT_IDENTIFIED = 32;
 
     public final static int DEFAULT_FLAGS = IS_PRODUCER | IS_CONSUMER | QUERY_AT_STARTUP |
             LISTEN_EVENT_IDENTIFIED;
@@ -100,7 +102,7 @@ public class BitProducerConsumer extends MessageDecoder {
     }
 
     private EventState getOnEventState() {
-        if (isValueAtDefault()) {
+        if (isValueAtDefault() || ((flags & SEND_UNKNOWN_EVENT_IDENTIFIED) > 0)) {
             return EventState.Unknown;
         }
         if (value.getLatestData()) return EventState.Valid;

--- a/test/org/openlcb/implementations/BitProducerConsumerTest.java
+++ b/test/org/openlcb/implementations/BitProducerConsumerTest.java
@@ -246,6 +246,47 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectNoFrames();
     }
 
+    public void testGenerateUnknown() throws Exception {
+        pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_PRODUCER | BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.SEND_UNKNOWN_EVENT_IDENTIFIED);
+
+        expectFrame(":X19547333N0504030201000708;", times(1));
+        expectFrame(":X19547333N0504030201000709;");
+        expectFrame(":X194C7333N0504030201000708;", times(1));
+        expectFrame(":X194C7333N0504030201000709;");
+
+        expectNoFrames();
+        sendFrameAndExpectResult( //
+                ":X19914444N0504030201000708;",
+                ":X19547333N0504030201000708;");
+        expectNoFrames();
+
+        // set the value
+        VersionedValue<Boolean> v = pc.getValue();
+        v.set(false);
+        expectFrame(":X195B4333N0504030201000709;");
+        // now a query tell us NO different
+        sendFrameAndExpectResult( //
+                ":X19914444N0504030201000708;",
+                ":X19547333N0504030201000708;");
+        expectNoFrames();
+        sendFrameAndExpectResult( //
+                ":X19914444N0504030201000709;",
+                ":X19547333N0504030201000709;");
+        expectNoFrames();
+
+        v.set(true);
+        expectFrame(":X195B4333N0504030201000708;");
+        // still a query tell us nothing
+        sendFrameAndExpectResult( //
+                ":X19914444N0504030201000708;",
+                ":X19547333N0504030201000708;");
+        expectNoFrames();
+        sendFrameAndExpectResult( //
+                ":X19914444N0504030201000709;",
+                ":X19547333N0504030201000709;");
+        expectNoFrames();
+    }
+
     public void testProducerOnlyNoListen() throws Exception {
         pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_PRODUCER);
         // startup


### PR DESCRIPTION
Adds a flag to the BitProducerConsumer to always respond "Unknown" state to producer / consumer identify requests. This allows creating "non-authoritative" producers and consumers that do not contribute to a distributed state recovery algorithm. That may be helpful for computers that do not have actual hardware that they drive in a particular way.