### PR TITLE
catch IllegalStateException when attempting to add a timer task after shutdown.

### DIFF
--- a/src/org/openlcb/implementations/DatagramMeteringBuffer.java
+++ b/src/org/openlcb/implementations/DatagramMeteringBuffer.java
@@ -210,8 +210,13 @@ public class DatagramMeteringBuffer extends MessageDecoder {
                     timerExpired();
                 }
             };
-            timer.schedule(timerTask, timeoutMillis);
+            try {
+                timer.schedule(timerTask, timeoutMillis);
+            } catch( java.lang.IllegalStateException ise) {
+                logger.log(Level.WARNING, "Timer already canceled when starting timeout for datagram {0}", message != null ? message : " == null");
+            }
         }
+
         void endTimeout() {
             if (timerTask != null) timerTask.cancel();
             else logger.log(Level.INFO, "Found timer null for datagram {0}", message != null ? message : " == null");


### PR DESCRIPTION
This replaces the stack trace reported in #128 with a warning, but does not address any potential race conditions that lead to the stack trace being generated.