### PR TITLE
Network Tree UI improvements

### DIFF
--- a/src/org/openlcb/MimicNodeStore.java
+++ b/src/org/openlcb/MimicNodeStore.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 public class MimicNodeStore extends AbstractConnection {
 
     public static final String ADD_PROP_NODE = "AddNode";
+    public static final String CLEAR_ALL_NODES = "ClearAllNodes";
     private final static Logger logger = Logger.getLogger(MimicNodeStore.class.getName());
 
     public MimicNodeStore(Connection connection, NodeID node) {
@@ -43,7 +44,16 @@ public class MimicNodeStore extends AbstractConnection {
         // check for necessary updates in specific node
         memo.put(msg, sender);
     }
-    
+
+    /**
+     * Resets the node store object by clearing all members, and sending out a new message to the bus to validate all nodes. Will cause a callback for clearing all nodes, then an AddNode for all nodes that actually exist on the network.
+     */
+    public void refresh() {
+        map.clear();
+        pcs.firePropertyChange(CLEAR_ALL_NODES, null, null);
+        connection.put(new VerifyNodeIDNumberMessage(node), this);
+    }
+
     public NodeMemo addNode(NodeID id) {
         NodeMemo memo = map.get(id);
         if (memo == null) {

--- a/src/org/openlcb/swing/networktree/TreePane.java
+++ b/src/org/openlcb/swing/networktree/TreePane.java
@@ -122,8 +122,6 @@ public class TreePane extends JPanel  {
             }
         };
         if (connection != null) connection.registerStartNotification(cl);
-        
-
     }
 
     /**

--- a/src/org/openlcb/swing/networktree/TreePane.java
+++ b/src/org/openlcb/swing/networktree/TreePane.java
@@ -2,8 +2,6 @@
 
 package org.openlcb.swing.networktree;
 
-import com.sun.awt.AWTUtilities;
-
 import org.openlcb.Connection;
 import org.openlcb.MimicNodeStore;
 import org.openlcb.NodeID;
@@ -12,6 +10,7 @@ import org.openlcb.VerifyNodeIDNumberMessage;
 
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
@@ -22,8 +21,12 @@ import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import javax.swing.AbstractAction;
 import javax.swing.JButton;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTree;
 import javax.swing.SwingUtilities;
@@ -122,6 +125,22 @@ public class TreePane extends JPanel  {
             }
         });
         bottomPanel.add(btnRefresh);
+
+        JButton btnSetSort = new JButton("Sort by...");
+        btnSetSort.setToolTipText("Changes the sort order of the nodes.");
+        btnSetSort.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                JPopupMenu sortMenu = new JPopupMenu();
+                sortMenu.add(createSortMenuEntry("Node ID", SortOrder.BY_NODE_ID));
+                sortMenu.add(createSortMenuEntry("Name", SortOrder.BY_NAME));
+                sortMenu.add(createSortMenuEntry("Description", SortOrder.BY_DESCRIPTION));
+                sortMenu.add(createSortMenuEntry("Mfg/Model", SortOrder.BY_MODEL));
+                sortMenu.show(btnSetSort, 0, btnSetSort.getHeight());
+            }
+        });
+        bottomPanel.add(btnSetSort);
+
         bottomPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, (int)bottomPanel.getPreferredSize().getHeight()));
         add(bottomPanel);
 
@@ -167,6 +186,18 @@ public class TreePane extends JPanel  {
             }
         };
         if (connection != null) connection.registerStartNotification(cl);
+    }
+
+    private JMenuItem createSortMenuEntry(String text, final SortOrder order) {
+        AbstractAction action = new AbstractAction(text) {
+            @Override
+            public void actionPerformed(ActionEvent actionEvent) {
+                setSortOrder(order);
+            }
+        };
+        JCheckBoxMenuItem it = new JCheckBoxMenuItem(action);
+        it.setState(order == sortOrder);
+        return it;
     }
 
     /**

--- a/src/org/openlcb/swing/networktree/TreePane.java
+++ b/src/org/openlcb/swing/networktree/TreePane.java
@@ -234,17 +234,27 @@ public class TreePane extends JPanel  {
         private String findCompareKey(MimicNodeStore.NodeMemo memo) {
             SimpleNodeIdent ident = memo.getSimpleNodeIdent();
             if (ident == null) return null;
+            String s = null, t = null;
             switch (sortOrder) {
                 case BY_NODE_ID:
                     return null;
                 case BY_NAME:
-                    return ident.getUserName() + "\0" + ident.getUserDesc();
+                    s = ident.getUserName();
+                    t = ident.getUserDesc();
+                    break;
                 case BY_DESCRIPTION:
-                    return ident.getUserDesc() + "\0" + ident.getUserName();
+                    s = ident.getUserDesc();
+                    t = ident.getUserName();
+                    break;
                 case BY_MODEL:
-                    return ident.getMfgName() + "\0" + ident.getModelName();
+                    s = ident.getMfgName();
+                    t = ident.getModelName();
+                    break;
             }
-            return null;
+            if (s == null) s = "";
+            if (t == null) t = "";
+            if (s.isEmpty() && t.isEmpty()) return null;
+            return s + "\0" + t;
         }
 
         public int compare(MimicNodeStore.NodeMemo m1, MimicNodeStore.NodeMemo m2) {
@@ -253,9 +263,9 @@ public class TreePane extends JPanel  {
             if (entry1 == null && entry2 == null) {
                 return m1.getNodeID().toString().compareTo(m2.getNodeID().toString());
             } else if (entry1 == null) {
-                return -1;
-            } else if (entry2 == null) {
                 return 1;
+            } else if (entry2 == null) {
+                return -1;
             } else {
                 int cc = entry1.compareTo(entry2);
                 if (cc != 0) {

--- a/src/org/openlcb/swing/networktree/TreePane.java
+++ b/src/org/openlcb/swing/networktree/TreePane.java
@@ -7,13 +7,20 @@ import com.sun.awt.AWTUtilities;
 import org.openlcb.Connection;
 import org.openlcb.MimicNodeStore;
 import org.openlcb.NodeID;
+import org.openlcb.SimpleNodeIdent;
 import org.openlcb.VerifyNodeIDNumberMessage;
 
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
 
 import javax.swing.JButton;
 import javax.swing.JPanel;
@@ -40,6 +47,13 @@ public class TreePane extends JPanel  {
 	    super();
     }
 
+    public enum SortOrder {
+        BY_NODE_ID,
+        BY_NAME,
+        BY_DESCRIPTION,
+        BY_MODEL,
+    }
+
     MimicNodeStore store;
     DefaultMutableTreeNode nodes;
     DefaultTreeModel treeModel;
@@ -47,9 +61,38 @@ public class TreePane extends JPanel  {
     MimicNodeStore getStore() { return store; }
     DefaultTreeModel getTreeModel() { return treeModel; }
     JTree tree;
-    
+    SortOrder sortOrder = SortOrder.BY_NODE_ID;
+
     NodeID nullNode = new NodeID(new byte[]{0,0,0,0,0,0});
-    
+    final Timer timer = new Timer();
+    private boolean needResortTree = false;
+
+    // This listener ensures that if any node's SNIP data changes we resort the visible tree.
+    PropertyChangeListener resortListener = new PropertyChangeListener() {
+        @Override
+        public void propertyChange(PropertyChangeEvent e) {
+            if (e.getPropertyName().equals(MimicNodeStore.NodeMemo.UPDATE_PROP_SIMPLE_NODE_IDENT)) {
+                // This code will delay the updating of the display by a bit and coalesces update
+                // commands. This way we can ensure we don't spend too much CPU repeatedly
+                // updating the display.
+                synchronized (timer) {
+                    needResortTree = true;
+                }
+                timer.schedule(new TimerTask() {
+                    @Override
+                    public void run() {
+                        synchronized (timer) {
+                            if (needResortTree) {
+                                SwingUtilities.invokeLater(() -> resortTree());
+                                needResortTree = false;
+                            }
+                        }
+                    }
+                }, 100);
+            }
+        }
+    };
+
     public void initComponents(MimicNodeStore store, final Connection connection, 
                                 final NodeID node, final NodeTreeRep.SelectionKeyLoader loader) {
         this.store = store;
@@ -91,6 +134,7 @@ public class TreePane extends JPanel  {
                         NodeTreeRep n = new NodeTreeRep(memo, getStore(), getTreeModel(), loader);
                         addNewHardwareNode(n);
                         n.initConnections();
+                        memo.addPropertyChangeListener(resortListener);
                     }
                 } else if (e.getPropertyName().equals(MimicNodeStore.CLEAR_ALL_NODES)) {
                     synchronized (nodes) {
@@ -131,12 +175,23 @@ public class TreePane extends JPanel  {
      */
     private void addNewHardwareNode(NodeTreeRep n) {
         synchronized (nodes) {
-            String newKey = n.toString();
+            Comparator<NodeTreeRep> s = getSorter();
             int i = 0;
             while (i < nodes.getChildCount() &&
-                    nodes.getChildAt(i).toString().compareTo(newKey) < 0) ++i;
+                    s.compare((NodeTreeRep) nodes.getChildAt(i), n) < 0) ++i;
             treeModel.insertNodeInto(n, nodes, i);
         }
+    }
+
+    /**
+     * Sets the sort order to be used in the tree;
+     *
+     * @param order new order.
+     */
+    public void setSortOrder(SortOrder order) {
+        if (sortOrder == order) return;
+        sortOrder = order;
+        SwingUtilities.invokeLater(() -> resortTree());
     }
 
     public void addTreeSelectionListener(final TreeSelectionListener listener) {
@@ -148,5 +203,73 @@ public class TreePane extends JPanel  {
             }
         });
     }
