### PR TITLE
Fixes incorrect handling of string fields that are more than 64 characters long.

### DIFF
--- a/src/org/openlcb/cdi/impl/ConfigRepresentation.java
+++ b/src/org/openlcb/cdi/impl/ConfigRepresentation.java
@@ -683,9 +683,9 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
 
         public void setValue(String value) {
             MemorySpaceCache cache = getCacheForSpace(space);
-            byte[] b = new byte[size];
             byte[] f;
             f = value.getBytes(UTF8);
+            byte[] b = new byte[Math.min(size, f.length + 1)];
             System.arraycopy(f, 0, b, 0, Math.min(f.length, b.length - 1));
             cache.write(this.origin, b, this);
         }

--- a/test/org/openlcb/cdi/impl/ConfigRepresentationTest.java
+++ b/test/org/openlcb/cdi/impl/ConfigRepresentationTest.java
@@ -10,6 +10,7 @@ import org.openlcb.cdi.jdom.SampleFactory;
 import org.openlcb.implementations.FakeMemoryConfigurationService;
 
 import java.io.StringWriter;
+import java.util.Arrays;
 
 /**
  * Created by bracz on 11/9/16.
@@ -26,7 +27,7 @@ public class ConfigRepresentationTest {
 
             fmt.setFormat(org.jdom2.output.Format.getPrettyFormat());
 
-            String s = fmt.outputString(doc);
+            String s = fmt.outputString(doc) + "\0";
             byte[] b = s.getBytes();
             mcs.addSpace(remoteNode, mcs.SPACE_CDI, b, false);
         } catch (Exception e) {
@@ -38,7 +39,8 @@ public class ConfigRepresentationTest {
     public void testComplexCdiLoad() throws Exception {
         addCdiData(SampleFactory.getOffsetSample());
         byte[] config = new byte[1000];
-        mcs.addSpace(remoteNode, mcs.SPACE_CONFIG, config, true);
+        mcs.addSpace(remoteNode, 13, config, true);
+        mcs.addSpace(remoteNode, 14, config, true);
         ConfigRepresentation rep = new ConfigRepresentation(iface, remoteNode);
         // Since all of our memory configuration commands execute inline, the representation will
         // be ready by the time it returns.
@@ -49,7 +51,7 @@ public class ConfigRepresentationTest {
         Assert.assertEquals(2, cont.getEntries().size());
 
         class Offset {
-            int i;
+            int i = 0;
         }
         final Offset o = new Offset();
         final int[][] readOffsets = {
@@ -70,9 +72,124 @@ public class ConfigRepresentationTest {
         rep.visit(new ConfigRepresentation.Visitor() {
             @Override
             public void visitLeaf(ConfigRepresentation.CdiEntry e) {
+                Assert.assertTrue(o.i < readOffsets.length);
+                Assert.assertEquals(e.space,readOffsets[o.i][2]);
+                Assert.assertEquals(e.size,readOffsets[o.i][1]);
+                Assert.assertEquals(e.origin,readOffsets[o.i][0]);
+                o.i++;
                 super.visitLeaf(e);
             }
         });
+    }
+
+    @Test
+    public void testStringWrites() throws Exception {
+        addCdiData(SampleFactory.getLargeStringSample());
+        byte[] config = new byte[1000];
+        mcs.addSpace(remoteNode, 13, config, true);
+        ConfigRepresentation rep = new ConfigRepresentation(iface, remoteNode);
+        ConfigRepresentation.CdiContainer cont = rep.getRoot();
+        Assert.assertNotNull(cont);
+
+        Assert.assertEquals(1, cont.getEntries().size());
+
+        // Uses the visitor to find the string entry.
+        class PE {
+            ConfigRepresentation.StringEntry e = null;
+        }
+        final PE p = new PE();
+        rep.visit(new ConfigRepresentation.Visitor(){
+            @Override
+            public void visitString(ConfigRepresentation.StringEntry e) {
+                p.e = e;
+            }
+        });
+        Assert.assertNotNull(p.e);
+
+        p.e.setValue("abcdef");
+        Assert.assertEquals(1, mcs.actualWriteList.size());
+        FakeMemoryConfigurationService.ActualWrite aw = mcs.actualWriteList.get(0);
+        Assert.assertEquals(0, aw.address);
+        Assert.assertEquals(7, aw.data.length);
+        mcs.actualWriteList.clear();
+
+        char[] carr = new char[151];
+        for (int i = 0; i < 151; ++i) {
+            carr[i] = (char)(64 + i%10);
+        }
+        String testLong = new String(carr);
+        p.e.setValue(testLong);
+
+        Assert.assertEquals(3, mcs.actualWriteList.size());
+        Assert.assertEquals(13, mcs.actualWriteList.get(0).space);
+        Assert.assertEquals(0, mcs.actualWriteList.get(0).address);
+        Assert.assertEquals(64, mcs.actualWriteList.get(0).data.length);
+        Assert.assertArrayEquals(new byte[]{ //
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 10
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 20
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 30
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 40
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 50
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 60
+                64, 65, 66, 67 //
+        }, mcs.actualWriteList.get(0).data);
+
+        Assert.assertEquals(13, mcs.actualWriteList.get(1).space);
+        Assert.assertEquals(64, mcs.actualWriteList.get(1).address);
+        Assert.assertEquals(64, mcs.actualWriteList.get(1).data.length);
+        Assert.assertArrayEquals(new byte[]{ //
+                                68, 69, 70, 71, 72, 73, // 6
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 16
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 26
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 36
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 46
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 56
+                64, 65, 66, 67, 68, 69, 70, 71 // 64
+        }, mcs.actualWriteList.get(1).data);
+
+
+        Assert.assertEquals(13, mcs.actualWriteList.get(2).space);
+        Assert.assertEquals(128, mcs.actualWriteList.get(2).address);
+        Assert.assertEquals(24, mcs.actualWriteList.get(2).data.length);
+        Assert.assertArrayEquals(new byte[]{ //
+                                                72, 73, // 2
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 12
+                64, 65, 66, 67, 68, 69, 70, 71, 72, 73, // 22
+                64, 0 // NULL termination!
+        }, mcs.actualWriteList.get(2).data);
+    }
+
+    @Test
+    public void testStringWriteClips() throws Exception {
+        addCdiData(SampleFactory.getOffsetSample());
+        byte[] config = new byte[1000];
+        mcs.addSpace(remoteNode, 13, config, true);
+        mcs.addSpace(remoteNode, 14, config, true);
+        ConfigRepresentation rep = new ConfigRepresentation(iface, remoteNode);
+        ConfigRepresentation.CdiContainer cont = rep.getRoot();
+        Assert.assertNotNull(cont);
+
+        // Uses the visitor to find the string entry.
+        class PE {
+            ConfigRepresentation.StringEntry e = null;
+        }
+        final PE p = new PE();
+        rep.visit(new ConfigRepresentation.Visitor() {
+            @Override
+            public void visitString(ConfigRepresentation.StringEntry e) {
+                p.e = e;
+            }
+        });
+        Assert.assertNotNull(p.e);
+
+        p.e.setValue("12345678901234567"); // too long
+        Assert.assertEquals(1, mcs.actualWriteList.size());
+        FakeMemoryConfigurationService.ActualWrite aw = mcs.actualWriteList.get(0);
+        Assert.assertEquals(224, aw.address);
+        Assert.assertEquals(9, aw.data.length);
+        Assert.assertArrayEquals(new byte[]{ //
+                0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0
+        }, mcs.actualWriteList.get(0).data);
     }
 
     @Before

--- a/test/org/openlcb/cdi/jdom/SampleFactory.java
+++ b/test/org/openlcb/cdi/jdom/SampleFactory.java
@@ -154,6 +154,18 @@ public class SampleFactory {
         return root;
     }
 
+    /**
+     *
+     * @return An example configuration with a long string field.
+     */
+    public static Element getLargeStringSample() {
+        Element root = new Element("cdi");
+
+        root.addContent(new Element("segment").setAttribute("space", "13")
+                .addContent(new Element("string").setAttribute("size", "200"))
+        );
+        return root;
+    }
 
 
     // Main entry point for standalone run


### PR DESCRIPTION
Fixes incorrect handling of string fields that are more than 64 characters long.

Previously this has created a "jumbo" datagram that is not standards compliant.

Testing improvements:
- Adds tests for long and short string writes including clipping and correct zero termination.
- Finishes a half-implemented test in the Config Rep area.
- Fixes warnings emitted by test.