### PR TITLE
Fix up LoaderClient

### DIFF
--- a/src/org/openlcb/LoaderClient.java
+++ b/src/org/openlcb/LoaderClient.java
@@ -8,6 +8,8 @@ import org.openlcb.implementations.MemoryConfigurationService;
 import org.openlcb.implementations.MemoryConfigurationService.McsWriteHandler;
 import org.openlcb.implementations.MemoryConfigurationService.McsWriteStreamMemo;
 
+import static org.openlcb.ProtocolIdentification.Protocol;
+
 //
 //  LoaderClient.java
 //
@@ -18,14 +20,18 @@ import org.openlcb.implementations.MemoryConfigurationService.McsWriteStreamMemo
 
 public class LoaderClient extends MessageDecoder {
     private static final Logger logger = Logger.getLogger(LoaderClient.class.getName());
+    private static final byte SRC_STREAM_ID = 4;
+    private static final int PIP_TIMEOUT_MSEC = 3000;
+    private static final int FREEZE_REBOOT_TIMEOUT_MSEC = 60000;
+    private static final int STREAM_INIT_TIMEOUT_MSEC = 10000;
+    private static final int STREAM_DATA_PROCEED_TIMEOUT_MSEC = 120000;
 
     enum State { IDLE, ABORT, FREEZE, INITCOMPL, PIP, PIPREPLY, SETUPSTREAM, STREAM, STREAMDATA, DG, UNFREEEZE, SUCCESS, FAIL };
+
+    // These objects are injected in the constructor.
     Connection connection;
-    Connection fromDownstream;
     MemoryConfigurationService mcs;
     DatagramService dcs;
-    MimicNodeStore store;
-    String errorString;
 
     State state;
     NodeID src;
@@ -43,15 +49,14 @@ public class LoaderClient extends MessageDecoder {
         public abstract void onProgress(float percent);
         public abstract void onDone(int errorCode, String errorString);
     }
-    
+
     public LoaderClient( Connection _connection, MemoryConfigurationService _mcs, DatagramService _dcs ) {
-                                       //System.out.println("LoaderClient init");
         connection = _connection;
         dcs = _dcs;
         mcs = _mcs;
         timer = new Timer("OpenLCB LoaderClient Timeout Timer");
     }
-    
+
     /* Protocol:
       ---> memconfig Freeze (DG)
      (<--- DG ok)    -- node may reboot, and not be able to garantee this
@@ -68,7 +73,7 @@ public class LoaderClient extends MessageDecoder {
       ---> StreamDataSend
       ...
       ---> StreamDataComplete
-     ELSE use datagrams: 
+     ELSE use datagrams:
       ---> DatagramMessage
       <--- DatagramAcknowledged
       ...
@@ -78,10 +83,9 @@ public class LoaderClient extends MessageDecoder {
       <--- DatagramAcknowledged
      THEN:
       ---> UnFreeze
-     
+
      */
-    
-    
+
     public void doLoad(NodeID _src, NodeID _dest, int _space, long _address, byte[] _content, LoaderStatusReporter _feedback) {
         src = _src;
         dest = _dest;
@@ -92,123 +96,112 @@ public class LoaderClient extends MessageDecoder {
         feedback = _feedback;
         sendFreeze();  // allow restarts
     }
-    
-    final int DG_OK = 0x0000;     // double check these
-    final int DG_FAIL = 0x0100;   // note that this value is used in DGMeteringBuffer to denote time-out
-    final int DG_RESEND = 0x0200;
-    void sendFreeze() {
-                                                // System.out.println("lSendFreeze ");
+
+    private void sendFreeze() {
         state = State.FREEZE;
-                                                // System.out.println("lsendFREEZE Enter: "+state);
         dcs.sendData(
             new DatagramService.DatagramServiceTransmitMemo(dest, new int[]{0x20, 0xA1, space}) {
+                // Ignores both success and failure callback, because the state machine will
+                // proceed on the Node Init Complete message below.
                 @Override
                 public void handleSuccess(int flags) {
-                    if(state==State.FREEZE) {
-                        state = State.PIP;
-                        timer.schedule(new TimerTask() {
-                            @Override
-                            public void run() {
-                                sendPipRequest();
-                                startTimeout(3000);
-                            }
-                        }, 130);
-                    } else {
-                        // ignore; maybe a late timeout callback.
-                    }
                 }
 
                 @Override
                 public void handleFailure(int errorCode) {
-                    // It is actually OK to have this fail because the remote node may have
-                    // rebooted.
-                    handleSuccess(0);
                 }
             });
+        state = State.INITCOMPL;
+        startTimeout(FREEZE_REBOOT_TIMEOUT_MSEC);
     }
 
     private Timer timer;
     private TimerTask task = null;
-    void startTimeout(int period) {
+    private void startTimeout(int period_msec) {
         task = new TimerTask(){
             public void run(){
                 timerExpired();
             }
         };
-        timer.schedule(task, period);
+        timer.schedule(task, period_msec);
     }
-    void endTimeout() {
+    private void endTimeout() {
         if (task != null) task.cancel();
         else {
             state = State.FAIL;
-            
         }
         task = null;
     }
-    void timerExpired() {
-        failWith(1, "Timed out");
+    private void timerExpired() {
+        failWith(1, "Timed out in state " + state.name());
     }
 
-    //@Override
+    /**
+     * Checks if a message is coming back from the target node to us.
+     * @param msg an addressed message
+     * @return true iff the addressed message is coming from the loader target and addressed to
+     * the loader client node.
+     */
+    private boolean isReply(Message msg) {
+        if (!msg.getSourceNodeID().equals(dest)) {
+            return false;
+        }
+        if (msg instanceof AddressedMessage) {
+            if (!((AddressedMessage) msg).getDestNodeID().equals(src)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
     public void handleInitializationComplete(InitializationCompleteMessage msg, Connection sender){
                                         //System.out.println("lhandleInitializationComplete state: "+state);
-//        if (state == State.FREEZE && msg.getSourceNodeID().equals(dest)) { state = State.PIP; sendPipRequest(); }
-//        if (state == State.INITCOMPL && msg.getSourceNodeID().equals(dest)) { state = State.PIP; sendPipRequest(); }
+        if (state == State.INITCOMPL && isReply(msg)) {
+            endTimeout();
+            state = State.PIP;
+            sendPipRequest();
+        }
+        if (state == State.SUCCESS && isReply(msg)) {
+            state = State.IDLE;
+        }
     }
-    void sendPipRequest() {
+    private void sendPipRequest() {
         state = State.PIPREPLY;
-                                       //System.out.println("lSendPipRequest "+state);
         Message msg = new ProtocolIdentificationRequestMessage(src, dest);
         connection.put(msg, this);
+        startTimeout(PIP_TIMEOUT_MSEC);
     }
     @Override
     public void handleProtocolIdentificationReply(ProtocolIdentificationReplyMessage msg, Connection sender){
-                                       //System.out.println("lhandleProtocolIdentificationReply Enter:"+state);
-                                       // System.out.println("lmsg.getSourceNodeID():"+msg.getSourceNodeID());
-                                //System.out.println("lmsg.getValue():"+String.format("0x%12X",msg.getValue()));
-        endTimeout();
-        if (state == State.PIPREPLY && msg.getSourceNodeID().equals(dest)) {
-            if((msg.getValue()&0x000010000000L)==0) {
-                state=State.FAIL;
-                errorString = "Target not in Upgrade state.";
-            }
-            else if((msg.getValue()&0x200000000000L)!=0) {
+        if (state == State.PIPREPLY && isReply(msg)) {
+            endTimeout();
+            ProtocolIdentification pi = new ProtocolIdentification(msg.getSourceNodeID(), msg);
+            if(!pi.hasProtocol(Protocol.FirmwareUpgradeActive)) {
+                failWith(1, "Target not in Upgrade state.");
+            } else if(pi.hasProtocol(Protocol.Stream)) {
                 state = State.SETUPSTREAM;
-                                    //System.out.println("lStream ok:"+state);
                 setupStream();
-            } else if((msg.getValue()&0x400000000000L)!=0) {
+            } else if(pi.hasProtocol(Protocol.Datagram)) {
                 state = State.DG;
-                                    //System.out.println("lDGs ok:"+state);
-               sendDGs();
+                sendDGs();
             } else {
-                state = State.FAIL;
-                errorString = "Target has no Streams nor Datagrams!";
+                failWith(1, "Target has no Streams nor Datagrams!");
             }
         }
-                                    //System.out.println("lhandleProtocolIdentificationReply Exit:"+state);
     }
 
-    int bufferSize;      // chunk size
-    int startaddr;
-    int endaddr;
-    int totalmsgs;
-    int sentmsgs;
-    int location;
-    int nextIndex;
+    private int bufferSize;      // chunk size
+    private int nextIndex;
     private int errorCounter;
-    float progress;
-    float replyCount;
-    float expectedTransactions;
-    byte destStreamID;
-    byte sourceStreamID = 4;  // notional value
+    private byte destStreamID;
 
-// ============================= STREAMS ==============================================
-    void setupStream() {
-                                      // System.out.println("lSetup Stream ");
+    // ============================= STREAMS ==============================================
+    private void setupStream() {
         bufferSize = 16384;
         state = State.STREAM;
-        
-        mcs.request(new McsWriteStreamMemo(dest, space, address, 4) {
+
+        mcs.request(new McsWriteStreamMemo(dest, space, address, SRC_STREAM_ID) {
             @Override
             public void handleSuccess() {
                 sendStream();
@@ -216,38 +209,38 @@ public class LoaderClient extends MessageDecoder {
 
             @Override
             public void handleFailure(String where, int errorCode) {
-                state = State.FAIL;
-                logger.warning("Failed to setup stream at " + where + ": error 0x" + Integer
-                        .toHexString(errorCode));
+                String f = "Failed to setup stream at " + where + ": error 0x" + Integer
+                        .toHexString(errorCode);
+                logger.warning(f);
+                failWith(errorCode, f);
             }
         });
     }
-        
-    void sendStream() {
+
+    private void sendStream() {
                                       // System.out.println("lSend Stream ");
-        StreamInitiateRequestMessage m = new StreamInitiateRequestMessage(src, dest, bufferSize, sourceStreamID, destStreamID);
+        // @todo the destStreamID is probably bogus at this point. Check why it is needed here.
+        StreamInitiateRequestMessage m = new StreamInitiateRequestMessage(src, dest, bufferSize, SRC_STREAM_ID, destStreamID);
         connection.put(m, this);
-    }
-    
-    void handleStreamDataCompleteMessage() {
-                                      // System.out.println("l>>>handleStreamDataCompleteMessage");
+        startTimeout(STREAM_INIT_TIMEOUT_MSEC);
     }
 
+    @Override
     public void handleStreamInitiateReply(StreamInitiateReplyMessage msg, Connection sender){
                                       // System.out.println("handleStreamInitiateReply ");
         // pick up buffer size to use
-        if(state==State.STREAM && sourceStreamID==msg.getSourceStreamID()) {
+        if(state==State.STREAM && isReply(msg) && SRC_STREAM_ID == msg.getSourceStreamID()) {
+            endTimeout();
             this.bufferSize = msg.getBufferSize();
             this.destStreamID = msg.getDestinationStreamID();
             // init transfer
             nextIndex = 0;
             // send data
             state=State.STREAMDATA;
-                                          // System.out.println("Stream proceed ");
             sendStreamNext();
         }
     }
-    public void sendStreamNext() {
+    private void sendStreamNext() {
         int size = Math.min(bufferSize, content.length-nextIndex);
         int[] data = new int[size];
         // copy the needed data
@@ -258,34 +251,37 @@ public class LoaderClient extends MessageDecoder {
         // are we done?
         nextIndex = nextIndex+size;
         feedback.onProgress(100.0F * (float)nextIndex / (float)content.length);
-        if (nextIndex < content.length) return; // wait for Data Proceed message
+        if (nextIndex < content.length) {
+            startTimeout(STREAM_DATA_PROCEED_TIMEOUT_MSEC);
+            return; // wait for Data Proceed message
+        }
         // yes, say we're done
-        m = new StreamDataCompleteMessage(src, dest, sourceStreamID, destStreamID);
+        m = new StreamDataCompleteMessage(src, dest, SRC_STREAM_ID, destStreamID);
         connection.put(m, this);
         sendUnfreeze();
         state = State.SUCCESS;
     }
-    //public void sendStreamComplete() {
-        //connection.put(new StreamDataCompleteMessage(src, dest, sourceStreamID, destStreamID), this);
-    //    sendUnfreeze();
-    //}
+
+    @Override
     public void handleStreamDataProceed(StreamDataProceedMessage msg, Connection sender){
                                       // System.out.println("handleStreamDataProceed");
-        sendStreamNext();
+        if (state == State.STREAMDATA && isReply(msg)) {
+            endTimeout();
+            sendStreamNext();
+        }
     }
-    
-    
-// ============================= DATAGRAMS ==============================================
-    void sendDGs() {
+
+
+    // ============================= DATAGRAMS ==============================================
+    private void sendDGs() {
                                        //System.out.println("\nlsendDGs: ");
         nextIndex = 0;
         bufferSize = 64;
-        replyCount = 0;
         errorCounter = 0;
-        expectedTransactions = content.length / bufferSize;
         sendDGNext();
     }
-    void sendDGNext() {
+
+    private void sendDGNext() {
         final int size = Math.min(bufferSize, content.length-nextIndex);
                                     //System.out.println("lsendDGNext Enter: "+state);
                                     //System.out.println("content.length: "+content.length);
@@ -294,8 +290,8 @@ public class LoaderClient extends MessageDecoder {
                                     //System.out.println("lsize: "+size);
         byte[] data = new byte[size];
         // copy the needed data
-        for (int i=0; i<size; i++) data[i] = content[nextIndex+i];
-        
+        System.arraycopy(content, nextIndex, data, 0, size);
+
         mcs.requestWrite(dest, space, nextIndex, data, new McsWriteHandler() {
             @Override
             public void handleFailure(int errorCode) {
@@ -321,9 +317,8 @@ public class LoaderClient extends MessageDecoder {
         });
     }
 
-    void sendUnfreeze() {
+    private void sendUnfreeze() {
         dcs.sendData(new DatagramService.DatagramServiceTransmitMemo(dest, new int[]{0x20, 0xA0, space}) {
-
             @Override
             public void handleSuccess(int flags) {
                 if (state == State.SUCCESS) {
@@ -341,7 +336,6 @@ public class LoaderClient extends MessageDecoder {
                     failWith(errorCode, "Download Failed in UnFreeze");
                 } // else we already reported a failure
             }
-
         });
     }
 

--- a/src/org/openlcb/ProtocolIdentification.java
+++ b/src/org/openlcb/ProtocolIdentification.java
@@ -99,4 +99,13 @@ public class ProtocolIdentification {
     public List<String> getProtocolNames() {
         return Protocol.decodeNames(value);
     }
+
+    /**
+     * Checks if the PIP response from the constructor claims to support the given protocol.
+     * @param protocol enum representing the protocol bit to test
+     * @return true if protocol is supported, false otherwise.
+     */
+    boolean hasProtocol(Protocol protocol) {
+        return protocol.supports(value);
+    }
 }

--- a/test/org/openlcb/LoaderClientTest.java
+++ b/test/org/openlcb/LoaderClientTest.java
@@ -280,8 +280,9 @@ public class LoaderClientTest {
         Assert.assertTrue(messagesReceived.get(0).equals(new StreamInitiateRequestMessage(hereID,farID,16384,(byte)4,(byte)0))); // Stream negn
         messagesReceived.clear();
         // *********** note small buffersize! **********
-        xmt.put(new StreamInitiateReplyMessage(hereID,farID,6,(byte)4,(byte)6), null);
+        xmt.put(new StreamInitiateReplyMessage(farID,hereID,6,(byte)4,(byte)6), null);
     // Stream Data
+
         Assert.assertEquals("stream data", 1, messagesReceived.size());
                                         //System.out.println("Msg0: "+(messagesReceived.get(0) != null ? messagesReceived.get(0).toString() : " == null"));
         Assert.assertTrue(messagesReceived.get(0).equals(new StreamDataSendMessage(hereID,farID,(byte)6,new int[]{'a','b','c','d','e','f'})));
@@ -333,7 +334,7 @@ public class LoaderClientTest {
         Assert.assertEquals(new StreamInitiateRequestMessage(hereID, farID, 16384, (byte)4, (byte)0), messagesReceived.get(0));
         messagesReceived.clear();
         // *********** note larger buffersize! **********
-        xmt.put(new StreamInitiateReplyMessage(hereID,farID,64,(byte)4,(byte)6), null);
+        xmt.put(new StreamInitiateReplyMessage(farID,hereID,64,(byte)4,(byte)6), null);
         // Stream Data
         Assert.assertEquals("stream data", 3, messagesReceived.size());
         Assert.assertTrue(messagesReceived.get(0).equals(new StreamDataSendMessage(hereID,farID,(byte)6,new int[]{'a','b','c','d','e','f','g','h','i','j'})));

--- a/test/org/openlcb/ProtocolIdentificationTest.java
+++ b/test/org/openlcb/ProtocolIdentificationTest.java
@@ -69,6 +69,24 @@ public class ProtocolIdentificationTest  {
         
         Assert.assertTrue("supports", !p.supports(0));
     }
+
+    @Test
+    public void hasProtocol() {
+        ProtocolIdentification pi = new ProtocolIdentification(
+                new NodeID(new byte[]{2,3,3,4,5,6}),
+                new ProtocolIdentificationReplyMessage(
+                        new NodeID(new byte[]{1,3,3,4,5,6}),new NodeID(new byte[]{2,3,3,4,5,6}),
+                        0x000F00000000L));
+        Assert.assertTrue(pi.hasProtocol(ProtocolIdentification.Protocol.ConfigurationDescription));
+        Assert.assertFalse(pi.hasProtocol(ProtocolIdentification.Protocol
+                .FirmwareUpgrade));
+        Assert.assertFalse(pi.hasProtocol(ProtocolIdentification.Protocol
+                .FirmwareUpgradeActive));
+        Assert.assertFalse(pi.hasProtocol(ProtocolIdentification.Protocol
+                .Datagram));
+        Assert.assertTrue(pi.hasProtocol(ProtocolIdentification.Protocol.FunctionDescription));
+        Assert.assertTrue(pi.hasProtocol(ProtocolIdentification.Protocol.DccCommandStation));
+    }
     
     @Test
     public void testCreationFromMessage() {


### PR DESCRIPTION
- clean up the code from dead code in comments, indentation and method access
- consistently apply the timeouts
- consistently check the state machine and whether the messages arriving are
  indeed targeted at us. This fixed NPEs when somebody else on the network
  is doing a firmware upgrade.