-	
+
+    private void resortTree() {
+        synchronized (nodes) {
+            ArrayList<NodeTreeRep> list = new ArrayList<>(nodes.getChildCount());
+            for (int i = 0; i < nodes.getChildCount(); ++i) {
+                list.add((NodeTreeRep) nodes.getChildAt(i));
+            }
+            list.sort(getSorter());
+            nodes.removeAllChildren();
+            for (NodeTreeRep ch : list) {
+                nodes.add(ch);
+            }
+            treeModel.nodeStructureChanged(nodes);
+        }
+    }
+
+    Comparator<NodeTreeRep> getSorter() {
+        return new Sorter(sortOrder);
+    }
+
+    public static class Sorter implements Comparator<NodeTreeRep> {
+        private final SortOrder sortOrder;
+
+        public Sorter(SortOrder order) {
+            sortOrder = order;
+        }
+
+        private String findCompareKey(MimicNodeStore.NodeMemo memo) {
+            SimpleNodeIdent ident = memo.getSimpleNodeIdent();
+            if (ident == null) return null;
+            switch (sortOrder) {
+                case BY_NODE_ID:
+                    return null;
+                case BY_NAME:
+                    return ident.getUserName() + "\0" + ident.getUserDesc();
+                case BY_DESCRIPTION:
+                    return ident.getUserDesc() + "\0" + ident.getUserName();
+                case BY_MODEL:
+                    return ident.getMfgName() + "\0" + ident.getModelName();
+            }
+            return null;
+        }
+
+        public int compare(MimicNodeStore.NodeMemo m1, MimicNodeStore.NodeMemo m2) {
+            String entry1 = findCompareKey(m1);
+            String entry2 = findCompareKey(m2);
+            if (entry1 == null && entry2 == null) {
+                return m1.getNodeID().toString().compareTo(m2.getNodeID().toString());
+            } else if (entry1 == null) {
+                return -1;
+            } else if (entry2 == null) {
+                return 1;
+            } else {
+                int cc = entry1.compareTo(entry2);
+                if (cc != 0) {
+                    return cc;
+                }
+                return m1.getNodeID().toString().compareTo(m2.getNodeID().toString());
+            }
+        }
+
+        @Override
+        public int compare(NodeTreeRep n1, NodeTreeRep n2) {
+            MimicNodeStore.NodeMemo m1 = n1.memo;
+            MimicNodeStore.NodeMemo m2 = n2.memo;
+            return compare(m1, m2);
+        }
+    }
+
 }

