### PR TITLE
Work on test performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
-                <configuration>
+		<configuration>
+                    <forkCount>3</forkCount>
+		    <reuseForks>true</reuseForks>
                     <argLine>${argLine}</argLine>
                     <excludes>
                         <exclude>AllTest</exclude>

--- a/test/AllTest.java
+++ b/test/AllTest.java
@@ -30,7 +30,7 @@ public class AllTest extends TestCase {
         TestSuite suite = new TestSuite(AllTest.class);
         suite.addTest(tools.ToolsTest.suite());
         suite.addTest(new JUnit4TestAdapter(org.openlcb.PackageTest.class));
-        suite.addTest(scenarios.PackageTest.suite());
+        suite.addTest(new JUnit4TestAdapter(scenarios.PackageTest.class));
         return suite;
     }
 }

--- a/test/AllTest.java
+++ b/test/AllTest.java
@@ -29,9 +29,8 @@ public class AllTest extends TestCase {
     public static Test suite() {
         TestSuite suite = new TestSuite(AllTest.class);
         suite.addTest(tools.ToolsTest.suite());
-        suite.addTest(org.openlcb.PackageTest.suite());
+        suite.addTest(new JUnit4TestAdapter(org.openlcb.PackageTest.class));
         suite.addTest(scenarios.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(org.openlcb.protocols.PackageTest.class));       
         return suite;
     }
 }

--- a/test/org/openlcb/EventIDTest.java
+++ b/test/org/openlcb/EventIDTest.java
@@ -1,15 +1,14 @@
 package org.openlcb;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
  * @version $Revision$
  */
