### PR TITLE
chore: Use OpenJDK instead of Oracle JDK.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ addons:
 jdk:
   - openjdk8
 
+services:
+  - xvfb
+
 before_script:
-  # setup a display on linux ( the sleep gives xvfb some time to start )
-  - if [ "$TRAVIS_OS_NAME" == "linux" ] ; then export DISPLAY=:99.0 ; sh -e /etc/init.d/xvfb start ; sleep 3 ; fi
   # runs spotbugs
   - mvn clean verify -U -P spotbugs --batch-mode -Dmaven.javadoc.skip=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
     - graphviz
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 before_script:
   # setup a display on linux ( the sleep gives xvfb some time to start )


### PR DESCRIPTION
Oracle no longer allows the JDK to be downloaded without authentication, so Travis CI can't pull it anymore.