--- a/src/org/openlcb/swing/networktree/TreePane.java
+++ b/src/org/openlcb/swing/networktree/TreePane.java
@@ -96,7 +96,8 @@ public class TreePane extends JPanel  {
     public void initComponents(MimicNodeStore store, final Connection connection, 
                                 final NodeID node, final NodeTreeRep.SelectionKeyLoader loader) {
         this.store = store;
-        
+
+        setPreferredSize(new Dimension(500, 700));
         nodes = new DefaultMutableTreeNode("OpenLCB Network");
     
         // build GUI

--- a/test/org/openlcb/swing/networktree/TreePaneTest.java
+++ b/test/org/openlcb/swing/networktree/TreePaneTest.java
@@ -169,7 +169,14 @@ public class TreePaneTest extends TestCase {
                 );
         store.put(msg, null);
     }
-    
+
+    public void testRefresh() {
+        // fill up with nodes
+        testNodeOrder();
+        assertEquals(5, pane.nodes.getChildCount());
+        store.refresh();
+        assertEquals(0, pane.nodes.getChildCount());
+    }
    
     // from here down is testing infrastructure
     

--- a/test/org/openlcb/swing/networktree/TreePaneTest.java
+++ b/test/org/openlcb/swing/networktree/TreePaneTest.java
@@ -231,6 +231,22 @@ public class TreePaneTest extends TestCase {
         assertTrue(new TreePane.Sorter(TreePane.SortOrder.BY_MODEL).compare(memo3, memo4) < 0);
     }
 
+    public void testSortOrder5() {
+        addNodeWithSnii(nid3, "", "", "", "");
+        addNodeWithSnii(nid4, "", "", "", "");
+        MimicNodeStore.NodeMemo memo4 = store.findNode(nid4);
+        MimicNodeStore.NodeMemo memo3 = store.findNode(nid3);
+        assertTrue(new TreePane.Sorter(TreePane.SortOrder.BY_MODEL).compare(memo3, memo4) < 0);
+    }
+
+    public void testSortOrder6() {
+        addNodeWithSnii(nid3, "", "", "", "");
+        addNodeWithSnii(nid4, "abcd", "", "", "");
+        MimicNodeStore.NodeMemo memo4 = store.findNode(nid4);
+        MimicNodeStore.NodeMemo memo3 = store.findNode(nid3);
+        assertTrue(new TreePane.Sorter(TreePane.SortOrder.BY_MODEL).compare(memo3, memo4) > 0);
+    }
+
     public void testSort() throws InvocationTargetException, InterruptedException {
         store.refresh(); // clears nid1.
         addNodeWithSnii(nid2, "xxx", "qqq", "aaa", "bbb");


### PR DESCRIPTION
- Adds a refresh button to the network tree panel. Fixes https://github.com/openlcb/OpenLCB_Java/issues/68.
- Adds the ability to sort the network tree by name, description, model in addition to the default Node ID. Fixes https://github.com/openlcb/OpenLCB_Java/issues/69.