### PR TITLE
Threading improvements

### DIFF
--- a/src/org/openlcb/LoaderClient.java
+++ b/src/org/openlcb/LoaderClient.java
@@ -49,6 +49,7 @@ public class LoaderClient extends MessageDecoder {
         connection = _connection;
         dcs = _dcs;
         mcs = _mcs;
+        timer = new Timer("OpenLCB LoaderClient Timeout Timer");
     }
     
     /* Protocol:
@@ -126,7 +127,7 @@ public class LoaderClient extends MessageDecoder {
             });
     }
 
-    private Timer timer = new Timer("OpenLCB LoaderClient Timeout Timer");
+    private Timer timer;
     private TimerTask task = null;
     void startTimeout(int period) {
         task = new TimerTask(){
@@ -362,5 +363,12 @@ public class LoaderClient extends MessageDecoder {
         if (b) {
             sendUnfreeze();
         }
+    }
+
+    /*
+     * clean up local storage
+     */
+    public void dispose(){
+       timer.cancel();
     }
 }

--- a/src/org/openlcb/LoaderClient.java
+++ b/src/org/openlcb/LoaderClient.java
@@ -125,8 +125,9 @@ public class LoaderClient extends MessageDecoder {
                 }
             });
     }
-    Timer timer = new Timer("OpenLCB LoaderClient Timeout Timer");
-    TimerTask task = null;
+
+    private Timer timer = new Timer("OpenLCB LoaderClient Timeout Timer");
+    private TimerTask task = null;
     void startTimeout(int period) {
         task = new TimerTask(){
             public void run(){

--- a/src/org/openlcb/MimicNodeStore.java
+++ b/src/org/openlcb/MimicNodeStore.java
@@ -40,7 +40,7 @@ public class MimicNodeStore extends AbstractConnection {
     
     Connection connection;
     NodeID node;
-    Timer timer;
+    private Timer timer;
     
     public Collection<NodeMemo> getNodeMemos() {
         return map.values();
@@ -123,7 +123,7 @@ public class MimicNodeStore extends AbstractConnection {
 
         Queue<Interaction> pendingInteractions = new ConcurrentLinkedDeque<>();
         Interaction currentInteraction = null;
-        TimerTask currentTask;
+        private TimerTask currentTask;
 
         public synchronized void startInteraction(final Interaction request) {
             if (currentInteraction == null) {

--- a/src/org/openlcb/MimicNodeStore.java
+++ b/src/org/openlcb/MimicNodeStore.java
@@ -29,11 +29,18 @@ public class MimicNodeStore extends AbstractConnection {
     public MimicNodeStore(Connection connection, NodeID node) {
         this.connection = connection;
         this.node = node;
+        timer = new Timer("OpenLCB Mimic Node Store Timer");
+    }
+
+    public void dispose(){
+       // cancel the timer.
+       timer.cancel();
+       timer=null;
     }
     
     Connection connection;
     NodeID node;
-    Timer timer = new Timer("OpenLCB Mimic Node Store Timer");
+    Timer timer;
     
     public Collection<NodeMemo> getNodeMemos() {
         return map.values();
@@ -330,4 +337,5 @@ public class MimicNodeStore extends AbstractConnection {
         public synchronized void addPropertyChangeListener(java.beans.PropertyChangeListener l) {pcs.addPropertyChangeListener(l);}
         public synchronized void removePropertyChangeListener(java.beans.PropertyChangeListener l) {pcs.removePropertyChangeListener(l);}
     }
+
 }

--- a/src/org/openlcb/OlcbInterface.java
+++ b/src/org/openlcb/OlcbInterface.java
@@ -196,10 +196,6 @@ public class OlcbInterface {
         return inputConnection.numListeners();
     }
 
-    public void terminateThreads(){
-         dmb.terminateThreads();
-    } 
-
     class MessageDispatcher extends AbstractConnection {
         // This is not the ideal container for add/remove, but keeping the ordering of
         // registrations is useful in ensuring that the system components receive the messages

--- a/src/org/openlcb/OlcbInterface.java
+++ b/src/org/openlcb/OlcbInterface.java
@@ -72,8 +72,7 @@ public class OlcbInterface {
      *                          initialized ready with this node ID.
      * @param outputConnection_ implements the hardware interface for sending messages to the
      *                          network. Usually this is an internal object of the CanInterface.
-     */
-    /**
+     *
      * @deprecated since OlcbLibrary version 0.18.  Use {@link #OlcbInterface(NodeID, Connection, ThreadPoolExecutor)} instead.
      */
     @Deprecated
@@ -86,6 +85,15 @@ public class OlcbInterface {
           threadPool.allowCoreThreadTimeOut(true);
     }
 
+    /**
+     * Creates the message-level interface.
+     *
+     * @param nodeId_           is the node ID for the node on this interface. Will send out a node
+     *                          initialized ready with this node ID.
+     * @param outputConnection_ implements the hardware interface for sending messages to the
+     *                          network. Usually this is an internal object of the CanInterface.
+     * @param tpe ThreadPoolExecutor for the interface.
+     */
     public OlcbInterface(NodeID nodeId_, Connection outputConnection_,ThreadPoolExecutor tpe) {
         threadPool = tpe;
         nodeId = nodeId_;

--- a/src/org/openlcb/OlcbInterface.java
+++ b/src/org/openlcb/OlcbInterface.java
@@ -39,13 +39,17 @@ public class OlcbInterface {
 
     // Client library for SNIP, PIP etc protocols.
     private final MimicNodeStore nodeStore;
+
     // Outgoing connection wrapper for datagrams that ensures that we only send one datagram at a
     // time to one destination node.
     private final DatagramMeteringBuffer dmb;
+
     // Client (and server) for datagrams.
     private final DatagramService dcs;
+
     // Client for memory configuration requests.
     private MemoryConfigurationService mcs;
+
     // CDIs for the nodes
     private final Map<NodeID, ConfigRepresentation> nodeConfigs = new HashMap<>();
     // Event Table is a helper for user interfaces to register and retrieve user names for

--- a/src/org/openlcb/OlcbThreadFactory.java
+++ b/src/org/openlcb/OlcbThreadFactory.java
@@ -1,0 +1,29 @@
+package org.openlcb;
+
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Thread factory used by thread pools created by OLCB objects. 
+ *
+ * @author Paul Bender Copyright (C) 2018 
+ */
+
+public class OlcbThreadFactory implements ThreadFactory{
+    private String name;
+    private int count;
+    private int factoryNumber;
+    static int factoryCount = 0;
+
+    public OlcbThreadFactory(){
+       factoryNumber=++factoryCount;
+       name = "Olcb-Pool-";
+       count = 0;
+    }
+
+    @Override
+    public Thread newThread(Runnable r){
+       Thread t = new Thread(r, name + factoryNumber + "-Thread-" + (count++));
+       return t;
+    }
+
+}

--- a/src/org/openlcb/can/NIDaAlgorithm.java
+++ b/src/org/openlcb/can/NIDaAlgorithm.java
@@ -30,7 +30,12 @@ public class NIDaAlgorithm implements CanFrameListener {
             timerExpired();
         }
         };
-        timer.schedule(task, delay);
+        try {
+           timer.schedule(task, delay);
+        } catch (IllegalStateException ise){
+           // the timer was canceled, dispose occured before
+           // the task was scheduled.
+        }
     }
 
     public NIDaAlgorithm(NodeID n) {

--- a/src/org/openlcb/can/NIDaAlgorithm.java
+++ b/src/org/openlcb/can/NIDaAlgorithm.java
@@ -127,4 +127,9 @@ public class NIDaAlgorithm implements CanFrameListener {
     public void send(CanFrame frame) {
         processFrame(new OpenLcbCanFrame(frame));
     }
+
+    public void dispose(){
+       timer.cancel();
+    }
+
 }

--- a/src/org/openlcb/can/NIDaAlgorithm.java
+++ b/src/org/openlcb/can/NIDaAlgorithm.java
@@ -32,7 +32,7 @@ public class NIDaAlgorithm implements CanFrameListener {
         };
         try {
            timer.schedule(task, delay);
-        } catch (IllegalStateException ise){
+        } catch (IllegalStateException | NullPointerException ise){
            // the timer was canceled, dispose occured before
            // the task was scheduled.
         }
@@ -134,7 +134,11 @@ public class NIDaAlgorithm implements CanFrameListener {
     }
 
     public void dispose(){
+       cancelTimer();  // dispose of the timer task
        timer.cancel();
+       timer = null;
+       done = null;
+       complete = true;
     }
 
 }

--- a/src/org/openlcb/can/impl/OlcbConnection.java
+++ b/src/org/openlcb/can/impl/OlcbConnection.java
@@ -271,4 +271,8 @@ public class OlcbConnection {
         }
     }
 
+    public void dispose(){
+       canInterface.dispose();
+    }
+
 }

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -1341,6 +1341,8 @@ public class CdiPanel extends JPanel {
 
         /**
          * Updates the UI for the list of other uses of the event.
+         * 
+         * @param eventInfo from the event table.
          */
         private void updateEventDescriptionField(EventTable.EventInfo eventInfo) {
             EventTable.EventTableEntry[] elist = eventInfo.getAllEntries();

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -116,6 +116,7 @@ public class CdiPanel extends JPanel {
 
     public CdiPanel () {
         super();
+        tabColorTimer = new Timer("OpenLCB CDI Reader Tab Color Timer");
     }
 
     /**
@@ -127,6 +128,7 @@ public class CdiPanel extends JPanel {
             task.run();
         }
         cleanupTasks.clear();
+        tabColorTimer.cancel(); 
     }
 
     /**
@@ -420,7 +422,7 @@ public class CdiPanel extends JPanel {
     JButton moreButton;
     SearchPane searchPane = new SearchPane();
 
-    final Timer tabColorTimer = new Timer("OpenLCB CDI Reader Tab Color Timer");
+    private Timer tabColorTimer;
     long lastColorRefreshNeeded = 0; // guarded by tabColorTimer
     long lastColorRefreshDone = Long.MAX_VALUE; // guarded by tabColorTimer
 

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -123,7 +123,7 @@ public class CdiPanel extends JPanel {
      * Cleans up all property change listeners etc in preparation when closing the window.
      */
     public void release() {
-        System.out.println("Cleanup of CDI window for " + nodeName);
+        logger.log(Level.FINE, "Cleanup of CDI window for {0}",nodeName);
         for (Runnable task : cleanupTasks) {
             task.run();
         }
@@ -513,7 +513,7 @@ public class CdiPanel extends JPanel {
         SwingUtilities.invokeLater(() -> {
             Window win = SwingUtilities.getWindowAncestor(this);
             if (win == null) {
-                System.out.println("Could not add close window listener");
+                logger.log(Level.FINE, "Could not add close window listener");
                 return;
             }
             win.addWindowListener(new WindowListener() {
@@ -1067,7 +1067,7 @@ public class CdiPanel extends JPanel {
         private void textUpdated() {
             if (parent == null) return;
             String searchQuery = textField.getText();
-            System.err.println("Search for: " + searchQuery);
+            logger.log(Level.FINE, String.format("Search for: {0}",searchQuery));
             boolean fresh = false;
             if (suggestMenu == null) {
                 suggestMenu = new JPopupMenu();
@@ -1076,7 +1076,8 @@ public class CdiPanel extends JPanel {
             long startTime = System.nanoTime();
             List<EventTable.EventTableEntry> results = eventTable.searchForEvent(searchQuery, 8);
             long timelen = System.nanoTime() - startTime;
-            System.out.println(String.format("Search took %.2f msec", timelen * 1.0 / 1e6));
+            logger.log(Level.FINE, String.format("Search took %.2f msec", 
+                                   timelen * 1.0 / 1e6));
             suggestMenu.removeAll();
             for (EventTable.EventTableEntry result : results) {
                 Action a = new AbstractAction(result.getDescription()) {
@@ -1103,7 +1104,7 @@ public class CdiPanel extends JPanel {
         }
 
         private void cancelSearch() {
-            System.err.println("Removing search box");
+            logger.log(Level.FINE, "Removing search box");
             if (suggestMenu != null) {
                 suggestMenu.setVisible(false);
             }

--- a/src/org/openlcb/hub/Hub.java
+++ b/src/org/openlcb/hub/Hub.java
@@ -49,6 +49,7 @@ public class Hub {
                     } catch (InterruptedException e) {
                         logger.severe("Hub: Interrupted in queue handling loop");
                         logger.log(Level.SEVERE, "", e);
+                        return; // we have been asked to exit.
                     }
                 }
             }

--- a/src/org/openlcb/implementations/DatagramMeteringBuffer.java
+++ b/src/org/openlcb/implementations/DatagramMeteringBuffer.java
@@ -113,7 +113,7 @@ public class DatagramMeteringBuffer extends MessageDecoder {
 
     /**
      * Waits until all pending entries are sent and their callbacks are executed.
-     * @throws {@link InterrptedException} when interrupted.
+     * @throws {@link java.lang.InterruptedException} when interrupted.
      */
     public void waitForSendCallbacks() throws InterruptedException {
         while(true) {

--- a/src/org/openlcb/implementations/DatagramMeteringBuffer.java
+++ b/src/org/openlcb/implementations/DatagramMeteringBuffer.java
@@ -40,17 +40,23 @@ public class DatagramMeteringBuffer extends MessageDecoder {
     final static long threadTimeout = 10; // allowed idle time for threads, in seconds.
 
     /**
+     * @param toDownstream connection object associated with the new buffer 
+     *
      * @deprecated since OlcbLibrary version 0.18.  Use {@link #DatagramMeteringBuffer(Connection,ThreadPoolExecutor)} instead.
      */
     @Deprecated
-    public DatagramMeteringBuffer(Connection toDownStream ){
-          this(toDownStream,
+    public DatagramMeteringBuffer(Connection toDownstream ){
+          this(toDownstream,
                new ThreadPoolExecutor(minThreads,maxThreads,
                                       threadTimeout,TimeUnit.SECONDS,
                                  new LinkedBlockingQueue<Runnable>(),
                                  new OlcbThreadFactory()));
     }
     
+    /**
+     * @param toDownstream Connection object associated with the new buffer 
+     * @param tpe Thread pool in which threads associated with the buffer run.
+     */
     public DatagramMeteringBuffer(Connection toDownstream,ThreadPoolExecutor tpe) {
         threadPool = tpe;
         if(timer == null){
@@ -107,6 +113,7 @@ public class DatagramMeteringBuffer extends MessageDecoder {
 
     /**
      * Waits until all pending entries are sent and their callbacks are executed.
+     * @throws {@link InterrptedException} when interrupted.
      */
     public void waitForSendCallbacks() throws InterruptedException {
         while(true) {

--- a/src/org/openlcb/implementations/DatagramMeteringBuffer.java
+++ b/src/org/openlcb/implementations/DatagramMeteringBuffer.java
@@ -113,7 +113,7 @@ public class DatagramMeteringBuffer extends MessageDecoder {
 
     /**
      * Waits until all pending entries are sent and their callbacks are executed.
-     * @throws {@link java.lang.InterruptedException} when interrupted.
+     * @throws java.lang.InterruptedException when interrupted.
      */
     public void waitForSendCallbacks() throws InterruptedException {
         while(true) {

--- a/src/org/openlcb/implementations/MemoryConfigurationService.java
+++ b/src/org/openlcb/implementations/MemoryConfigurationService.java
@@ -198,6 +198,7 @@ public class MemoryConfigurationService {
 
     /**
      * Waits to ensure that all pending timer tasks are complete. Used for testing.
+     * @throws {@link InterruptedException} if interrupted
      */
     public void waitForTimer() throws InterruptedException {
         final Semaphore s = new Semaphore(0);

--- a/src/org/openlcb/implementations/MemoryConfigurationService.java
+++ b/src/org/openlcb/implementations/MemoryConfigurationService.java
@@ -186,7 +186,7 @@ public class MemoryConfigurationService {
     
     NodeID here;
     DatagramService downstream;
-    Timer retryTimer;
+    private Timer retryTimer;
 
     public MemoryConfigurationService(MemoryConfigurationService mcs) {
         this(mcs.here, mcs.downstream);

--- a/src/org/openlcb/implementations/MemoryConfigurationService.java
+++ b/src/org/openlcb/implementations/MemoryConfigurationService.java
@@ -55,6 +55,7 @@ public class MemoryConfigurationService {
      * @param downstream Connection in the direction of the layout
      */
     public MemoryConfigurationService(NodeID here, DatagramService downstream) {
+        retryTimer = new Timer("OpenLCB Memory Configuration Service Retry Timer");
         this.here = here;
         this.downstream = downstream;   
         
@@ -185,7 +186,7 @@ public class MemoryConfigurationService {
     
     NodeID here;
     DatagramService downstream;
-    Timer retryTimer = new Timer("OpenLCB Memory Configuration Service Retry Timer");
+    Timer retryTimer;
 
     public MemoryConfigurationService(MemoryConfigurationService mcs) {
         this(mcs.here, mcs.downstream);
@@ -947,5 +948,10 @@ public class MemoryConfigurationService {
         }
         
 
+    }
+
+
+    public void dispose(){
+       retryTimer.cancel();
     }
 }

--- a/src/org/openlcb/implementations/MemoryConfigurationService.java
+++ b/src/org/openlcb/implementations/MemoryConfigurationService.java
@@ -198,7 +198,8 @@ public class MemoryConfigurationService {
 
     /**
      * Waits to ensure that all pending timer tasks are complete. Used for testing.
-     * @throws {@link java.lang.InterruptedException} if interrupted
+     *
+     * @throws java.lang.InterruptedException if interrupted
      */
     public void waitForTimer() throws InterruptedException {
         final Semaphore s = new Semaphore(0);

--- a/src/org/openlcb/implementations/MemoryConfigurationService.java
+++ b/src/org/openlcb/implementations/MemoryConfigurationService.java
@@ -198,7 +198,7 @@ public class MemoryConfigurationService {
 
     /**
      * Waits to ensure that all pending timer tasks are complete. Used for testing.
-     * @throws {@link InterruptedException} if interrupted
+     * @throws {@link java.lang.InterruptedException} if interrupted
      */
     public void waitForTimer() throws InterruptedException {
         final Semaphore s = new Semaphore(0);

--- a/src/org/openlcb/swing/networktree/TreePane.java
+++ b/src/org/openlcb/swing/networktree/TreePane.java
@@ -13,6 +13,8 @@ import java.awt.FlowLayout;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
@@ -187,6 +189,48 @@ public class TreePane extends JPanel  {
             }
         };
         if (connection != null) connection.registerStartNotification(cl);
+
+        SwingUtilities.invokeLater(() -> {
+            Window win = SwingUtilities.getWindowAncestor(this);
+            if (win == null) {
+                System.out.println("Could not add close window listener");
+                return;
+            }
+            win.addWindowListener(new WindowListener() {
+                @Override
+                public void windowOpened(WindowEvent windowEvent) {
+                }
+
+                @Override
+                public void windowClosing(WindowEvent windowEvent) {
+                    release();
+                }
+
+                @Override
+                public void windowClosed(WindowEvent windowEvent) {
+                }
+
+                @Override
+                public void windowIconified(WindowEvent windowEvent) {
+
+                }
+
+                @Override
+                public void windowDeiconified(WindowEvent windowEvent) {
+
+                }
+
+                @Override
+                public void windowActivated(WindowEvent windowEvent) {
+
+                }
+
+                @Override
+                public void windowDeactivated(WindowEvent windowEvent) {
+
+                }
+            });
+        });
     }
 
     private JMenuItem createSortMenuEntry(String text, final SortOrder order) {
@@ -313,6 +357,13 @@ public class TreePane extends JPanel  {
             MimicNodeStore.NodeMemo m2 = n2.memo;
             return compare(m1, m2);
         }
+    }
+
+    /**
+     * Cleans up all property change listeners etc in preparation when closing the window.
+     */
+    public void release() {
+        timer.cancel(); 
     }
 
 }

--- a/src/org/openlcb/swing/networktree/TreePane.java
+++ b/src/org/openlcb/swing/networktree/TreePane.java
@@ -48,6 +48,7 @@ public class TreePane extends JPanel  {
 
     public TreePane() {
 	    super();
+            timer = new Timer("OpenLCB Tree Pane Timer");
     }
 
     public enum SortOrder {
@@ -67,7 +68,7 @@ public class TreePane extends JPanel  {
     SortOrder sortOrder = SortOrder.BY_NODE_ID;
 
     NodeID nullNode = new NodeID(new byte[]{0,0,0,0,0,0});
-    final Timer timer = new Timer("OpenLCB Tree Pane Timer");
+    private Timer timer;
     private boolean needResortTree = false;
 
     // This listener ensures that if any node's SNIP data changes we resort the visible tree.

--- a/test/org/openlcb/InterfaceTestBase.java
+++ b/test/org/openlcb/InterfaceTestBase.java
@@ -1,7 +1,7 @@
 package org.openlcb;
 
-import junit.framework.AssertionFailedError;
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
 
 import org.mockito.ArgumentMatcher;
 import org.mockito.verification.VerificationMode;
@@ -23,19 +23,15 @@ import static org.mockito.Mockito.*;
  *
  * Created by bracz on 1/9/16.
  */
-public abstract class InterfaceTestBase extends TestCase {
+public abstract class InterfaceTestBase {
     protected Connection outputConnectionMock = mock(AbstractConnection.class);
     protected OlcbInterface iface = null;
     protected AliasMap aliasMap = new AliasMap();
     protected boolean testWithCanFrameRendering = false;
     private boolean debugFrames = false;
 
-    public InterfaceTestBase(String s) {
-        super(s);
-        expectInit();
-    }
-
-    public InterfaceTestBase() {
+    @Before
+    public void setUp() {
         expectInit();
     }
 
@@ -46,11 +42,10 @@ public abstract class InterfaceTestBase extends TestCase {
         expectMessage(new InitializationCompleteMessage(iface.getNodeId()));
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() {
         expectNoMessages();
         iface.dispose();
-        super.tearDown();
     }
 
     /** Sends one or more OpenLCB message, as represented by the given CAN frames, to the

--- a/test/org/openlcb/InterfaceTestBase.java
+++ b/test/org/openlcb/InterfaceTestBase.java
@@ -46,6 +46,7 @@ public abstract class InterfaceTestBase {
     public void tearDown() {
         expectNoMessages();
         iface.dispose();
+        iface = null;
     }
 
     /** Sends one or more OpenLCB message, as represented by the given CAN frames, to the

--- a/test/org/openlcb/InterfaceTestBase.java
+++ b/test/org/openlcb/InterfaceTestBase.java
@@ -49,6 +49,7 @@ public abstract class InterfaceTestBase extends TestCase {
     @Override
     protected void tearDown() throws Exception {
         expectNoMessages();
+        iface.dispose();
         super.tearDown();
     }
 

--- a/test/org/openlcb/LoaderClientTest.java
+++ b/test/org/openlcb/LoaderClientTest.java
@@ -56,6 +56,7 @@ public class LoaderClientTest extends TestCase {
     boolean flag;
     LoaderClient.LoaderStatusReporter reporter;
     
+    @Override
     public void setUp() {
                                       // System.out.println("SetUp()");
         messagesReceived = new java.util.ArrayList<Message>();
@@ -69,7 +70,11 @@ public class LoaderClientTest extends TestCase {
         mcs = new MemoryConfigurationService(hereID, dcs);
         flag = false;
     };
-
+ 
+    @Override
+    protected void tearDown(){
+       mcs.dispose();
+    }
 
 
 /* Protocol:
@@ -124,6 +129,7 @@ public class LoaderClientTest extends TestCase {
         Assert.assertTrue(messagesReceived.get(0).equals(new ProtocolIdentificationRequestMessage(hereID,farID)));
         messagesReceived.clear();
         xmt.put(new ProtocolIdentificationReplyMessage(farID,hereID,0x400000000000L), null);
+        xmt.dispose();
     }
     
     
@@ -149,6 +155,7 @@ public class LoaderClientTest extends TestCase {
         Assert.assertTrue(messagesReceived.get(0).equals(new ProtocolIdentificationRequestMessage(hereID,farID)));
         messagesReceived.clear();
         xmt.put(new ProtocolIdentificationReplyMessage(farID,hereID,0x000010000000L), null);
+        xmt.dispose();
     }
     
     
@@ -174,6 +181,7 @@ public class LoaderClientTest extends TestCase {
         Assert.assertTrue(messagesReceived.get(0).equals(new ProtocolIdentificationRequestMessage(hereID,farID)));
         messagesReceived.clear();
         xmt.put(new ProtocolIdentificationReplyMessage(farID,hereID,0x000030000000L), null);
+        xmt.dispose();
     }
 
 
@@ -227,6 +235,7 @@ public class LoaderClientTest extends TestCase {
                                 //System.out.println("Msg0: "+(messagesReceived.get(0) != null ? messagesReceived.get(0).toString() : " == null"));
         Assert.assertEquals(messagesReceived.get(0),new DatagramMessage(hereID,farID,
                 new int []{0x20, 0xA0, 0xEF}));
+        xmt.dispose();
     }
 
     
@@ -280,6 +289,7 @@ public class LoaderClientTest extends TestCase {
     // Unfreeze
         Assert.assertTrue(messagesReceived.get(2).equals(new DatagramMessage(hereID,farID,new int[]{0x20, 0xA0, 45}))); // Unfreeze
         messagesReceived.clear();
+        xmt.dispose();
     }
 
 
@@ -327,6 +337,7 @@ public class LoaderClientTest extends TestCase {
         // Unfreeze
         Assert.assertTrue(messagesReceived.get(2).equals(new DatagramMessage(hereID,farID,new int[]{0x20, 0xA0, 45}))); // Unfreeze
         messagesReceived.clear();
+        xmt.dispose();
     }
 
 

--- a/test/org/openlcb/MimicNodeStoreTest.java
+++ b/test/org/openlcb/MimicNodeStoreTest.java
@@ -49,6 +49,11 @@ public class MimicNodeStoreTest extends TestCase {
         listenerFired = false;
     }
 
+    @Override
+    protected void tearDown() {
+       store.dispose();
+    }
+
     public void testCtor() {
         Assert.assertNotNull(store);
     }

--- a/test/org/openlcb/OlcbInterfaceTest.java
+++ b/test/org/openlcb/OlcbInterfaceTest.java
@@ -23,6 +23,7 @@ public class OlcbInterfaceTest {
         };
         OlcbInterface t = new OlcbInterface(nodeID,testConnection);
         Assert.assertNotNull("exists",t);
+        t.dispose();
     }
 
     // The minimal setup for log4J

--- a/test/org/openlcb/can/CanInterfaceTest.java
+++ b/test/org/openlcb/can/CanInterfaceTest.java
@@ -19,6 +19,7 @@ public class CanInterfaceTest {
         NodeID nodeID = new NodeID(new byte[]{1,2,3,4,5,6});
         CanInterface t = new CanInterface(nodeID, new CanFrameListenerScaffold() );
         Assert.assertNotNull("exists",t);
+        t.dispose();
     }
 
     // The minimal setup for log4J

--- a/test/org/openlcb/cdi/impl/ConfigRepresentationTest.java
+++ b/test/org/openlcb/cdi/impl/ConfigRepresentationTest.java
@@ -83,6 +83,12 @@ public class ConfigRepresentationTest extends TestCase {
         mcs = new FakeMemoryConfigurationService(iface);
     }
 
+    @Override
+    protected void tearDown() throws Exception {
+        iface.dispose();
+        super.tearDown();
+    }
+
     // test suite from all defined tests
     public static Test suite() {
         TestSuite suite = new TestSuite(ConfigRepresentationTest.class);

--- a/test/org/openlcb/cdi/impl/ConfigRepresentationTest.java
+++ b/test/org/openlcb/cdi/impl/ConfigRepresentationTest.java
@@ -86,6 +86,7 @@ public class ConfigRepresentationTest extends TestCase {
     @Override
     protected void tearDown() throws Exception {
         iface.dispose();
+        mcs.dispose();
         super.tearDown();
     }
 

--- a/test/org/openlcb/cdi/impl/MemorySpaceCacheTest.java
+++ b/test/org/openlcb/cdi/impl/MemorySpaceCacheTest.java
@@ -14,26 +14,29 @@ import org.openlcb.*;
  */
 public class MemorySpaceCacheTest {
 
+    private OlcbInterface oi;
+    private NodeID nodeID;
+ 
     @Test
     public void testCTor() {
-        NodeID nodeID = new NodeID(new byte[]{1,2,3,4,5,6});
-        Connection testConnection = new AbstractConnection(){
-            public void put(Message msg, Connection node) {
-            }
-        };
-        OlcbInterface oi = new OlcbInterface(nodeID,testConnection);
         MemorySpaceCache t = new MemorySpaceCache(oi,nodeID,42);
         Assert.assertNotNull("exists",t);
-        oi.dispose();
     }
 
     // The minimal setup for log4J
     @Before
     public void setUp() {
+        nodeID = new NodeID(new byte[]{1,2,3,4,5,6});
+        Connection testConnection = new AbstractConnection(){
+            public void put(Message msg, Connection node) {
+            }
+        };
+        oi = new OlcbInterface(nodeID,testConnection);
     }
 
     @After
     public void tearDown() {
+        oi.dispose();
     }
 
 }

--- a/test/org/openlcb/cdi/impl/MemorySpaceCacheTest.java
+++ b/test/org/openlcb/cdi/impl/MemorySpaceCacheTest.java
@@ -24,6 +24,7 @@ public class MemorySpaceCacheTest {
         OlcbInterface oi = new OlcbInterface(nodeID,testConnection);
         MemorySpaceCache t = new MemorySpaceCache(oi,nodeID,42);
         Assert.assertNotNull("exists",t);
+        oi.dispose();
     }
 
     // The minimal setup for log4J

--- a/test/org/openlcb/cdi/impl/MemorySpaceCacheTest.java
+++ b/test/org/openlcb/cdi/impl/MemorySpaceCacheTest.java
@@ -37,6 +37,8 @@ public class MemorySpaceCacheTest {
     @After
     public void tearDown() {
         oi.dispose();
+        oi = null;
+        nodeID = null;
     }
 
 }

--- a/test/org/openlcb/cdi/jdom/CdiMemConfigReaderTest.java
+++ b/test/org/openlcb/cdi/jdom/CdiMemConfigReaderTest.java
@@ -51,6 +51,8 @@ public class CdiMemConfigReaderTest extends TestCase {
     }
     
     public void tearDown() {
+       store.dispose();
+       service.dispose();
     }
             
     public void testSetup() {

--- a/test/org/openlcb/implementations/BitProducerConsumerTest.java
+++ b/test/org/openlcb/implementations/BitProducerConsumerTest.java
@@ -1,5 +1,11 @@
 package org.openlcb.implementations;
 
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
 import org.openlcb.EventID;
 import org.openlcb.NodeID;
 
@@ -7,16 +13,24 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * Created by bracz on 1/8/16.
  */
+
 public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
+
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
 
     public static final EventID onEvent = new EventID(new byte[]{5, 4, 3, 2, 1, 0, 7, 8});
     public static final EventID offEvent = new EventID(new byte[]{5, 4, 3, 2, 1, 0, 7, 9});
     BitProducerConsumer pc;
 
+    @Test
     public void testHandleIdentifyConsumers() throws Exception {
         createWithDefaults();
         sendFrameAndExpectResult( //
@@ -46,6 +60,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
                 ":X194C5333N0504030201000708;");
     }
 
+    @Test
     public void testHandleIdentifyProducers() throws Exception {
         createWithDefaults();
         sendFrameAndExpectResult( //
@@ -74,16 +89,19 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
                 ":X19544333N0504030201000709;");
     }
 
+    @Test
     public void testHandleProducerIdentified() throws Exception {
         createWithDefaults();
         helperInputSetClear(":X19544333N0504030201000708;", ":X19545333N0504030201000708;");
     }
 
+    @Test
     public void testHandleProducerIdentifiedOff() throws Exception {
         createWithDefaults();
         helperInputSetClear(":X19545333N0504030201000709;", ":X19544333N0504030201000709;");
     }
 
+    @Test
     public void testHandleProducerIdentifiedOnOff() throws Exception {
         createWithDefaults();
         helperInputSetClear(":X19544333N0504030201000708;", ":X19544333N0504030201000709;");
@@ -92,12 +110,12 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
     public void helperInputSetClear(String frameOn, String frameOff) {
         //assertTrue(pc.isValueAtDefault());
         sendFrame(frameOff);
-        assertFalse(pc.getValue().getLatestData());
+        Assert.assertFalse(pc.getValue().getLatestData());
         sendFrame(frameOn);
-        assertFalse(pc.isValueAtDefault());
-        assertTrue(pc.getValue().getLatestData());
+        Assert.assertFalse(pc.isValueAtDefault());
+        Assert.assertTrue(pc.getValue().getLatestData());
         sendFrame(frameOff);
-        assertFalse(pc.getValue().getLatestData());
+        Assert.assertFalse(pc.getValue().getLatestData());
 
         MockVersionedValueListener<Boolean> listener = new MockVersionedValueListener<>(pc
                 .getValue());
@@ -106,7 +124,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         reset(listener.stub);
 
         sendFrame(frameOn);
-        assertTrue(pc.getValue().getLatestData());
+        Assert.assertTrue(pc.getValue().getLatestData());
         verify(listener.stub).update(true);
         verifyNoMoreInteractions(listener.stub);
         reset(listener.stub);
@@ -120,7 +138,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         verify(listener.stub).update(false);
         verifyNoMoreInteractions(listener.stub);
         reset(listener.stub);
-        assertFalse(pc.getValue().getLatestData());
+        Assert.assertFalse(pc.getValue().getLatestData());
     }
 
     public void helperInputNoChange(String frameOn, String frameOff) {
@@ -128,23 +146,23 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         boolean atDefault = pc.isValueAtDefault();
 
         sendFrame(frameOn);
-        assertEquals(data, pc.getValue().getLatestData());
-        assertEquals(atDefault, pc.isValueAtDefault());
+        Assert.assertEquals(data, pc.getValue().getLatestData());
+        Assert.assertEquals(atDefault, pc.isValueAtDefault());
         expectNoFrames();
 
         sendFrame(frameOff);
-        assertEquals(data, pc.getValue().getLatestData());
-        assertEquals(atDefault, pc.isValueAtDefault());
+        Assert.assertEquals(data, pc.getValue().getLatestData());
+        Assert.assertEquals(atDefault, pc.isValueAtDefault());
         expectNoFrames();
 
         sendFrame(frameOn);
-        assertEquals(data, pc.getValue().getLatestData());
-        assertEquals(atDefault, pc.isValueAtDefault());
+        Assert.assertEquals(data, pc.getValue().getLatestData());
+        Assert.assertEquals(atDefault, pc.isValueAtDefault());
         expectNoFrames();
 
         sendFrame(frameOff);
-        assertEquals(data, pc.getValue().getLatestData());
-        assertEquals(atDefault, pc.isValueAtDefault());
+        Assert.assertEquals(data, pc.getValue().getLatestData());
+        Assert.assertEquals(atDefault, pc.isValueAtDefault());
         expectNoFrames();
     }
 
@@ -163,26 +181,31 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
                 ":X195B4333N0504030201000709;");
     }
 
+    @Test
     public void testHandleConsumerIdentified() throws Exception {
         createWithDefaults();
         helperInputSetClear(":X194C4333N0504030201000708;", ":X194C5333N0504030201000708;");
     }
 
+    @Test
     public void testHandleConsumerIdentifiedOff() throws Exception {
         createWithDefaults();
         helperInputSetClear(":X194C5333N0504030201000709;", ":X194C4333N0504030201000709;");
     }
 
+    @Test
     public void testHandleConsumerIdentifiedOnOff() throws Exception {
         createWithDefaults();
         helperInputSetClear(":X194C4333N0504030201000708;", ":X194C4333N0504030201000709;");
     }
 
+    @Test
     public void testHandleProducerConsumerEventReport() throws Exception {
         createWithDefaults();
         helperInputSetClear(":X195B4333N0504030201000708;", ":X195B4333N0504030201000709;");
     }
 
+    @Test
     public void testHandleIdentifyEventsUnknown() throws Exception {
         createWithDefaults();
         sendFrame(":X19968444N0333;");
@@ -193,6 +216,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectFrame(":X194C7333N0504030201000709;");
     }
 
+    @Test
     public void testHandleIdentifyEventsKnown() throws Exception {
         createWithDefaults();
         sendFrame(":X194C5333N0504030201000709;");
@@ -216,6 +240,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectNoFrames();
     }
 
+    @Test
     public void testGenerateEvents() throws Exception {
         createWithDefaults();
         VersionedValue<Boolean> v = pc.getValue();
@@ -246,6 +271,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectNoFrames();
     }
 
+    @Test
     public void testGenerateUnknown() throws Exception {
         pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_PRODUCER | BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.SEND_UNKNOWN_EVENT_IDENTIFIED);
 
@@ -287,6 +313,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectNoFrames();
     }
 
+    @Test
     public void testProducerOnlyNoListen() throws Exception {
         pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_PRODUCER);
         // startup
@@ -313,19 +340,19 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectFrame(":X195B4333N0504030201000709;");
         // now a query tell us different
         expectNoFrames();
-        assertFalse(pc.isValueAtDefault());
+        Assert.assertFalse(pc.isValueAtDefault());
 
         sendFrameAndExpectResult( //
                 ":X19914444N0504030201000708;",
                 ":X19545333N0504030201000708;");
         expectNoFrames();
 
-        assertFalse(v.getLatestData());
+        Assert.assertFalse(v.getLatestData());
         v.set(true);
         expectFrame(":X195B4333N0504030201000708;");
         expectNoFrames();
 
-        assertTrue(v.getLatestData());
+        Assert.assertTrue(v.getLatestData());
 
         helperInputNoChange(":X19545333N0504030201000708;",
                 ":X19545333N0504030201000709;");
@@ -333,6 +360,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
                 ":X195B4333N0504030201000709;");
     }
 
+    @Test
     public void testConsumerOnlyNoListen() throws Exception {
         pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_CONSUMER);
         expectFrame(":X194C7333N0504030201000708;");
@@ -362,6 +390,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectFrame(":X194C4333N0504030201000709;");
     }
 
+    @Test
     public void testConsumerOnlyListenFirst() throws Exception {
         pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.QUERY_AT_STARTUP);
 
@@ -380,11 +409,11 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectFrame(":X194C7333N0504030201000709;");
         expectNoFrames();
 
-        assertTrue(pc.isValueAtDefault());
+        Assert.assertTrue(pc.isValueAtDefault());
         sendFrame(":X19544333N0504030201000708;");
         expectNoFrames();
-        assertFalse(pc.isValueAtDefault());
-        assertTrue(pc.getValue().getLatestData());
+        Assert.assertFalse(pc.isValueAtDefault());
+        Assert.assertTrue(pc.getValue().getLatestData());
 
         sendFrame(":X19968444N0333;");
         expectFrame(":X194C4333N0504030201000708;");
@@ -403,6 +432,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         helperNotProducing();
     }
 
+    @Test
     public void testConsumerOnlyListenFirstSetState() throws Exception {
         pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.QUERY_AT_STARTUP);
 
@@ -422,6 +452,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
                 ":X194C5333N0504030201000709;");
     }
 
+    @Test
     public void testConsumerOnlyListenAlways() throws Exception {
         pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.LISTEN_EVENT_IDENTIFIED | BitProducerConsumer.LISTEN_INVALID_STATE);
 
@@ -438,6 +469,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
                 ":X19544333N0504030201000709;");
     }
 
+    @Test
     public void testListenNoInvalid() throws Exception {
         pc = new BitProducerConsumer(iface, onEvent, offEvent, BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.LISTEN_EVENT_IDENTIFIED);
 
@@ -455,6 +487,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
                 ":X194C5333N0504030201000708;");
     }
 
+    @Test
     public void testOneEventNull() throws Exception {
         pc = new BitProducerConsumer(iface, onEvent, pc.nullEvent, BitProducerConsumer.IS_PRODUCER | BitProducerConsumer.IS_CONSUMER | BitProducerConsumer.LISTEN_EVENT_IDENTIFIED |
                 BitProducerConsumer.LISTEN_INVALID_STATE);
@@ -496,6 +529,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
 
     }
 
+    @Test
     public void testSendQuery() {
         createWithDefaults();
 
@@ -507,6 +541,7 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectNoFrames();
     }
 
+    @Test
     public void testResetToDefault() {
         createWithDefaults();
         MockVersionedValueListener<Boolean> listener = new MockVersionedValueListener<>(pc
@@ -585,12 +620,6 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
                 ":X194C5333N0504030201000708;");
     }
 
-        @Override
-    protected void tearDown() throws Exception {
-        expectNoFrames();
-        super.tearDown();
-    }
-
     private void createWithDefaults() {
         pc = new BitProducerConsumer(iface, onEvent, offEvent, false);
         expectFrame(":X19547333N0504030201000708;", times(1));
@@ -605,8 +634,14 @@ public class BitProducerConsumerTest extends org.openlcb.InterfaceTestBase {
         expectNoFrames();
     }
 
-    @Override
+    @Before
     public void setUp() {
+        super.setUp();
         aliasMap.insert(0x444, new NodeID(new byte[]{1,2,3,1,2,3}));
+    }
+
+    @After
+    public void tearDown() {
+        super.tearDown();
     }
 }

--- a/test/org/openlcb/implementations/DatagramMeteringBufferTest.java
+++ b/test/org/openlcb/implementations/DatagramMeteringBufferTest.java
@@ -209,6 +209,9 @@ public class DatagramMeteringBufferTest extends TestCase {
         Assert.assertTrue(messagesForwarded.get(1).equals(datagram2));        
     }
 
+    public void tearDown() {
+        buffer.dispose(); 
+    }
     
     // from here down is testing infrastructure
     

--- a/test/org/openlcb/implementations/DatagramMeteringBufferTest.java
+++ b/test/org/openlcb/implementations/DatagramMeteringBufferTest.java
@@ -33,8 +33,9 @@ public class DatagramMeteringBufferTest extends TestCase {
     
     DatagramAcknowledgedMessage replyOK;
     DatagramRejectedMessage replyNAKresend;
-    
-    public void setUp() {
+
+    @Override    
+    protected void setUp() {
 
         repliesReturned1 = new java.util.ArrayList<Message>();
         replyConnection1 = new AbstractConnection(){
@@ -209,7 +210,8 @@ public class DatagramMeteringBufferTest extends TestCase {
         Assert.assertTrue(messagesForwarded.get(1).equals(datagram2));        
     }
 
-    public void tearDown() {
+    @Override
+    protected void tearDown() {
         buffer.dispose(); 
     }
     

--- a/test/org/openlcb/implementations/DatagramMeteringBufferTest.java
+++ b/test/org/openlcb/implementations/DatagramMeteringBufferTest.java
@@ -213,6 +213,17 @@ public class DatagramMeteringBufferTest extends TestCase {
     @Override
     protected void tearDown() {
         buffer.dispose(); 
+        repliesReturned1 = null; 
+        replyConnection1 = null;
+        messagesForwarded = null;
+        forwardConnection = null;
+        data = null;
+        buffer = null;
+        returnConnection = null;
+        datagram1 = null;
+        datagram2 = null;                                        
+        replyOK = null;
+        replyNAKresend = null;
     }
     
     // from here down is testing infrastructure

--- a/test/org/openlcb/implementations/DatagramMeteringBufferTest.java
+++ b/test/org/openlcb/implementations/DatagramMeteringBufferTest.java
@@ -66,10 +66,6 @@ public class DatagramMeteringBufferTest extends TestCase {
         replyNAKresend = new DatagramRejectedMessage(farID, hereID, 0x210);
     }
 
-    public void tearDown(){
-       buffer.terminateThreads();
-    }
-    
     public void testSend() {
         buffer.put(datagram1, replyConnection1);
 

--- a/test/org/openlcb/implementations/FakeMemoryConfigurationServiceTest.java
+++ b/test/org/openlcb/implementations/FakeMemoryConfigurationServiceTest.java
@@ -19,6 +19,7 @@ public class FakeMemoryConfigurationServiceTest {
         OlcbInterface oi = new FakeOlcbInterface();
         FakeMemoryConfigurationService t = new FakeMemoryConfigurationService(oi);
         Assert.assertNotNull("exists",t);
+        t.dispose();
         oi.dispose();
     }
 

--- a/test/org/openlcb/implementations/FakeMemoryConfigurationServiceTest.java
+++ b/test/org/openlcb/implementations/FakeMemoryConfigurationServiceTest.java
@@ -16,14 +16,10 @@ public class FakeMemoryConfigurationServiceTest {
 
     @Test
     public void testCTor() {
-        NodeID nodeID = new NodeID(new byte[]{1,2,3,4,5,6});
-        Connection testConnection = new AbstractConnection(){
-            public void put(Message msg, Connection node) {
-            }
-        };
-        OlcbInterface oi = new OlcbInterface(nodeID,testConnection);
+        OlcbInterface oi = new FakeOlcbInterface();
         FakeMemoryConfigurationService t = new FakeMemoryConfigurationService(oi);
         Assert.assertNotNull("exists",t);
+        oi.dispose();
     }
 
     // The minimal setup for log4J

--- a/test/org/openlcb/implementations/MemoryConfigSpaceRetrieverTest.java
+++ b/test/org/openlcb/implementations/MemoryConfigSpaceRetrieverTest.java
@@ -24,8 +24,9 @@ public class MemoryConfigSpaceRetrieverTest {
         OlcbInterface oi = new OlcbInterface(nodeID,testConnection);
         MemoryConfigSpaceRetriever t = new MemoryConfigSpaceRetriever(nodeID,oi,42,null);
         Assert.assertNotNull("exists",t);
+        oi.dispose();
     }
-
+ 
     // The minimal setup for log4J
     @Before
     public void setUp() {

--- a/test/org/openlcb/implementations/MemoryConfigurationServiceInterfaceTest.java
+++ b/test/org/openlcb/implementations/MemoryConfigurationServiceInterfaceTest.java
@@ -918,6 +918,8 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
     @After
     public void tearDown() {
         super.tearDown();
+        hereID = null;
+        farID = null;
     }
 
 }

--- a/test/org/openlcb/implementations/MemoryConfigurationServiceInterfaceTest.java
+++ b/test/org/openlcb/implementations/MemoryConfigurationServiceInterfaceTest.java
@@ -1,11 +1,16 @@
 package org.openlcb.implementations;
 
-import junit.framework.AssertionFailedError;
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.openlcb.DatagramAcknowledgedMessage;
 import org.openlcb.DatagramMessage;
 import org.openlcb.DatagramRejectedMessage;
@@ -36,12 +41,17 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  */
 public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
 
-    NodeID hereID = iface.getNodeId();
-    NodeID farID = new NodeID(new byte[]{1,2,3,4,5,7});
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
 
+    NodeID hereID;
+    NodeID farID;
+
+    @Test
     public void testCtorViaSetup() {
     }
 
+    @Test
     public void testSimpleWrite() {
         int space = 0xFD;
         long address = 0x12345678;
@@ -63,6 +73,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         verifyNoMoreInteractions(hnd);
     }
 
+    @Test
     public void testSimpleWriteError() {
         int space = 0xFD;
         long address = 0x12345678;
@@ -84,6 +95,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         verifyNoMoreInteractions(hnd);
     }
 
+    @Test
     public void testDelayedWrite() {
         int space = 0xFD;
         long address = 0x12345678;
@@ -111,6 +123,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         verifyNoMoreInteractions(hnd);
     }
 
+    @Test
     public void testDelayedWriteError() {
         int space = 0xFD;
         long address = 0x12345678;
@@ -138,6 +151,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         verifyNoMoreInteractions(hnd);
     }
 
+    @Test
     public void testManyWritesQueuesUp() {
         int space = MemoryConfigurationService.SPACE_CONFIG;
         long address = 0x12340078;
@@ -156,15 +170,15 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
                     new byte[]{(byte) i, 2}, mock);
 
             if (i > 0) {
-                assertEquals(i, iface.getMemoryConfigurationService().queuedRequests.get(0).size());
+                Assert.assertEquals(i, iface.getMemoryConfigurationService().queuedRequests.get(0).size());
                 MemoryConfigurationService.McsWriteMemo m = (MemoryConfigurationService
                         .McsWriteMemo) iface.getMemoryConfigurationService().queuedRequests.get
                         (0).getLast();
-                assertEquals(address + i * 256, m.address);
+               Assert.assertEquals(address + i * 256, m.address);
             }
         }
 
-        assertEquals(count - 1, iface.getMemoryConfigurationService().queuedRequests.get(0).size());
+        Assert.assertEquals(count - 1, iface.getMemoryConfigurationService().queuedRequests.get(0).size());
 
         for (int i = 0; i < count; ++i) {
             MemoryConfigurationService.McsWriteHandler hnd = hnds.get(i);
@@ -188,6 +202,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         expectNoMessages();
     }
 
+    @Test
     public void testSimpleRead() {
         int space = 0xFD;
         long address = 0x12345678;
@@ -215,6 +230,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         verifyNoMoreInteractions(hnd);
     }
 
+    @Test
     public void testTwoSimpleReadsInSequence() {
         int space = 0xFD;
         long address = 0x12345678;
@@ -300,6 +316,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         verifyNoMoreInteractions(hnd);
     }
 
+    @Test
     public void testReadWithTimeout() throws InterruptedException {
         int space = 0xFD;
         long address = 0x12345678;
@@ -346,6 +363,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
 
     }
 
+    @Test
     public void testReadWithTimeoutInterleaved() throws InterruptedException {
         int space = 0xFD;
         long address = 0x12345678;
@@ -424,6 +442,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         sendAnother(space, address+5);
     }
 
+    @Test
     public void testManyReadsInlinePrint() {
         final int space = 0xFD;
         final long address = 0x12345678;
@@ -471,6 +490,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         }
     }
 
+    @Test
     public void testManyReadsInline() {
         final int space = 0xFD;
         final long address = 0x12345678;
@@ -480,7 +500,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
                 .McsReadHandler.class, new Answer() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                throw new AssertionFailedError("Not stubbed invocation: " + invocationOnMock.toString());
+                throw new junit.framework.AssertionFailedError("Not stubbed invocation: " + invocationOnMock.toString());
             }
         });
         int count = 10;
@@ -527,6 +547,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         }
     }
 
+    @Test
     public void testSimpleReadFails() {
         int space = 0xFD;
         long address = 0x12345678;
@@ -554,6 +575,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         verifyNoMoreInteractions(hnd);
     }
 
+    @Test
     public void testSimpleReadFromSpace1() {
         int space = 0x1;
         long address = 0x12345678;
@@ -581,6 +603,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         verifyNoMoreInteractions(hnd);
     }
 
+    @Test
     public void testSimpleReadFromSpaceFB() {
         int space = 0xFB;
         long address = 0x12345678;
@@ -608,6 +631,7 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         verifyNoMoreInteractions(hnd);
     }
 
+    @Test
     public void testGetSpaceId() {
         boolean debugFrames = false;
 
@@ -629,16 +653,17 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
                 parsedMessages.addAll(l);
             }
         }
-        assertEquals(1, parsedMessages.size());
-        assertTrue(parsedMessages.get(0) instanceof DatagramMessage);
+        Assert.assertEquals(1, parsedMessages.size());
+        Assert.assertTrue(parsedMessages.get(0) instanceof DatagramMessage);
         DatagramMessage dg = (DatagramMessage) parsedMessages.get(0);
-        assertEquals("20 50 12 34 56 78 FB AA", Utilities.toHexSpaceString(dg.getData()));
+        Assert.assertEquals("20 50 12 34 56 78 FB AA", Utilities.toHexSpaceString(dg.getData()));
 
-        assertEquals(0xFB, dg.getData()[6]);
+        Assert.assertEquals(0xFB, dg.getData()[6]);
 
-        assertEquals(0xFB, MemoryConfigurationService.getSpaceFromPayload(dg.getData()));
+        Assert.assertEquals(0xFB, MemoryConfigurationService.getSpaceFromPayload(dg.getData()));
     }
 
+    @Test
     public void testTwoSimpleReadsInParallel() {
         int space = 0xFD;
         long address = 0x12345678;
@@ -683,8 +708,9 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         verifyNoMoreInteractions(hnd2);
     }
 
-
-/*
+    /*
+    @Test
+    @Ignore("commented out prior to JUnit 4")
     public void testConfigMemoIsRealClass() {
         MemoryConfigurationService.McsConfigMemo m20 =
             new MemoryConfigurationService.McsConfigMemo(farID);
@@ -702,6 +728,8 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
 
     }
 
+    @Test
+    @Ignore("commented out prior to JUnit 4")
     public void testGetConfig() {
         MemoryConfigurationService.McsConfigMemo memo =
             new MemoryConfigurationService.McsConfigMemo(farID) {
@@ -748,6 +776,8 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
 
     }
 
+    @Test
+    @Ignore("commented out prior to JUnit 4")
     public void testAddrSpaceMemoIsRealClass() {
         MemoryConfigurationService.McsAddrSpaceMemo m20 =
             new MemoryConfigurationService.McsAddrSpaceMemo(farID,0xFD);
@@ -768,6 +798,8 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
 
     }
 
+    @Test
+    @Ignore("commented out prior to JUnit 4")
     public void testGetAddrSpace1() {
         int space = 0xFD;
         MemoryConfigurationService.McsAddrSpaceMemo memo =
@@ -819,6 +851,9 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         Assert.assertTrue(flag);
 
     }
+
+    @Test
+    @Ignore("commented out prior to JUnit 4")
     public void testGetAddrSpace2() {
         int space = 0xFD;
         MemoryConfigurationService.McsAddrSpaceMemo memo =
@@ -870,24 +905,19 @@ public class MemoryConfigurationServiceInterfaceTest extends InterfaceTestBase {
         Assert.assertTrue(flag);
 
     }
-    */
-    // from here down is testing infrastructure
-
-    public MemoryConfigurationServiceInterfaceTest(String s) {
-        super(s);
+*/
+    @Before 
+    public void setUp() {
+        super.setUp();
+        hereID = iface.getNodeId();
+        farID = new NodeID(new byte[]{1,2,3,4,5,7});
         aliasMap.insert(0x987, farID);
         testWithCanFrameRendering = true;
     }
 
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {MemoryConfigurationServiceInterfaceTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
+    @After
+    public void tearDown() {
+        super.tearDown();
     }
 
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(MemoryConfigurationServiceInterfaceTest.class);
-        return suite;
-    }
 }

--- a/test/org/openlcb/implementations/MemoryConfigurationServiceTest.java
+++ b/test/org/openlcb/implementations/MemoryConfigurationServiceTest.java
@@ -21,7 +21,8 @@ public class MemoryConfigurationServiceTest extends TestCase {
     MemoryConfigurationService service;
     
     @Override
-    public void setUp() {
+    public void setUp() throws Exception {
+        super.setUp();
         messagesReceived = new java.util.ArrayList<Message>();
         flag = false;
         testConnection = new AbstractConnection(){

--- a/test/org/openlcb/implementations/MemoryConfigurationServiceTest.java
+++ b/test/org/openlcb/implementations/MemoryConfigurationServiceTest.java
@@ -35,6 +35,11 @@ public class MemoryConfigurationServiceTest extends TestCase {
         
         service = new MemoryConfigurationService(hereID, datagramService);
     }
+
+    @Override
+    protected void tearDown(){
+       service.dispose();
+    }
     
     
     

--- a/test/org/openlcb/implementations/throttle/RemoteTrainNodeCacheTest.java
+++ b/test/org/openlcb/implementations/throttle/RemoteTrainNodeCacheTest.java
@@ -110,4 +110,8 @@ public class RemoteTrainNodeCacheTest extends TestCase {
         fakeInterface = new FakeOlcbInterface();
         cache = new TrainNodeCache(fakeInterface);
     }
+
+    public void tearDown() {
+        fakeInterface.dispose();
+    }
 }

--- a/test/org/openlcb/implementations/throttle/ThrottleImplementationTest.java
+++ b/test/org/openlcb/implementations/throttle/ThrottleImplementationTest.java
@@ -36,6 +36,10 @@ public class ThrottleImplementationTest extends TestCase {
         store = new MimicNodeStore(testConnection, hereID);
     }
 
+    public void tearDown() {
+       store.dispose();
+    }
+
     public void testCtors() {
         new ThrottleImplementation(1234, true, store, service);
         new ThrottleImplementation(3, true, store, service);

--- a/test/org/openlcb/implementations/throttle/TractionThrottleTest.java
+++ b/test/org/openlcb/implementations/throttle/TractionThrottleTest.java
@@ -16,14 +16,10 @@ public class TractionThrottleTest {
 
     @Test
     public void testCTor() {
-        NodeID nodeID = new NodeID(new byte[]{1,2,3,4,5,6});
-        Connection testConnection = new AbstractConnection(){
-            public void put(Message msg, Connection node) {
-            }
-        };
-        OlcbInterface oi = new OlcbInterface(nodeID,testConnection);
+        OlcbInterface oi = new FakeOlcbInterface();
         TractionThrottle t = new TractionThrottle(oi);
         Assert.assertNotNull("exists",t);
+        oi.dispose();
     }
 
     // The minimal setup for log4J

--- a/test/org/openlcb/implementations/throttle/TrainNodeCacheTest.java
+++ b/test/org/openlcb/implementations/throttle/TrainNodeCacheTest.java
@@ -16,14 +16,10 @@ public class TrainNodeCacheTest {
 
     @Test
     public void testCTor() {
-        NodeID nodeID = new NodeID(new byte[]{1,2,3,4,5,6});
-        Connection testConnection = new AbstractConnection(){
-            public void put(Message msg, Connection node) {
-            }
-        };
-        OlcbInterface oi = new OlcbInterface(nodeID,testConnection);
+        OlcbInterface oi = new FakeOlcbInterface();
         TrainNodeCache t = new TrainNodeCache(oi);
         Assert.assertNotNull("exists",t);
+        oi.dispose();
     }
 
     // The minimal setup for log4J

--- a/test/org/openlcb/protocols/VerifyNodeIdHandlerTest.java
+++ b/test/org/openlcb/protocols/VerifyNodeIdHandlerTest.java
@@ -24,6 +24,7 @@ public class VerifyNodeIdHandlerTest {
         OlcbInterface oi = new OlcbInterface(nodeID,testConnection);
         VerifyNodeIdHandler t = new VerifyNodeIdHandler(nodeID,oi);
         Assert.assertNotNull("exists",t);
+        oi.dispose();
     }
 
     // The minimal setup for log4J

--- a/test/org/openlcb/swing/NodeSelectorTest.java
+++ b/test/org/openlcb/swing/NodeSelectorTest.java
@@ -47,7 +47,9 @@ public class NodeSelectorTest extends TestCase {
         
     }
     
-    public void tearDown() {}
+    public void tearDown() {
+       store.dispose();
+    }
             
     public void testCtor() {
         // test is really in setUp()

--- a/test/org/openlcb/swing/memconfig/MemConfigDescriptionPaneTest.java
+++ b/test/org/openlcb/swing/memconfig/MemConfigDescriptionPaneTest.java
@@ -73,6 +73,8 @@ public class MemConfigDescriptionPaneTest extends TestCase {
     
     public void tearDown() {
         //frame.setVisible(false);
+        store.dispose();
+        service.dispose();
     }
             
     public void testSetup() {

--- a/test/org/openlcb/swing/memconfig/MemConfigReadWritePaneTest.java
+++ b/test/org/openlcb/swing/memconfig/MemConfigReadWritePaneTest.java
@@ -65,6 +65,8 @@ public class MemConfigReadWritePaneTest extends TestCase {
     
     public void tearDown() {
         //frame.setVisible(false);
+        store.dispose();
+        service.dispose();
     }
             
     public void testSetup() {

--- a/test/org/openlcb/swing/networktree/NodeTreeRepTest.java
+++ b/test/org/openlcb/swing/networktree/NodeTreeRepTest.java
@@ -49,6 +49,7 @@ public class NodeTreeRepTest {
 
         NodeTreeRep t = new NodeTreeRep((MimicNodeStore.NodeMemo)list.toArray()[0],store,treeModel,loader);
         Assert.assertNotNull("exists",t);
+        store.dispose();
     }
 
     // The minimal setup for log4J

--- a/test/org/openlcb/swing/networktree/TreePaneTest.java
+++ b/test/org/openlcb/swing/networktree/TreePaneTest.java
@@ -92,6 +92,7 @@ public class TreePaneTest extends TestCase {
     
     public void tearDown() {
         frame.setVisible(false);
+        store.dispose();
     }
             
     public void testPriorMessage() {

--- a/test/org/openlcb/swing/networktree/TreePaneTest.java
+++ b/test/org/openlcb/swing/networktree/TreePaneTest.java
@@ -92,6 +92,7 @@ public class TreePaneTest extends TestCase {
     
     public void tearDown() {
         frame.setVisible(false);
+        pane.release();
         store.dispose();
     }
             

--- a/test/org/openlcb/swing/networktree/TreePaneTest.java
+++ b/test/org/openlcb/swing/networktree/TreePaneTest.java
@@ -94,6 +94,9 @@ public class TreePaneTest extends TestCase {
         frame.setVisible(false);
         pane.release();
         store.dispose();
+        store = null;
+        pane = null;
+        frame = null;
     }
             
     public void testPriorMessage() {

--- a/test/tools/cansim/CanSegmentTest.java
+++ b/test/tools/cansim/CanSegmentTest.java
@@ -24,7 +24,7 @@ public class CanSegmentTest extends TestCase {
         seg.add(sender);
         
         seg.send(new CanFrame(12), sender);
-        
+
     }
     
     boolean received = false;


### PR DESCRIPTION
Put most threads into a thread pool and allow those to be terminated.

This at least partly addresses #119.  There are still a large number of threads created during JMRI testing that I can't terminate, most of them are timer threads.

@balazsracz If you get a chance, can you try this to make sure I didn't break something.

Once this is merged in, we'll need to make another release.