-public class EventIDTest extends TestCase {
+public class EventIDTest {
+
+    @Test
     public void testNullArg() {
         try {
             new EventID((byte[])null);
@@ -17,6 +16,7 @@ public class EventIDTest extends TestCase {
         Assert.fail("Should have thrown exception");
     }
 
+    @Test
     public void testTooLongArg() {
         try {
             new EventID(new byte[]{1,2,3,4,5,6,7,8,9});
@@ -24,6 +24,7 @@ public class EventIDTest extends TestCase {
         Assert.fail("Should have thrown exception");
     }
 
+    @Test
     public void testTooShortArg() {
         try {
             new EventID(new byte[]{1,2,3,4,5,6,7});
@@ -31,10 +32,12 @@ public class EventIDTest extends TestCase {
         Assert.fail("Should have thrown exception");
     }
     
+    @Test
     public void testOKLengthArg() {
         new EventID(new byte[]{1,2,3,4,5,6,7,8});
     }
     
+    @Test
     public void testEqualsSame() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         EventID e2 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
@@ -42,6 +45,7 @@ public class EventIDTest extends TestCase {
         Assert.assertEquals("hashcodes equal when equal",e1.hashCode(),e2.hashCode());
     }
     
+    @Test
     public void testStringArgDotted() {
         EventID e1 = new EventID("1.2.3.4.5.6.7.8");
         EventID e2 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
@@ -49,6 +53,7 @@ public class EventIDTest extends TestCase {
         
     }
 
+    @Test
     public void testStringArgSpaces() {
         EventID e1 = new EventID("1 2 3 4 5 6 7 8");
         EventID e2 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
@@ -56,6 +61,7 @@ public class EventIDTest extends TestCase {
         
     }
 
+    @Test
     public void testAltCtor() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         
@@ -65,6 +71,7 @@ public class EventIDTest extends TestCase {
         Assert.assertTrue(e1.equals(e2));
     }
     
+    @Test
     public void testEqualsCastSame() {
         Object e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         EventID e2 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
@@ -72,12 +79,14 @@ public class EventIDTest extends TestCase {
         Assert.assertEquals("hashcodes equal when equal",e1.hashCode(),e2.hashCode());
     }
     
+    @Test
     public void testEqualsSelf() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         Assert.assertTrue(e1.equals(e1));
         Assert.assertEquals("hashcodes equal when equal",e1.hashCode(),e1.hashCode());
     }
     
+    @Test
     public void testEqualsCastSelf() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         Object e2 = e1;
@@ -85,59 +94,46 @@ public class EventIDTest extends TestCase {
         Assert.assertEquals("hashcodes equal when equal",e1.hashCode(),e1.hashCode());
     }
     
+    @Test
     public void testNotEquals() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         EventID e2 = new EventID(new byte[]{1,3,3,4,5,6,7,8});
         Assert.assertTrue(!e1.equals(e2));
     }
     
+    @Test
     public void testNotEqualsOtherType() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         Object e2 = new Object();
         Assert.assertTrue(!e1.equals(e2));
     }
 
+    @Test
     public void testNodesAreNotEvents() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         NodeID e2 = new NodeID(new byte[]{1,2,3,4,5,6});
         Assert.assertTrue(!e1.equals(e2));
     }
 
+    @Test
     public void testOutputFormat() {
         EventID e1 = new EventID(new byte[]{0,0,1,0x10,0x13,0x0D,(byte)0xD0,(byte)0xAB});
         Assert.assertEquals(e1.toString(), "EventID:00.00.01.10.13.0D.D0.AB");
     }
 
+    @Test
     public void testToLong() {
         EventID e1 = new EventID(new byte[]{0,0,0,0,0,0,0,0});
-        assertEquals(0L, e1.toLong());
-        assertEquals(1L, new EventID(new byte[]{0,0,0,0,0,0,0,1}).toLong());
-        assertEquals(256L, new EventID(new byte[]{0,0,0,0,0,0,1,0}).toLong());
-        assertEquals(1L<<32, new EventID(new byte[]{0,0,0,1,0,0,0,0}).toLong());
-        assertEquals(150L<<32, new EventID(new byte[]{0,0,0,(byte)150,0,0,0,0}).toLong());
+        Assert.assertEquals(0L, e1.toLong());
+        Assert.assertEquals(1L, new EventID(new byte[]{0,0,0,0,0,0,0,1}).toLong());
+        Assert.assertEquals(256L, new EventID(new byte[]{0,0,0,0,0,0,1,0}).toLong());
+        Assert.assertEquals(1L<<32, new EventID(new byte[]{0,0,0,1,0,0,0,0}).toLong());
+        Assert.assertEquals(150L<<32, new EventID(new byte[]{0,0,0,(byte)150,0,0,0,0}).toLong());
 
-        assertEquals(127L<<56, new EventID(new byte[]{127,0,0,0,0,0,0,0}).toLong());
-        assertEquals(-1L, new EventID(new byte[]{(byte)0xff,(byte)0xff,(byte)0xff,(byte)0xff,
+        Assert.assertEquals(127L<<56, new EventID(new byte[]{127,0,0,0,0,0,0,0}).toLong());
+        Assert.assertEquals(-1L, new EventID(new byte[]{(byte)0xff,(byte)0xff,(byte)0xff,(byte)0xff,
                 (byte)0xff,(byte)0xff,(byte)0xff,(byte)0xff}).toLong());
-        assertEquals(-2L, new EventID(new byte[]{(byte)0xff,(byte)0xff,(byte)0xff,(byte)0xff,
+        Assert.assertEquals(-2L, new EventID(new byte[]{(byte)0xff,(byte)0xff,(byte)0xff,(byte)0xff,
                 (byte)0xff,(byte)0xff,(byte)0xff,(byte)0xfe}).toLong());
-    }
-
-    // from here down is testing infrastructure
-    
-    public EventIDTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {EventIDTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(EventIDTest.class);
-        return suite;
     }
 }

--- a/test/org/openlcb/GatewayTest.java
+++ b/test/org/openlcb/GatewayTest.java
@@ -1,23 +1,23 @@
 package org.openlcb;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
  * @version $Revision$
  */
-public class GatewayTest extends TestCase {
+public class GatewayTest {
+
     protected Gateway getGateway() {
         return new Gateway();
     }
-    
+
+    @Test    
     public void testCtor() {
         getGateway();
     }
 
+    @Test    
     public void testGet() {
         g = getGateway();
         Connection cE = g.getEastConnection();
@@ -55,6 +55,7 @@ public class GatewayTest extends TestCase {
         cW = g.getWestConnection();
     }
 
+    @Test    
     public void testEastToWest() {
         buildGateway();
         Message m = new Message(new NodeID(new byte[]{1,2,3,4,5,6}))
@@ -72,6 +73,7 @@ public class GatewayTest extends TestCase {
         resultW = false;
     }
     
+    @Test    
     public void testWestToEast() {
         buildGateway();
         Message m = new Message(new NodeID(new byte[]{1,2,3,4,5,6}))
@@ -89,21 +91,4 @@ public class GatewayTest extends TestCase {
         resultW = false;
     }
         
-    // from here down is testing infrastructure
-    
-    public GatewayTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {GatewayTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(GatewayTest.class);
-        return suite;
-    }
 }

--- a/test/org/openlcb/LearnEventMessageTest.java
+++ b/test/org/openlcb/LearnEventMessageTest.java
@@ -1,17 +1,13 @@
 package org.openlcb;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
-public class LearnEventMessageTest extends TestCase {
-    boolean result;
-    
+public class LearnEventMessageTest {
+   
+    @Test	
     public void testEqualsSame() {
         Message m1 = new LearnEventMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}),
@@ -23,6 +19,7 @@ public class LearnEventMessageTest extends TestCase {
         Assert.assertTrue(m1.equals(m2));
     }
 
+    @Test	
     public void testNotEqualsDifferentNode() {
         Message m1 = new LearnEventMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}),
@@ -34,6 +31,7 @@ public class LearnEventMessageTest extends TestCase {
         Assert.assertTrue( ! m1.equals(m2));
     }
 
+    @Test	
     public void testNotEqualsDifferentEvent() {
         Message m1 = new LearnEventMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}),
@@ -45,6 +43,8 @@ public class LearnEventMessageTest extends TestCase {
         Assert.assertTrue( ! m1.equals(m2));
     }
 
+    private boolean result;
+    @Test	
     public void testHandling() {
         result = false;
         Node n = new Node(){
@@ -62,21 +62,4 @@ public class LearnEventMessageTest extends TestCase {
         Assert.assertTrue(result);
     }
     
-    // from here down is testing infrastructure
-    
-    public LearnEventMessageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {LearnEventMessageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(LearnEventMessageTest.class);
-        return suite;
-    }
 }

--- a/test/org/openlcb/MessageDecoderTest.java
+++ b/test/org/openlcb/MessageDecoderTest.java
@@ -1,34 +1,15 @@
 package org.openlcb;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
  * @version $Revision$
  */
-public class MessageDecoderTest extends TestCase {
+public class MessageDecoderTest {
+
+    @Test
     public void testCtor() {
         new MessageDecoder();
-    }
-    
-    // from here down is testing infrastructure
-    
-    public MessageDecoderTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {MessageDecoderTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(MessageDecoderTest.class);
-        return suite;
     }
 }

--- a/test/org/openlcb/MimicNodeStoreTest.java
+++ b/test/org/openlcb/MimicNodeStoreTest.java
@@ -1,9 +1,6 @@
 package org.openlcb;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 import java.beans.PropertyChangeEvent;
 import java.util.Collection;
@@ -13,7 +10,7 @@ import java.beans.PropertyChangeListener;
  * @author  Bob Jacobsen   Copyright 2012
  * @version $Revision$
  */
-public class MimicNodeStoreTest extends TestCase {
+public class MimicNodeStoreTest {
     MimicNodeStore store = null;
     
     NodeID nid1 = new NodeID(new byte[]{1,3,3,4,5,6});
@@ -38,7 +35,8 @@ public class MimicNodeStoreTest extends TestCase {
     };
     
     NodeID src = new NodeID(new byte[]{1,2,3,4,5,6});
-                                   
+
+    @Before    
     public void setUp() {
         store = new MimicNodeStore(connection, src);
         lastMessage = null;
@@ -49,41 +47,50 @@ public class MimicNodeStoreTest extends TestCase {
         listenerFired = false;
     }
 
-    @Override
-    protected void tearDown() {
+    @After
+    public void tearDown() {
        store.dispose();
+       store = null;
+       listener = null;
     }
 
+    @Test
     public void testCtor() {
         Assert.assertNotNull(store);
     }
     
+    @Test
     public void testListExists() {
         Collection<MimicNodeStore.NodeMemo> list = store.getNodeMemos();
         Assert.assertNotNull(list);        
     }
 
+    @Test
     public void testListInitiallyEmpty() {
         Collection<MimicNodeStore.NodeMemo> list = store.getNodeMemos();
         Assert.assertTrue(list.size()==0);        
     }
     
+    @Test
     public void testAcceptsMessage() {
         store.put(pim1,null);
     }
     
+    @Test
     public void testMessageAddsToList() {
         store.put(pim1,null);
         Collection<MimicNodeStore.NodeMemo> list = store.getNodeMemos();
         Assert.assertTrue(list.size()==1);
     }
     
+    @Test
     public void testMessageMemoKnowsNodeID() {
         store.put(pim1,null);
         Collection<MimicNodeStore.NodeMemo> list = store.getNodeMemos();
         Assert.assertEquals(list.iterator().next().getNodeID(), nid1);
     }
     
+    @Test
     public void testHandleMultipleNodes() {
         store.put(pim1,null);
         store.put(pim2,null);
@@ -91,6 +98,7 @@ public class MimicNodeStoreTest extends TestCase {
         Assert.assertTrue(list.size()==2);
     }
     
+    @Test
     public void testHandleMultipleMessagesFromNode() {
         store.put(pim1,null);
         store.put(pim1,null);
@@ -98,6 +106,7 @@ public class MimicNodeStoreTest extends TestCase {
         Assert.assertTrue(list.size()==1);
     }
     
+    @Test
     public void testNoDefaultProtocolInfo() {
         store.put(pim1,null);
         Collection<MimicNodeStore.NodeMemo> list = store.getNodeMemos();
@@ -106,6 +115,7 @@ public class MimicNodeStoreTest extends TestCase {
         Assert.assertNotNull(memo.getProtocolIdentification());
     }
 
+    @Test
     public void testProtocolInfoAvailableFromNode() {
         store.put(pim1,null);
         Collection<MimicNodeStore.NodeMemo> list = store.getNodeMemos();
@@ -115,6 +125,7 @@ public class MimicNodeStoreTest extends TestCase {
         Assert.assertNotNull(memo.getProtocolIdentification());
     }
     
+    @Test
     public void testForNotificationOfNode() {
         store.addPropertyChangeListener(
             new PropertyChangeListener(){
@@ -131,6 +142,7 @@ public class MimicNodeStoreTest extends TestCase {
         
     }
 
+    @Test
     public void testForNotificationOfOnlyOneNode() {
         store.put(pim1,null);
 
@@ -152,6 +164,7 @@ public class MimicNodeStoreTest extends TestCase {
         
     }
 
+    @Test
     public void testForNotificationOfProtocolIdent() {
         store.addPropertyChangeListener(listener);
         store.put(pim1,null);
@@ -159,6 +172,7 @@ public class MimicNodeStoreTest extends TestCase {
         Assert.assertTrue(listenerFired);
     }
     
+    @Test
     public void testNoDefaultSimpleInfo() {
         store.put(pim1,null);
         Collection<MimicNodeStore.NodeMemo> list = store.getNodeMemos();
@@ -167,6 +181,7 @@ public class MimicNodeStoreTest extends TestCase {
         Assert.assertNotNull(memo.getSimpleNodeIdent());
     }
 
+    @Test
     public void testSimpleInfoAvailableFromNode() {
         store.put(pim1,null);
         Collection<MimicNodeStore.NodeMemo> list = store.getNodeMemos();
@@ -178,6 +193,7 @@ public class MimicNodeStoreTest extends TestCase {
         Assert.assertEquals("abc", memo.getSimpleNodeIdent().getMfgName());
     }
 
+    @Test
     public void testSimpleInfoRetry() {
         store.put(pim1,null);
         Collection<MimicNodeStore.NodeMemo> list = store.getNodeMemos();
@@ -190,6 +206,7 @@ public class MimicNodeStoreTest extends TestCase {
         Assert.assertEquals(lastMessage, new SimpleNodeIdentInfoRequestMessage(src, nid1) );
     }
     
+    @Test
     public void testFindNodeNotPresent() {
         MimicNodeStore.NodeMemo retval = store.findNode(nid1);
 
@@ -198,6 +215,7 @@ public class MimicNodeStoreTest extends TestCase {
         
     }
     
+    @Test
     public void testFindNodePresent() {
         store.put(pim1,null);
 
@@ -208,11 +226,12 @@ public class MimicNodeStoreTest extends TestCase {
         
     }
 
+    @Test
     public void testRefresh() {
         store.put(pim1,null);
         store.put(pim2,null);
-        assertNotNull(store.findNode(nid1));
-        assertNotNull(store.findNode(nid2));
+        Assert.assertNotNull(store.findNode(nid1));
+        Assert.assertNotNull(store.findNode(nid2));
 
         // Adds a dummy listener to test callbacks.
         class MyListener implements PropertyChangeListener {
@@ -228,34 +247,17 @@ public class MimicNodeStoreTest extends TestCase {
         store.refresh();
 
         // There is a side effect of a callback to clear everything.
-        assertNotNull(l.lastEvent);
-        assertEquals(MimicNodeStore.CLEAR_ALL_NODES,l.lastEvent.getPropertyName());
+        Assert.assertNotNull(l.lastEvent);
+        Assert.assertEquals(MimicNodeStore.CLEAR_ALL_NODES,l.lastEvent.getPropertyName());
 
         // And a verify node ID message going out.
-        assertNotNull(lastMessage);
-        assertTrue(lastMessage instanceof VerifyNodeIDNumberMessage);
+        Assert.assertNotNull(lastMessage);
+        Assert.assertTrue(lastMessage instanceof VerifyNodeIDNumberMessage);
 
         // As well as the node tree being clear now.
-        assertEquals(0, store.getNodeMemos().size());
-        assertNull(store.findNode(nid1));
-        assertNull(store.findNode(nid2));
+        Assert.assertEquals(0, store.getNodeMemos().size());
+        Assert.assertNull(store.findNode(nid1));
+        Assert.assertNull(store.findNode(nid2));
     }
 
-    // from here down is testing infrastructure
-    
-    public MimicNodeStoreTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {MimicNodeStoreTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(MimicNodeStoreTest.class);
-        return suite;
-    }
 }

--- a/test/org/openlcb/NodeIDTest.java
+++ b/test/org/openlcb/NodeIDTest.java
@@ -1,15 +1,14 @@
 package org.openlcb;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
  * @version $Revision$
  */
-public class NodeIDTest extends TestCase {
+public class NodeIDTest {
+
+    @Test
     public void testNullArg() {
         try {
             new NodeID((byte[])null);
@@ -17,11 +16,13 @@ public class NodeIDTest extends TestCase {
         Assert.fail("Should have thrown exception");
     }
 
+    @Test
     public void testTooLongArg() {
         // shouldn't throw, just takes 1st part
         new NodeID(new byte[]{1,2,3,4,5,6,7});
     }
 
+    @Test
     public void testTooShortArg() {
         try {
             new NodeID(new byte[]{1,2,3,4,5});
@@ -29,10 +30,12 @@ public class NodeIDTest extends TestCase {
         Assert.fail("Should have thrown exception");
     }
     
+    @Test
     public void testOKArg() {
         new NodeID(new byte[]{1,2,3,4,5,6});
     }
     
+    @Test
     public void testNullStringArg() {
         try {
             new NodeID((String)null);
@@ -40,11 +43,13 @@ public class NodeIDTest extends TestCase {
         Assert.fail("Should have thrown exception");
     }
 
+    @Test
     public void testTooLongStringArg() {
         // shouldn't throw, just takes 1st part
         new NodeID("1.2.3.4.5.6.7");
     }
 
+    @Test
     public void testTooShortStringArg() {
         try {
             new NodeID("1.2.3.4.5");
@@ -52,57 +57,67 @@ public class NodeIDTest extends TestCase {
         Assert.fail("Should have thrown exception");
     }
     
+    @Test
     public void testOKStringArg() {
         new NodeID("1.2.3.4.5.6");
     }
     
+    @Test
     public void testEqualsSame() {
         NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6});
         NodeID e2 = new NodeID(new byte[]{1,2,3,4,5,6});
         Assert.assertTrue(e1.equals(e2));
     }
     
+    @Test
     public void testEqualsSameString() {
         NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6});
         NodeID e2 = new NodeID("1.2.3.4.5.6");
         Assert.assertTrue(e1.equals(e2));
     }
     
+    @Test
     public void testEqualsCastSame() {
         Object e1 = new NodeID(new byte[]{1,2,3,4,5,6});
         NodeID e2 = new NodeID(new byte[]{1,2,3,4,5,6});
         Assert.assertTrue(e1.equals(e2));
     }
     
+    @Test
     public void testEqualsSelf() {
         NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6});
         Assert.assertTrue(e1.equals(e1));
     }
     
+    @Test
     public void testEqualsCastSelf() {
         NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6});
         Object e2 = e1;
         Assert.assertTrue(e1.equals(e2));
     }
     
+    @Test
     public void testNotEquals() {
         NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6});
         NodeID e2 = new NodeID(new byte[]{1,3,3,4,5,6});
         Assert.assertTrue(!e1.equals(e2));
     }
     
+    @Test
     public void testNotEqualsOtherType() {
         NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6});
         Object e2 = new Object();
         Assert.assertTrue(!e1.equals(e2));
     }
 
+    @Test
     public void testNodesAreNotEvents() {
         NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6});
         EventID e2 = new EventID(new byte[]{1,0,0,0,0,0,1,0});
         Assert.assertTrue(!e1.equals(e2));
     }
 
+    @Test
     public void testGetContents() {
         NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6});
         byte[] contents;
@@ -118,6 +133,7 @@ public class NodeIDTest extends TestCase {
         Assert.assertTrue(contents[5] == 6);
     }
 
+    @Test
     public void testImmutable() {
         NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6});
         byte[] contents;
@@ -135,26 +151,10 @@ public class NodeIDTest extends TestCase {
         Assert.assertTrue(contents[5] == 6);
     }
 
+    @Test
     public void testOutputFormat() {
         NodeID e1 = new NodeID(new byte[]{1,0x10,0x13,0x0D,(byte)0xD0,(byte)0xAB});
         Assert.assertEquals("01.10.13.0D.D0.AB", e1.toString());
     }
 
-   // from here down is testing infrastructure
-    
-    public NodeIDTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {NodeIDTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(NodeIDTest.class);
-        return suite;
-    }
 }

--- a/test/org/openlcb/PackageTest.java
+++ b/test/org/openlcb/PackageTest.java
@@ -1,107 +1,66 @@
 package org.openlcb;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.framework.JUnit4TestAdapter;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        UtilitiesTest.class,
+        VersionTest.class,
+        EventIDTest.class,
+        NodeIDTest.class,
+        MessageTypeIdentifierTest.class,
+        MessageTest.class,
+        MessageDecoderTest.class,
+        NodeTest.class,
+        // specific message types (uses Node, IDs)
+        InitializationCompleteMessageTest.class,
+        OptionalIntRejectedMessageTest.class,
+        VerifiedNodeIDNumberMessageTest.class,
+        VerifyNodeIDNumberMessageTest.class,
+        IdentifyProducersMessageTest.class,
+        ProducerIdentifiedMessageTest.class,
+        IdentifyConsumersMessageTest.class,
+        ConsumerIdentifiedMessageTest.class,
+        IdentifyEventsMessageTest.class,
+        ProducerConsumerEventReportMessageTest.class,
+        LearnEventMessageTest.class,
+        DatagramMessageTest.class,
+        ProtocolIdentificationRequestMessageTest.class,
+        ProtocolIdentificationReplyMessageTest.class,
+        ProtocolIdentificationTest.class,
+        SimpleNodeIdentInfoRequestMessageTest.class,
+        SimpleNodeIdentInfoReplyMessageTest.class,
+        SimpleNodeIdentTest.class,
+        ConfigurationPortalTest.class,
+        SingleLinkNodeTest.class,
+        GatewayTest.class,
+        ThrottleTest.class,
+        MimicNodeStoreTest.class,
+        LoaderClientTest.class,
+        CommonIdentifiersTest.class,       
+        DatagramAcknowledgedMessageTest.class,
+        DatagramRejectedMessageTest.class,  
+        DefaultPropertyListenerSupportTest.class,	
+        OlcbInterfaceTest.class, 
+        StreamDataCompleteMessageTest.class,       
+        StreamDataProceedMessageTest.class,       
+        StreamDataSendMessageTest.class,    
+        StreamInitiateReplyMessageTest.class,       
+        StreamInitiateRequestMessageTest.class,  
+        // test implementation classes
+        org.openlcb.implementations.PackageTest.class,
+        org.openlcb.messages.PackageTest.class,
+        org.openlcb.swing.PackageTest.class,
+        org.openlcb.cdi.PackageTest.class,
+        org.openlcb.hub.PackageTest.class,       
+        org.openlcb.protocols.PackageTest.class,       
+        // test CAN classes
+        org.openlcb.can.PackageTest.class
+})
 /**
  * @author  Bob Jacobsen   Copyright 2009, 2012
  */
-public class PackageTest extends TestCase {
-    public void testStart() {
-    }
-    
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-
-        suite.addTest(UtilitiesTest.suite());
-        suite.addTest(VersionTest.suite());
-
-        suite.addTest(EventIDTest.suite());
-        suite.addTest(NodeIDTest.suite());
-
-        suite.addTest(MessageTypeIdentifierTest.suite());
-
-        suite.addTest(MessageTest.suite());
-
-        suite.addTest(MessageDecoderTest.suite());
-        suite.addTest(NodeTest.suite());
-
-        // specific message types (uses Node, IDs)
-        suite.addTest(InitializationCompleteMessageTest.suite());
-
-        suite.addTest(OptionalIntRejectedMessageTest.suite());
-
-        suite.addTest(VerifiedNodeIDNumberMessageTest.suite());
-        suite.addTest(VerifyNodeIDNumberMessageTest.suite());
-
-        suite.addTest(IdentifyProducersMessageTest.suite());
-        suite.addTest(ProducerIdentifiedMessageTest.suite());
-        suite.addTest(IdentifyConsumersMessageTest.suite());
-        suite.addTest(ConsumerIdentifiedMessageTest.suite());
-        suite.addTest(IdentifyEventsMessageTest.suite());
-        suite.addTest(ProducerConsumerEventReportMessageTest.suite());
-
-        suite.addTest(LearnEventMessageTest.suite());
-
-        suite.addTest(DatagramMessageTest.suite());
-
-        suite.addTest(ProtocolIdentificationRequestMessageTest.suite());
-        suite.addTest(ProtocolIdentificationReplyMessageTest.suite());
-        suite.addTest(ProtocolIdentificationTest.suite());
-        
-        suite.addTest(SimpleNodeIdentInfoRequestMessageTest.suite());
-        suite.addTest(SimpleNodeIdentInfoReplyMessageTest.suite());
-        suite.addTest(SimpleNodeIdentTest.suite());
-
-        suite.addTest(ConfigurationPortalTest.suite());
-
-        suite.addTest(SingleLinkNodeTest.suite());
-
-        suite.addTest(GatewayTest.suite());
-
-        suite.addTest(ThrottleTest.suite());
-
-        suite.addTest(MimicNodeStoreTest.suite());
-        
-        suite.addTest(LoaderClientTest.suite());
-        suite.addTest(new JUnit4TestAdapter(CommonIdentifiersTest.class));       
-        suite.addTest(new JUnit4TestAdapter(DatagramAcknowledgedMessageTest.class));       
-        suite.addTest(new JUnit4TestAdapter(DatagramRejectedMessageTest.class));       
-        suite.addTest(new JUnit4TestAdapter(DefaultPropertyListenerSupportTest.class));       
-        suite.addTest(new JUnit4TestAdapter(OlcbInterfaceTest.class));       
-        suite.addTest(new JUnit4TestAdapter(StreamDataCompleteMessageTest.class));       
-        suite.addTest(new JUnit4TestAdapter(StreamDataProceedMessageTest.class));       
-        suite.addTest(new JUnit4TestAdapter(StreamDataSendMessageTest.class));       
-        suite.addTest(new JUnit4TestAdapter(StreamInitiateReplyMessageTest.class));       
-        suite.addTest(new JUnit4TestAdapter(StreamInitiateRequestMessageTest.class));       
-
-        // test implementation classes
-        suite.addTest(org.openlcb.implementations.PackageTest.suite());
-        suite.addTest(org.openlcb.messages.PackageTest.suite());
-        suite.addTest(org.openlcb.swing.PackageTest.suite());
-        suite.addTest(org.openlcb.cdi.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(org.openlcb.hub.PackageTest.class));       
-        suite.addTest(new JUnit4TestAdapter(org.openlcb.protocols.PackageTest.class));       
-        
-        // test CAN classes
-        suite.addTest(org.openlcb.can.PackageTest.suite());
-
-        return suite;
-    }
+public class PackageTest {
 }

--- a/test/org/openlcb/ProducerIdentifiedMessageTest.java
+++ b/test/org/openlcb/ProducerIdentifiedMessageTest.java
@@ -1,15 +1,12 @@
 package org.openlcb;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
  * @version $Revision$
  */
-public class ProducerIdentifiedMessageTest extends TestCase {
+public class ProducerIdentifiedMessageTest {
     boolean result;
     
     EventID eventID1 = new EventID(new byte[]{1,0,0,0,0,0,1,0});
@@ -18,6 +15,7 @@ public class ProducerIdentifiedMessageTest extends TestCase {
     NodeID nodeID1 = new NodeID(new byte[]{1,2,3,4,5,6});
     NodeID nodeID2 = new NodeID(new byte[]{0,0,0,0,0,0});
 
+    @Test
     public void testEqualsSame() {
         Message m1 = new ProducerIdentifiedMessage(
                                nodeID1, eventID1, EventState.Valid);
@@ -27,6 +25,7 @@ public class ProducerIdentifiedMessageTest extends TestCase {
         Assert.assertTrue(m1.equals(m2));
     }
 
+    @Test
     public void testNotEqualsDifferentNode() {
         Message m1 = new ProducerIdentifiedMessage(
                                 nodeID1, eventID1, EventState.Valid );
@@ -36,6 +35,7 @@ public class ProducerIdentifiedMessageTest extends TestCase {
         Assert.assertTrue( ! m1.equals(m2));
     }
 
+    @Test
     public void testNotEqualsDifferentEvent() {
         Message m1 = new ProducerIdentifiedMessage(
                                 nodeID1, eventID1, EventState.Valid );
@@ -45,6 +45,7 @@ public class ProducerIdentifiedMessageTest extends TestCase {
         Assert.assertTrue( ! m1.equals(m2));
     }
 
+    @Test
     public void testNotEqualsDifferentState() {
         Message m1 = new ProducerIdentifiedMessage(
                 nodeID1, eventID1, EventState.Valid );
@@ -54,6 +55,7 @@ public class ProducerIdentifiedMessageTest extends TestCase {
         Assert.assertTrue( ! m1.equals(m2));
     }
 
+    @Test
     public void testHandling() {
         result = false;
         Node n = new Node(){
@@ -69,21 +71,4 @@ public class ProducerIdentifiedMessageTest extends TestCase {
         Assert.assertTrue(result);
     }
     
-    // from here down is testing infrastructure
-    
-    public ProducerIdentifiedMessageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {ProducerIdentifiedMessageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(ProducerIdentifiedMessageTest.class);
-        return suite;
-    }
 }

--- a/test/org/openlcb/SimpleNodeIdentInfoReplyMessageTest.java
+++ b/test/org/openlcb/SimpleNodeIdentInfoReplyMessageTest.java
@@ -1,20 +1,18 @@
 package org.openlcb;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 /**
  * @author  Bob Jacobsen   Copyright 2012
  * @version $Revision$
  */
-public class SimpleNodeIdentInfoReplyMessageTest extends TestCase {
+public class SimpleNodeIdentInfoReplyMessageTest {
     boolean result;
     
     NodeID nodeID1 = new NodeID(new byte[]{1,2,3,4,5,6});
     NodeID nodeID2 = new NodeID(new byte[]{0,0,0,0,0,0});
 
+    @Test
     public void testEqualsSame() {
         Message m1 = new SimpleNodeIdentInfoReplyMessage(
                                nodeID1, nodeID2, new byte[]{1,2});
@@ -24,6 +22,7 @@ public class SimpleNodeIdentInfoReplyMessageTest extends TestCase {
         Assert.assertTrue(m1.equals(m2));
     }
 
+    @Test
     public void testNotEqualsDifferentNode() {
         Message m1 = new SimpleNodeIdentInfoReplyMessage(
                                 nodeID1, nodeID2, new byte[]{1,2});
@@ -34,6 +33,7 @@ public class SimpleNodeIdentInfoReplyMessageTest extends TestCase {
     }
 
 
+    @Test
     public void testNotEqualsDifferentValue() {
         Message m1 = new SimpleNodeIdentInfoReplyMessage(
                                 nodeID1, nodeID2, new byte[]{1,2});
@@ -43,6 +43,7 @@ public class SimpleNodeIdentInfoReplyMessageTest extends TestCase {
         Assert.assertTrue( ! m1.equals(m2));
     }
 
+    @Test
     public void testNotEqualsDifferentValueLength() {
         Message m1 = new SimpleNodeIdentInfoReplyMessage(
                                 nodeID1, nodeID2, new byte[]{1,2});
@@ -51,6 +52,8 @@ public class SimpleNodeIdentInfoReplyMessageTest extends TestCase {
     
         Assert.assertTrue( ! m1.equals(m2));
     }
+
+    @Test
     public void testNotEqualsDifferentValueLengthBis() {
         Message m1 = new SimpleNodeIdentInfoReplyMessage(
                                 nodeID1, nodeID2, new byte[]{1,2,3});
@@ -60,7 +63,7 @@ public class SimpleNodeIdentInfoReplyMessageTest extends TestCase {
         Assert.assertTrue( ! m1.equals(m2));
     }
 
-
+    @Test
     public void testHandling() {
         result = false;
         Node n = new Node(){
@@ -76,29 +79,12 @@ public class SimpleNodeIdentInfoReplyMessageTest extends TestCase {
         Assert.assertTrue(result);
     }
 
+    @Test
     public void testPrint() {
         Message m = new SimpleNodeIdentInfoReplyMessage(nodeID1, nodeID2, new byte[]{4,'a','b',
                 'c',0,'d','e','f','g',0,0,2,'u',0,'v',0});
         String s = m.toString();
         Assert.assertEquals("01.02.03.04.05.06 - 00.00.00.00.00.00 Simple Node Ident Info with" +
                 " content '4,abc,defg,,2,u,v,'", s);
-    }
-
-    // from here down is testing infrastructure
-    
-    public SimpleNodeIdentInfoReplyMessageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {SimpleNodeIdentInfoReplyMessageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(SimpleNodeIdentInfoReplyMessageTest.class);
-        return suite;
     }
 }

--- a/test/org/openlcb/SimpleNodeIdentInfoRequestMessageTest.java
+++ b/test/org/openlcb/SimpleNodeIdentInfoRequestMessageTest.java
@@ -1,20 +1,18 @@
 package org.openlcb;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 /**
  * @author  Bob Jacobsen   Copyright 2012
  * @version $Revision$
  */
-public class SimpleNodeIdentInfoRequestMessageTest extends TestCase {
+public class SimpleNodeIdentInfoRequestMessageTest {
     boolean result;
     
     NodeID nodeID1 = new NodeID(new byte[]{1,2,3,4,5,6});
     NodeID nodeID2 = new NodeID(new byte[]{0,0,0,0,0,0});
 
+    @Test
     public void testEqualsSame() {
         Message m1 = new SimpleNodeIdentInfoRequestMessage(
                                nodeID1,nodeID2);
@@ -24,6 +22,7 @@ public class SimpleNodeIdentInfoRequestMessageTest extends TestCase {
         Assert.assertTrue(m1.equals(m2));
     }
 
+    @Test
     public void testNotEqualsDifferentSrcNode() {
         Message m1 = new SimpleNodeIdentInfoRequestMessage(
                                 nodeID1,nodeID2);
@@ -33,6 +32,7 @@ public class SimpleNodeIdentInfoRequestMessageTest extends TestCase {
         Assert.assertTrue( ! m1.equals(m2));
     }
     
+    @Test
     public void testNotEqualsDifferentDstNode() {
         Message m1 = new SimpleNodeIdentInfoRequestMessage(
                                 nodeID1,nodeID2);
@@ -42,7 +42,7 @@ public class SimpleNodeIdentInfoRequestMessageTest extends TestCase {
         Assert.assertTrue( ! m1.equals(m2));
     }
 
-
+    @Test
     public void testHandling() {
         result = false;
         Node n = new Node(){
@@ -56,23 +56,5 @@ public class SimpleNodeIdentInfoRequestMessageTest extends TestCase {
         n.put(m, null);
         
         Assert.assertTrue(result);
-    }
-    
-    // from here down is testing infrastructure
-    
-    public SimpleNodeIdentInfoRequestMessageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {SimpleNodeIdentInfoRequestMessageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(SimpleNodeIdentInfoRequestMessageTest.class);
-        return suite;
     }
 }

--- a/test/org/openlcb/SingleLinkNodeTest.java
+++ b/test/org/openlcb/SingleLinkNodeTest.java
@@ -1,20 +1,17 @@
 package org.openlcb;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
-public class SingleLinkNodeTest extends TestCase {
+public class SingleLinkNodeTest {
     
     boolean result;
     
     NodeID nodeID = new NodeID(new byte[]{1,2,3,4,5,6});
-    
+
+    @Test    
     public void testInitialization() {
         result = false;
         Connection testConnection = new AbstractConnection(){
@@ -34,21 +31,4 @@ public class SingleLinkNodeTest extends TestCase {
         Assert.assertTrue(result);
     }
     
-    // from here down is testing infrastructure
-    
-    public SingleLinkNodeTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {SingleLinkNodeTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(SingleLinkNodeTest.class);
-        return suite;
-    }
 }

--- a/test/org/openlcb/VerifiedNodeIDNumberMessageTest.java
+++ b/test/org/openlcb/VerifiedNodeIDNumberMessageTest.java
@@ -1,17 +1,14 @@
 package org.openlcb;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
-public class VerifiedNodeIDNumberMessageTest extends TestCase {
+public class VerifiedNodeIDNumberMessageTest {
     boolean result;
-    
+
+    @Test    
     public void testEqualsSame() {
         Message m1 = new VerifiedNodeIDNumberMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}) );
@@ -21,6 +18,7 @@ public class VerifiedNodeIDNumberMessageTest extends TestCase {
         Assert.assertTrue(m1.equals(m2));
     }
 
+    @Test    
     public void testNotEqualsDifferent() {
         Message m1 = new VerifiedNodeIDNumberMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}) );
@@ -30,6 +28,7 @@ public class VerifiedNodeIDNumberMessageTest extends TestCase {
         Assert.assertTrue( ! m1.equals(m2));
     }
 
+    @Test    
     public void testHandling() {
         result = false;
         Node n = new Node(){
@@ -46,21 +45,4 @@ public class VerifiedNodeIDNumberMessageTest extends TestCase {
         Assert.assertTrue(result);
     }
     
-    // from here down is testing infrastructure
-    
-    public VerifiedNodeIDNumberMessageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {VerifiedNodeIDNumberMessageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(VerifiedNodeIDNumberMessageTest.class);
-        return suite;
-    }
 }

--- a/test/org/openlcb/can/PackageTest.java
+++ b/test/org/openlcb/can/PackageTest.java
@@ -1,44 +1,21 @@
 package org.openlcb.can;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.framework.JUnit4TestAdapter;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        OpenLcbCanFrameTest.class,
+        MessageBuilderTest.class,
+        NIDaTest.class,
+        NIDaAlgorithmTest.class,
+        AliasMapTest.class,
+        GridConnectTest.class,
+        CanInterfaceTest.class,
+        org.openlcb.can.impl.PackageTest.class 
+})
 /**
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
-public class PackageTest extends TestCase {
-    public void testStart() {
-    }
-    
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-
-        suite.addTest(OpenLcbCanFrameTest.suite());
-        suite.addTest(MessageBuilderTest.suite());
-        suite.addTest(NIDaTest.suite());
-        suite.addTest(NIDaAlgorithmTest.suite());
-        suite.addTest(AliasMapTest.suite());
-        suite.addTest(new TestSuite(GridConnectTest.class));
-        suite.addTest(new JUnit4TestAdapter(CanInterfaceTest.class));       
-        suite.addTest(new JUnit4TestAdapter(org.openlcb.can.impl.PackageTest.class));       
-
-        return suite;
-    }
+public class PackageTest {
 }

--- a/test/org/openlcb/cdi/PackageTest.java
+++ b/test/org/openlcb/cdi/PackageTest.java
@@ -1,41 +1,17 @@
 package org.openlcb.cdi;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.framework.JUnit4TestAdapter;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        org.openlcb.cdi.jdom.PackageTest.class,
+        org.openlcb.cdi.swing.CdiPanelTest.class,
+        org.openlcb.cdi.impl.PackageTest.class,
+        org.openlcb.cdi.cmd.PackageTest.class 
+})
 /**
  * @author  Bob Jacobsen   Copyright 2011
- * @version $Revision: 34 $
  */
-public class PackageTest extends TestCase {
-    
-    public void testStart() {
-    }
-    
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-        
-        suite.addTest(org.openlcb.cdi.jdom.PackageTest.suite());
-        suite.addTest(org.openlcb.cdi.swing.CdiPanelTest.suite());
-        suite.addTest(org.openlcb.cdi.impl.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(org.openlcb.cdi.cmd.PackageTest.class));       
-
-        return suite;
-    }
+public class PackageTest {
 }

--- a/test/org/openlcb/cdi/impl/ConfigRepresentationTest.java
+++ b/test/org/openlcb/cdi/impl/ConfigRepresentationTest.java
@@ -1,8 +1,6 @@
 package org.openlcb.cdi.impl;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -16,7 +14,7 @@ import java.io.StringWriter;
 /**
  * Created by bracz on 11/9/16.
  */
-public class ConfigRepresentationTest extends TestCase {
+public class ConfigRepresentationTest {
     protected FakeOlcbInterface iface;
     protected FakeMemoryConfigurationService mcs;
     protected NodeID remoteNode = new NodeID("05.01.01.01.14.39");
@@ -36,6 +34,7 @@ public class ConfigRepresentationTest extends TestCase {
         }
     }
 
+    @Test
     public void testComplexCdiLoad() throws Exception {
         addCdiData(SampleFactory.getOffsetSample());
         byte[] config = new byte[1000];
@@ -43,11 +42,11 @@ public class ConfigRepresentationTest extends TestCase {
         ConfigRepresentation rep = new ConfigRepresentation(iface, remoteNode);
         // Since all of our memory configuration commands execute inline, the representation will
         // be ready by the time it returns.
-        assertEquals("Representation complete.", rep.getStatus());
-        assertNotNull(rep.getRoot());
+        Assert.assertEquals("Representation complete.", rep.getStatus());
+        Assert.assertNotNull(rep.getRoot());
 
         ConfigRepresentation.CdiContainer cont = rep.getRoot();
-        assertEquals(2, cont.getEntries().size());
+        Assert.assertEquals(2, cont.getEntries().size());
 
         class Offset {
             int i;
@@ -76,24 +75,16 @@ public class ConfigRepresentationTest extends TestCase {
         });
     }
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() {
         iface = new FakeOlcbInterface();
         mcs = new FakeMemoryConfigurationService(iface);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown(){
         iface.dispose();
         mcs.dispose();
-        super.tearDown();
     }
 
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(ConfigRepresentationTest.class);
-
-        return suite;
-    }
 }

--- a/test/org/openlcb/cdi/impl/PackageTest.java
+++ b/test/org/openlcb/cdi/impl/PackageTest.java
@@ -1,43 +1,19 @@
 package org.openlcb.cdi.impl;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.framework.JUnit4TestAdapter;
-
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 import org.openlcb.cdi.jdom.CdiMemConfigReaderTest;
 import org.openlcb.cdi.jdom.JdomCdiRepTest;
 
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        RangeCacheUtilTest.class,
+        ConfigRepresentationTest.class,
+        MemorySpaceCacheTest.class,    
+        DemoReadWriteAccessTest.class   
+})
 /**
  * @author  Bob Jacobsen   Copyright 2011
- * @version $Revision: 34 $
  */
-public class PackageTest extends TestCase {
-    
-    public void testStart() {
-    }
-    
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-        
-        suite.addTest(RangeCacheUtilTest.suite());
-        suite.addTest(ConfigRepresentationTest.suite());
-        suite.addTest(new JUnit4TestAdapter(MemorySpaceCacheTest.class));       
-        suite.addTest(new JUnit4TestAdapter(DemoReadWriteAccessTest.class));       
-
-        return suite;
-    }
+public class PackageTest {
 }

--- a/test/org/openlcb/cdi/jdom/PackageTest.java
+++ b/test/org/openlcb/cdi/jdom/PackageTest.java
@@ -1,41 +1,18 @@
 package org.openlcb.cdi.jdom;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.framework.JUnit4TestAdapter;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        JdomCdiRepTest.class,
+        CdiMemConfigReaderTest.class,
+        JdomCdiReaderTest.class, 
+        XmlHelperTest.class     
+})
 
 /**
  * @author  Bob Jacobsen   Copyright 2011
- * @version $Revision: 34 $
  */
-public class PackageTest extends TestCase {
-    
-    public void testStart() {
-    }
-    
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-        
-        suite.addTest(JdomCdiRepTest.suite());
-        suite.addTest(CdiMemConfigReaderTest.suite());
-        suite.addTest(new JUnit4TestAdapter(JdomCdiReaderTest.class));       
-        suite.addTest(new JUnit4TestAdapter(XmlHelperTest.class));       
-
-        return suite;
-    }
+public class PackageTest {
 }

--- a/test/org/openlcb/implementations/EventFilterGatewayTest.java
+++ b/test/org/openlcb/implementations/EventFilterGatewayTest.java
@@ -2,18 +2,15 @@ package org.openlcb.implementations;
 
 import org.openlcb.*;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.*;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
 public class EventFilterGatewayTest extends GatewayTest {
     
     // create a filtering gateway for parent tests
+    @Override
     protected Gateway getGateway() {
         return new EventFilterGateway();
     }
@@ -26,6 +23,7 @@ public class EventFilterGatewayTest extends GatewayTest {
     // first will be specific tests of filtering
     // followed by all the inherited tests of a regular Gateway
 
+    @Test
     public void testEventNotPassByDefaultEtoW() {
         buildGateway();
         Message m = new ProducerConsumerEventReportMessage(node1, eventA);
@@ -42,6 +40,7 @@ public class EventFilterGatewayTest extends GatewayTest {
         resultW = false;
     }
 
+    @Test
     public void testEventNotPassByDefaultWtoE() {
         buildGateway();
         Message m = new ProducerConsumerEventReportMessage(node1, eventA);
@@ -51,6 +50,7 @@ public class EventFilterGatewayTest extends GatewayTest {
         checkMovedNeitherWay();
     }
     
+    @Test
     public void testReqEventPassesEtoW() {
         buildGateway();
 
@@ -63,6 +63,7 @@ public class EventFilterGatewayTest extends GatewayTest {
         checkMovedEastToWestOnly();
     }
     
+    @Test
     public void testReqEventPassesWtoE() {
         buildGateway();
 
@@ -75,21 +76,4 @@ public class EventFilterGatewayTest extends GatewayTest {
         checkMovedWestToEastOnly();
     }
     
-    // from here down is testing infrastructure
-    
-    public EventFilterGatewayTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {EventFilterGatewayTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(EventFilterGatewayTest.class);
-        return suite;
-    }
 }

--- a/test/org/openlcb/implementations/PackageTest.java
+++ b/test/org/openlcb/implementations/PackageTest.java
@@ -1,65 +1,35 @@
 package org.openlcb.implementations;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.framework.JUnit4TestAdapter;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SingleConsumerNodeTest.class,
+        SingleProducerNodeTest.class,
+        ScatterGatherTest.class,
+        EventFilterGatewayTest.class,
+        DatagramTransmitterTest.class,
+        DatagramReceiverTest.class,
+        DatagramMeteringBufferTest.class,
+        DatagramServiceTest.class,
+        StreamTransmitterTest.class,
+        StreamReceiverTest.class,
+        BlueGoldEngineTest.class,
+        MemoryConfigurationServiceTest.class,
+        org.openlcb.implementations.throttle.PackageTest.class,
+        BitProducerConsumerTest.class,
+        VersionedValueTest.class,
+        FakeMemoryConfigurationServiceTest.class,  
+        MemoryConfigSpaceRetrieverTest.class,     
+        SingleConsumerTest.class,
+        SingleProducerTest.class,       
+        VersionOutOfDateExceptionTest.class,      
+        BlueGoldExtendedEngineTest.class,      
+    })
 /**
  * @author  Bob Jacobsen   Copyright 2009, 2012
- * @version $Revision$
  */
-public class PackageTest extends TestCase {
-    public void testStart() {
-    }
-    
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-
-        suite.addTest(SingleConsumerNodeTest.suite());
-        suite.addTest(SingleProducerNodeTest.suite());
-
-        suite.addTest(ScatterGatherTest.suite());
-        suite.addTest(EventFilterGatewayTest.suite());
-
-        suite.addTest(DatagramTransmitterTest.suite());
-        suite.addTest(DatagramReceiverTest.suite());
-        
-        suite.addTest(DatagramMeteringBufferTest.suite());
-
-        suite.addTest(DatagramServiceTest.suite());
-
-        suite.addTest(StreamTransmitterTest.suite());
-        suite.addTest(StreamReceiverTest.suite());
-
-        suite.addTest(BlueGoldEngineTest.suite());
-
-        suite.addTest(MemoryConfigurationServiceTest.suite());
-
-        suite.addTest(org.openlcb.implementations.throttle.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(BitProducerConsumerTest.class));
-        suite.addTest(new TestSuite(VersionedValueTest.class));
-        suite.addTest(new JUnit4TestAdapter(FakeMemoryConfigurationServiceTest.class));       
-        suite.addTest(new JUnit4TestAdapter(MemoryConfigSpaceRetrieverTest.class));       
-        suite.addTest(new JUnit4TestAdapter(SingleConsumerTest.class));       
-        suite.addTest(new JUnit4TestAdapter(SingleProducerTest.class));       
-        suite.addTest(new JUnit4TestAdapter(VersionOutOfDateExceptionTest.class));       
-        suite.addTest(new JUnit4TestAdapter(BlueGoldExtendedEngineTest.class));       
-
-        return suite;
-    }
+public class PackageTest {
 }

--- a/test/org/openlcb/implementations/throttle/PackageTest.java
+++ b/test/org/openlcb/implementations/throttle/PackageTest.java
@@ -1,46 +1,23 @@
 package org.openlcb.implementations.throttle;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.framework.JUnit4TestAdapter;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        Float16Test.class,
+        ThrottleSpeedDatagramTest.class,
+        ThrottleImplementationTest.class,
+        RemoteTrainNodeTest.class,
+        RemoteTrainNodeCacheTest.class,
+        org.openlcb.implementations.throttle.dcc.PackageTest.class,
+        ThrottleFunctionDatagramTest.class, 
+        TractionThrottleTest.class,
+        TrainNodeCacheTest.class,      
+        FdiParserTest.class,      
+})
 /**
  * @author  Bob Jacobsen   Copyright 2012
- * @version $Revision$
  */
-public class PackageTest extends TestCase {
-    public void testStart() {
-    }
-    
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-
-        suite.addTest(Float16Test.suite());
-        suite.addTest(ThrottleSpeedDatagramTest.suite());
-        suite.addTest(ThrottleImplementationTest.suite());
-        suite.addTest(RemoteTrainNodeTest.suite());
-        suite.addTest(RemoteTrainNodeCacheTest.suite());
-
-        suite.addTest(org.openlcb.implementations.throttle.dcc.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(ThrottleFunctionDatagramTest.class));       
-        suite.addTest(new JUnit4TestAdapter(TractionThrottleTest.class));       
-        suite.addTest(new JUnit4TestAdapter(TrainNodeCacheTest.class));       
-        suite.addTest(new JUnit4TestAdapter(FdiParserTest.class));       
-
-        return suite;
-    }
+public class PackageTest {
 }

--- a/test/org/openlcb/implementations/throttle/dcc/PackageTest.java
+++ b/test/org/openlcb/implementations/throttle/dcc/PackageTest.java
@@ -1,38 +1,17 @@
 package org.openlcb.implementations.throttle.dcc;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.framework.JUnit4TestAdapter;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        DccProxyCacheTest.class,
+        RemoteDccProxyTest.class       
+})
 
 /**
  * @author  Bob Jacobsen   Copyright 2012
  * @version $Revision$
  */
-public class PackageTest extends TestCase {
-    public void testStart() {
-    }
-    
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-
-        suite.addTest(DccProxyCacheTest.suite());
-        suite.addTest(new JUnit4TestAdapter(RemoteDccProxyTest.class));       
-
-        return suite;
-    }
+public class PackageTest {
 }

--- a/test/org/openlcb/messages/PackageTest.java
+++ b/test/org/openlcb/messages/PackageTest.java
@@ -1,39 +1,17 @@
 package org.openlcb.messages;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.framework.JUnit4TestAdapter;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        TractionControlRequestMessageTest.class,
+        TractionControlReplyMessageTest.class,       
+        TractionProxyRequestMessageTest.class,       
+        TractionProxyReplyMessageTest.class       
+})
 /**
  * @author  Bob Jacobsen   Copyright 2009, 2012
- * @version $Revision$
  */
-public class PackageTest extends TestCase {
-    public void testStart() {
-    }
-    
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-
-        suite.addTest(TractionControlRequestMessageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(TractionControlReplyMessageTest.class));       
-        suite.addTest(new JUnit4TestAdapter(TractionProxyRequestMessageTest.class));       
-        suite.addTest(new JUnit4TestAdapter(TractionProxyReplyMessageTest.class));       
-
-        return suite;
-    }
+public class PackageTest {
 }

--- a/test/org/openlcb/swing/PackageTest.java
+++ b/test/org/openlcb/swing/PackageTest.java
@@ -1,49 +1,25 @@
 package org.openlcb.swing;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.framework.JUnit4TestAdapter;
-
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 import javax.swing.*;
 
 import org.openlcb.swing.*;
 
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        MonPaneTest.class,
+        NodeSelectorTest.class,
+        EventIdTextFieldTest.class,
+        org.openlcb.swing.networktree.PackageTest.class,
+        org.openlcb.swing.memconfig.PackageTest.class,
+        ConsumerPaneTest.class,       
+        ProducerPaneTest.class,       
+        NodeIdTextFieldTest.class       
+})
+
 /**
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
-public class PackageTest extends TestCase {
-    public void testStart() {
-    }
-    
-    
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-        suite.addTest(MonPaneTest.suite());
-        suite.addTest(NodeSelectorTest.suite());
-        suite.addTest(EventIdTextFieldTest.suite());
-
-        suite.addTest(org.openlcb.swing.networktree.PackageTest.suite());
-        suite.addTest(org.openlcb.swing.memconfig.PackageTest.suite());
-        suite.addTest(new JUnit4TestAdapter(ConsumerPaneTest.class));       
-        suite.addTest(new JUnit4TestAdapter(ProducerPaneTest.class));       
-        suite.addTest(new JUnit4TestAdapter(NodeIdTextFieldTest.class));       
-
-        return suite;
-    }
+public class PackageTest {
 }

--- a/test/org/openlcb/swing/memconfig/PackageTest.java
+++ b/test/org/openlcb/swing/memconfig/PackageTest.java
@@ -1,37 +1,15 @@
 package org.openlcb.swing.memconfig;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        MemConfigDescriptionPaneTest.class,
+        MemConfigReadWritePaneTest.class
+})
 /**
  * @author  Bob Jacobsen   Copyright 2012
- * @version $Revision$
  */
-public class PackageTest extends TestCase {
-    public void testStart() {
-    }
-    
-    
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-        suite.addTest(MemConfigDescriptionPaneTest.suite());
-        suite.addTest(MemConfigReadWritePaneTest.suite());
-
-        return suite;
-    }
+public class PackageTest {
 }

--- a/test/org/openlcb/swing/networktree/PackageTest.java
+++ b/test/org/openlcb/swing/networktree/PackageTest.java
@@ -1,42 +1,18 @@
 package org.openlcb.swing.networktree;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.framework.JUnit4TestAdapter;
-
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 import javax.swing.*;
 
 import org.openlcb.swing.*;
 
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        TreePaneTest.class,
+        NodeTreeRepTest.class      
+})
 /**
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
-public class PackageTest extends TestCase {
-    public void testStart() {
-    }
-    
-    
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-        suite.addTest(TreePaneTest.suite());
-        suite.addTest(new JUnit4TestAdapter(NodeTreeRepTest.class));       
-
-        return suite;
-    }
+public class PackageTest {
 }

--- a/test/scenarios/PackageTest.java
+++ b/test/scenarios/PackageTest.java
@@ -1,55 +1,35 @@
 package scenarios;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.Test;
 
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        NineOnALink.class,
+        TwoBuses.class,
+        TwoBusesFiltered.class,
+        ThreeBuses.class,
+        scenarios.can.CanScenarios.class
+})
 /**
  * Primary test runner for this package.
  *
  * @author  Bob Jacobsen   Copyright 2009
  * @version $Revision$
  */
-public class PackageTest extends TestCase {
-    public void testStart() {
-    }
+public class PackageTest {
     
     // BlueGoldCheck not JUnit so can run standalone
+    @Test
     public void testBlueGold() throws Exception {
         BlueGoldCheck.runTest();
     }
     
     // ConfigDemoApplet not JUnit so can run standalone
+    @Test
     public void testConfigDemoApplet() throws Exception {
         ConfigDemoApplet.runTest();
     }
 
-    // from here down is testing infrastructure
-    
-    public PackageTest(String s) {
-        super(s);
-    }
-
-    // Main entry point
-    static public void main(String[] args) {
-        String[] testCaseName = {PackageTest.class.getName()};
-        junit.textui.TestRunner.main(testCaseName);
-    }
-
-    // test suite from all defined tests
-    public static Test suite() {
-        TestSuite suite = new TestSuite(PackageTest.class);
-        suite.addTest(NineOnALink.suite());
-        
-        suite.addTest(TwoBuses.suite());
-        suite.addTest(TwoBusesFiltered.suite());
-        suite.addTest(ThreeBuses.suite());
-
-        suite.addTest(scenarios.can.CanScenarios.suite());
-
-        // Applets done above
-        
-        return suite;
-    }
 }


### PR DESCRIPTION
@balazsracz running the tests in parallel through maven cuts the build and test runtime in half on my machine. (execution time went from 9:30 to 4:14).  On this machine, that makes the execution time about the same as it was prior to #122 being merged.

This PR puts that in place and does some conversion to JUnit4.  I'll probably add some more JUnit conversions before I merge.