### PR TITLE
Fixes flakiness in the memory configuration service tests

### DIFF
--- a/src/org/openlcb/implementations/MemoryConfigurationService.java
+++ b/src/org/openlcb/implementations/MemoryConfigurationService.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.Semaphore;
 import java.util.logging.Logger;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
@@ -192,6 +193,20 @@ public class MemoryConfigurationService {
 
     public void setTimeoutMillis(long t) {
         timeoutMillis = t;
+    }
+
+    /**
+     * Waits to ensure that all pending timer tasks are complete. Used for testing.
+     */
+    public void waitForTimer() throws InterruptedException {
+        final Semaphore s = new Semaphore(0);
+        retryTimer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                s.release();
+            }
+        }, 1);
+        s.acquire();
     }
 
     private abstract static class McsRequestMemo {

--- a/test/org/openlcb/implementations/MemoryConfigurationServiceInterfaceTest.java
+++ b/test/org/openlcb/implementations/MemoryConfigurationServiceInterfaceTest.java
@@ -300,7 +300,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         verifyNoMoreInteractions(hnd);
     }
 
-    public void testReadWithTimeout() {
+    public void testReadWithTimeout() throws InterruptedException {
         int space = 0xFD;
         long address = 0x12345678;
         int length = 4;
@@ -317,6 +317,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
 
             System.err.println("Expect 'Never received reply' here -->");
             delay(50);
+            iface.getDatagramMeteringBuffer().waitForSendCallbacks();
             System.err.println("<--");
 
             verify(hnd).handleFailure(0x100);
@@ -345,7 +346,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
 
     }
 
-    public void testReadWithTimeoutInterleaved() {
+    public void testReadWithTimeoutInterleaved() throws InterruptedException {
         int space = 0xFD;
         long address = 0x12345678;
         int length = 4;
@@ -365,6 +366,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
 
             System.err.println("Expect 'Never received reply' here -->");
             delay(50);
+            iface.getDatagramMeteringBuffer().waitForSendCallbacks();
             System.err.println("<--");
 
             verify(hnd).handleFailure(0x100);
@@ -396,6 +398,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
             expectNoMessages();
 
             delay(50);
+            iface.getMemoryConfigurationService().waitForTimer();
             // retry should be out now.
             expectMessageAndNoMore(new DatagramMessage(hereID, farID, new int[]{
                     0x20, 0x41, 0x12, 0x34, 0x56, 0x79, 4}));


### PR DESCRIPTION
Makes the datagram-metering-buffer have a single timer thread for datagram expiration timers.
Adds a thread name for this timer thread.
Adds testing accessors that wait for callbacks on this timer thread to complete.
Fixes flakiness in the memory configuration service tests.