### PR TITLE
Better Invalid report handling.

### DIFF
--- a/src/org/openlcb/implementations/BitProducerConsumer.java
+++ b/src/org/openlcb/implementations/BitProducerConsumer.java
@@ -42,9 +42,11 @@ public class BitProducerConsumer extends MessageDecoder {
     public final static int LISTEN_EVENT_IDENTIFIED = 16;
     /// Flag bit to always send UNKNOWN response for event identified messages.
     public final static int SEND_UNKNOWN_EVENT_IDENTIFIED = 32;
+    /// Flag bit to interpret INVALID response for event identified messages.
+    public final static int LISTEN_INVALID_STATE = 64;
 
     public final static int DEFAULT_FLAGS = IS_PRODUCER | IS_CONSUMER | QUERY_AT_STARTUP |
-            LISTEN_EVENT_IDENTIFIED;
+            LISTEN_EVENT_IDENTIFIED | LISTEN_INVALID_STATE;
 
     public BitProducerConsumer(OlcbInterface iface, EventID eventOn, EventID eventOff) {
         this(iface, eventOn, eventOff, DEFAULT_FLAGS);
@@ -95,6 +97,8 @@ public class BitProducerConsumer extends MessageDecoder {
      * Sends out query messages to the bus. Useful to be called after resetToDefault().
      */
     public void sendQuery() {
+        sendMessage(new IdentifyProducersMessage(iface.getNodeId(), eventOff));
+        sendMessage(new IdentifyConsumersMessage(iface.getNodeId(), eventOff));
         sendMessage(new IdentifyProducersMessage(iface.getNodeId(), eventOn));
         sendMessage(new IdentifyConsumersMessage(iface.getNodeId(), eventOn));
     }
@@ -200,7 +204,8 @@ public class BitProducerConsumer extends MessageDecoder {
         }
         if (msg.getEventState().equals(EventState.Valid)) {
             setValueFromNetwork(isOn);
-        } else if (msg.getEventState().equals(EventState.Invalid)) {
+        } else if (msg.getEventState().equals(EventState.Invalid) && ((flags &
+                LISTEN_INVALID_STATE) != 0)) {
             setValueFromNetwork(!isOn);
         }
     }
@@ -218,7 +223,8 @@ public class BitProducerConsumer extends MessageDecoder {
         }
         if (msg.getEventState().equals(EventState.Valid)) {
             setValueFromNetwork(isOn);
-        } else if (msg.getEventState().equals(EventState.Invalid)) {
+        } else if (msg.getEventState().equals(EventState.Invalid) && ((flags &
+                LISTEN_INVALID_STATE) != 0)) {
             setValueFromNetwork(!isOn);
         }
     }

--- a/test/org/openlcb/implementations/BitProducerConsumerTest.java
+++ b/test/org/openlcb/implementations/BitProducerConsumerTest.java
@@ -368,6 +368,8 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectFrame(":X194C7333N0504030201000708;");
         expectFrame(":X194C7333N0504030201000709;");
 
+        expectFrame(":X19914333N0504030201000709;");
+        expectFrame(":X198F4333N0504030201000709;");
         expectFrame(":X19914333N0504030201000708;");
         expectFrame(":X198F4333N0504030201000708;");
 
@@ -407,6 +409,8 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectFrame(":X194C7333N0504030201000708;");
         expectFrame(":X194C7333N0504030201000709;");
 
+        expectFrame(":X19914333N0504030201000709;");
+        expectFrame(":X198F4333N0504030201000709;");
         expectFrame(":X19914333N0504030201000708;");
         expectFrame(":X198F4333N0504030201000708;");
 
@@ -419,7 +423,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
     }
 
     public void testConsumerOnlyListenAlways() throws Exception {
-        pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.LISTEN_EVENT_IDENTIFIED);
+        pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.LISTEN_EVENT_IDENTIFIED | BitProducerConsumer.LISTEN_INVALID_STATE);
 
         expectFrame(":X194C7333N0504030201000708;");
         expectFrame(":X194C7333N0504030201000709;");
@@ -434,8 +438,26 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
                 ":X19544333N0504030201000709;");
     }
 
+    public void testListenNoInvalid() throws Exception {
+        pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.LISTEN_EVENT_IDENTIFIED);
+
+        expectFrame(":X194C7333N0504030201000708;");
+        expectFrame(":X194C7333N0504030201000709;");
+
+        expectNoFrames();
+        helperNotProducing();
+
+        helperInputSetClear(":X195B4333N0504030201000708;",
+                ":X195B4333N0504030201000709;");
+        helperInputSetClear(":X19544333N0504030201000708;",
+                ":X19544333N0504030201000709;");
+        helperInputNoChange(":X194C5333N0504030201000709;",
+                ":X194C5333N0504030201000708;");
+    }
+
     public void testOneEventNull() throws Exception {
-        pc = new BitProducerConsumer(iface, onEvent, pc.nullEvent, BitProducerConsumer.IS_PRODUCER | BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.LISTEN_EVENT_IDENTIFIED);
+        pc = new BitProducerConsumer(iface, onEvent, pc.nullEvent, BitProducerConsumer.IS_PRODUCER | BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.LISTEN_EVENT_IDENTIFIED |
+                BitProducerConsumer.LISTEN_INVALID_STATE);
 
         expectFrame(":X19547333N0504030201000708;");
         expectFrame(":X194C7333N0504030201000708;");
@@ -478,6 +500,8 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         createWithDefaults();
 
         pc.sendQuery();
+        expectFrame(":X19914333N0504030201000709;");
+        expectFrame(":X198F4333N0504030201000709;");
         expectFrame(":X19914333N0504030201000708;");
         expectFrame(":X198F4333N0504030201000708;");
         expectNoFrames();
@@ -574,6 +598,8 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectFrame(":X194C7333N0504030201000708;", times(1));
         expectFrame(":X194C7333N0504030201000709;");
 
+        expectFrame(":X19914333N0504030201000709;");
+        expectFrame(":X198F4333N0504030201000709;");
         expectFrame(":X19914333N0504030201000708;");
         expectFrame(":X198F4333N0504030201000708;");
         expectNoFrames();


### PR DESCRIPTION
Adds an option to not listen to event state reports that have Invalid as state.
Makes the Query messages send out queries for both events.