### PR TITLE
Fix spotbugs warnings

### DIFF
--- a/src/org/openlcb/AddressedMessage.java
+++ b/src/org/openlcb/AddressedMessage.java
@@ -1,7 +1,5 @@
 package org.openlcb;
 
-// For annotations
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
 
@@ -14,13 +12,11 @@ import net.jcip.annotations.ThreadSafe;
  * pattern to do message specific-processing in e.g. a node implementation.
  *
  * @author  Bob Jacobsen   Copyright 2009, 2010
- * @version $Revision$
  * @see MessageDecoder
  */
 @Immutable
 @ThreadSafe
 abstract public class AddressedMessage extends Message {
-
     public AddressedMessage(NodeID source, NodeID dest) {
         super(source);
         destNodeID = dest;
@@ -29,28 +25,32 @@ abstract public class AddressedMessage extends Message {
     // cannot create without sourceID, destID
     protected AddressedMessage() {}
     
-    @SuppressWarnings("JCIP_FIELD_ISNT_FINAL_IN_IMMUTABLE_CLASS")
     NodeID destNodeID;
     
     public NodeID getDestNodeID() { return destNodeID; }
          
-     /**
-      * To be equal, messages have to have the
-      * same type and content
-      */
+    /**
+     * To be equal, messages have to have the same type and content
+     */
     @Override
-     public boolean equals(Object o) {
-        if (o == null) return false;
-        if (! (o instanceof AddressedMessage))
+    public boolean equals(Object o) {
+        if (o == null) {
             return false;
+        }
+        if (! (o instanceof AddressedMessage)) {
+            return false;
+        }
         AddressedMessage msg = (AddressedMessage) o;
-        if (!this.getDestNodeID().equals(msg.getDestNodeID()))
+        if (!this.getDestNodeID().equals(msg.getDestNodeID())) {
             return false;
-        else return super.equals(o);
-     }
+        }
+        return super.equals(o);
+    }
 
-     @Override
-     public int hashCode() { return super.hashCode()+getDestNodeID().hashCode(); }
+    @Override
+    public int hashCode() {
+        return super.hashCode()+getDestNodeID().hashCode();
+    }
 
     @Override
     public String toString() {

--- a/src/org/openlcb/MimicNodeStore.java
+++ b/src/org/openlcb/MimicNodeStore.java
@@ -1,8 +1,9 @@
 package org.openlcb;
 
-import java.util.HashMap;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
 import java.util.Collection;
-
+import java.util.HashMap;
 import java.util.Queue;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -18,45 +19,63 @@ import javax.annotation.Nullable;
  * Provides a Connection for incoming Messages.
  *
  * @author  Bob Jacobsen   Copyright 2011
- * @version $Revision$
  */
 public class MimicNodeStore extends AbstractConnection {
-
     public static final String ADD_PROP_NODE = "AddNode";
     public static final String CLEAR_ALL_NODES = "ClearAllNodes";
     private final static Logger logger = Logger.getLogger(MimicNodeStore.class.getName());
+    
+    private static class MimicNodeStoreTimer {
+        private Timer timer;
+        
+        private synchronized void init() {
+            if (timer == null) {
+                // only initialize timer if it is not initialized or has been canceled before
+                timer = new Timer("OpenLCB Mimic Node Store Timer");
+            }
+        }
+
+        private synchronized void schedule(final TimerTask t, final int delay) {
+            if (timer != null) {
+                // only schedule task if timer is initialized and not canceled
+                timer.schedule(t,delay);
+            }
+        }
+        
+        private synchronized void cancel() {
+            if (timer != null ) {
+                // only cancel time if it is initialized and not canceled
+                timer.cancel();
+                timer = null;
+            }
+        }
+    }
 
     public MimicNodeStore(Connection connection, NodeID node) {
         this.connection = connection;
         this.node = node;
-        if(timer == null) {
-           timer = new Timer("OpenLCB Mimic Node Store Timer");
-        }
+        
+        timer.init();
     }
 
-    public void dispose(){
-       // cancel the timer.
-       if(timer != null ) {
-          timer.cancel();
-          timer=null;
-       }
+    public void dispose() {
+        // cancel the timer.
+        timer.cancel();
     }
 
-    void scheduleTask(TimerTask t,int delay){
-       if(timer == null) {
-          return; // attempt to schedule after dispose.
-       }
-       timer.schedule(t,delay);
+    void scheduleTask(TimerTask t, int delay) {
+        timer.schedule(t,delay);
     }
     
     Connection connection;
     NodeID node;
-    private static Timer timer;
+    private static MimicNodeStoreTimer timer = new MimicNodeStoreTimer();
     
     public Collection<NodeMemo> getNodeMemos() {
         return map.values();
     } 
     
+    @Override
     public void put(Message msg, Connection sender) {
         NodeMemo memo = addNode(msg.getSourceNodeID());
         // check for necessary updates in specific node
@@ -84,13 +103,16 @@ public class MimicNodeStore extends AbstractConnection {
     
     /**
      * If node not present, initiate process to find it.
-     * @param id    remote node ID to find
-     * @return NodeMemo already known, but note you have to
-     * register listeners before calling in any case
+     * 
+     * @param id remote node ID to find
+     * @return NodeMemo already known, but note you have to register listeners before calling
+     *         in any case
      */
     public NodeMemo findNode(NodeID id) {
         NodeMemo memo = map.get(id);
-        if (memo != null) return memo;
+        if (memo != null) {
+            return memo;
+        }
         
         // create and send targeted request
         connection.put(new VerifyNodeIDNumberMessage(node, id), null);
@@ -99,34 +121,34 @@ public class MimicNodeStore extends AbstractConnection {
     
     public SimpleNodeIdent getSimpleNodeIdent(NodeID dest) {
         NodeMemo memo = map.get(dest);
-        if (memo == null) {
-            return null;
-        } else {
-            return memo.getSimpleNodeIdent();
-        }
+        return (memo == null) ? null : memo.getSimpleNodeIdent();
     }
     
     public ProtocolIdentification getProtocolIdentification(NodeID dest) {
         NodeMemo memo = map.get(dest);
-        if (memo == null) {
-            return null;
-        } else {
-            return memo.getProtocolIdentification();
-        }
+        return (memo == null) ? null : memo.getProtocolIdentification();
     }
     
     HashMap<NodeID, NodeMemo> map = new java.util.HashMap<NodeID, NodeMemo>();
 
-    java.beans.PropertyChangeSupport pcs = new java.beans.PropertyChangeSupport(this);
-    public synchronized void addPropertyChangeListener(java.beans.PropertyChangeListener l) {pcs.addPropertyChangeListener(l);}
-    public synchronized void removePropertyChangeListener(java.beans.PropertyChangeListener l) {pcs.removePropertyChangeListener(l);}
+    PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+    
+    public synchronized void addPropertyChangeListener(PropertyChangeListener l) {
+        pcs.addPropertyChangeListener(l);
+    }
+    
+    public synchronized void removePropertyChangeListener(PropertyChangeListener l) {
+        pcs.removePropertyChangeListener(l);
+    }
 
     public class NodeMemo extends MessageDecoder {
         public static final String UPDATE_PROP_SIMPLE_NODE_IDENT = "updateSimpleNodeIdent";
         public static final String UPDATE_PROP_PROTOCOL = "updateProtocol";
         NodeID id;
         
-        public NodeMemo(NodeID id) { this.id = id; }
+        public NodeMemo(NodeID id) {
+            this.id = id;
+        }
         
         public NodeID getNodeID() {
             return id;
@@ -148,6 +170,7 @@ public class MimicNodeStore extends AbstractConnection {
             if (request == null) {
                 return;
             }
+            
             currentInteraction = request;
             request.sendRequest(connection);
             currentTask = new TimerTask() {
@@ -161,11 +184,15 @@ public class MimicNodeStore extends AbstractConnection {
         }
 
         public synchronized void tryCompleteInteraction(@Nullable Interaction request) {
-            if (request == null) return;
+            if (request == null) {
+                return;
+            }
             synchronized (request) {
                 request.isComplete = true;
             }
-            if (currentInteraction != request) return;
+            if (currentInteraction != request) {
+                return;
+            }
             completeInteraction(request);
         }
 
@@ -188,13 +215,16 @@ public class MimicNodeStore extends AbstractConnection {
 
         ProtocolIdentification pIdent = null;
         Interaction pipInteraction = null;
+        
+        @Override
         public void handleProtocolIdentificationReply(ProtocolIdentificationReplyMessage msg, Connection sender){
             // accept assumes from mimic'd node
             pIdent = new ProtocolIdentification(node, msg);
             pcs.firePropertyChange(UPDATE_PROP_PROTOCOL, null, pIdent);
             tryCompleteInteraction(pipInteraction);
             pipInteraction = null;
-        }  
+        }
+        
         public ProtocolIdentification getProtocolIdentification() {
             if (pIdent == null) {
                 if (id == null) {
@@ -217,7 +247,9 @@ public class MimicNodeStore extends AbstractConnection {
                     @Override
                     void onTimeout() {
                         synchronized (this) {
-                            if (isComplete) return;
+                            if (isComplete) {
+                                return;
+                            }
                         }
                         final Interaction request = this;
                         if (--numTriesLeft > 0) {
@@ -237,18 +269,23 @@ public class MimicNodeStore extends AbstractConnection {
 
         SimpleNodeIdent pSimpleNode = null;
         Interaction snipInteraction = null;
-        public void handleSimpleNodeIdentInfoReply(SimpleNodeIdentInfoReplyMessage msg, Connection sender){
+        
+        @Override
+        public void handleSimpleNodeIdentInfoReply(
+                SimpleNodeIdentInfoReplyMessage msg, Connection sender){
             // accept assumes from mimic'd node
-            if (pSimpleNode == null) 
+            if (pSimpleNode == null) {
                 pSimpleNode = new SimpleNodeIdent(msg);
-            else
+            } else {
                 pSimpleNode.addMsg(msg);
+            }
             if (pSimpleNode.contentComplete()) {
                 tryCompleteInteraction(snipInteraction);
                 snipInteraction = null;
             }
             pcs.firePropertyChange(UPDATE_PROP_SIMPLE_NODE_IDENT, null, pSimpleNode);
         }  
+        
         public SimpleNodeIdent getSimpleNodeIdent() {
             if (pSimpleNode == null) {
                 pSimpleNode = new SimpleNodeIdent(node, id);
@@ -268,7 +305,9 @@ public class MimicNodeStore extends AbstractConnection {
                     @Override
                     void onTimeout() {
                         synchronized (this) {
-                            if (isComplete) return;
+                            if (isComplete) {
+                                return;
+                            }
                         }
                         final Interaction request = this;
                         if (--numTriesLeft > 0) {
@@ -286,32 +325,47 @@ public class MimicNodeStore extends AbstractConnection {
             return pSimpleNode;
         }
 
+        @Override
         public void handleOptionalIntRejected(OptionalIntRejectedMessage msg, Connection sender){
-            if (msg.getMti() == MessageTypeIdentifier.SimpleNodeIdentInfoRequest.mti()) {
+            if (msg.getRejectMTI() == MessageTypeIdentifier.SimpleNodeIdentInfoRequest.mti()) {
                 // check for temporary error
-                if ( (msg.getCode() & 0x1000 ) == 0) {
+                if ((msg.getCode() & 0x1000) == 0) {
                     // not a temporary error, assume a permanent error
-                    logger.log(Level.SEVERE, "Permanent error geting Simple Node Info for node {0} code 0x{1}", new Object[]{msg.getSourceNodeID(), Integer.toHexString(msg.getCode()).toUpperCase()});
+                    String logmsg = "Permanent error geting Simple Node Info "
+                            + "for node {0} code 0x{1}";
+                    Object[] logparam = new Object[] {
+                                msg.getSourceNodeID(),
+                                Integer.toHexString(msg.getCode()).toUpperCase()
+                            };
+                    logger.log(Level.SEVERE, logmsg, logparam);
                     return;
                 }
                 // have to resend the SNII request
-                connection.put(new SimpleNodeIdentInfoRequestMessage(node, msg.getSourceNodeID()), null);
+                connection.put(new SimpleNodeIdentInfoRequestMessage(
+                        node, msg.getSourceNodeID()), null);
             }
-            if (msg.getMti() == MessageTypeIdentifier.ProtocolSupportInquiry.mti()) {
+            if (msg.getRejectMTI() == MessageTypeIdentifier.ProtocolSupportInquiry.mti()) {
                 // check for temporary error
-                if ( (msg.getCode() & 0x1000 ) == 0) {
+                if ((msg.getCode() & 0x1000) == 0) {
                     // not a temporary error, assume a permanent error
-                    logger.log(Level.SEVERE, "Permanent error geting Protocol Identification information for node {0} code 0x{1}", new Object[]{msg.getSourceNodeID(), Integer.toHexString(msg.getCode()).toUpperCase()});
+                    String logmsg = "Permanent error geting Protocol Identification information "
+                            + "for node {0} code 0x{1}";
+                    Object[] logparam = new Object[] {
+                                msg.getSourceNodeID(),
+                                Integer.toHexString(msg.getCode()).toUpperCase()
+                            };
+                    logger.log(Level.SEVERE, logmsg, logparam);
                     return;
                 }
                 // have to resend the PIP request
-                connection.put(new ProtocolIdentificationRequestMessage(node, msg.getSourceNodeID
-                        ()), null);
+                connection.put(new ProtocolIdentificationRequestMessage(
+                        node, msg.getSourceNodeID()), null);
             }
         }
 
         @Override
-        public void handleInitializationComplete(InitializationCompleteMessage msg, Connection sender) {
+        public void handleInitializationComplete(
+                InitializationCompleteMessage msg, Connection sender) {
             if (!msg.getSourceNodeID().equals(id)) {
                 return;
             }
@@ -344,9 +398,14 @@ public class MimicNodeStore extends AbstractConnection {
             }
         }
 
-        java.beans.PropertyChangeSupport pcs = new java.beans.PropertyChangeSupport(this);
-        public synchronized void addPropertyChangeListener(java.beans.PropertyChangeListener l) {pcs.addPropertyChangeListener(l);}
-        public synchronized void removePropertyChangeListener(java.beans.PropertyChangeListener l) {pcs.removePropertyChangeListener(l);}
+        PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+        
+        public synchronized void addPropertyChangeListener(PropertyChangeListener l) {
+            pcs.addPropertyChangeListener(l);
+        }
+        
+        public synchronized void removePropertyChangeListener(PropertyChangeListener l) {
+            pcs.removePropertyChangeListener(l);
+        }
     }
-
 }

--- a/src/org/openlcb/OptionalIntRejectedMessage.java
+++ b/src/org/openlcb/OptionalIntRejectedMessage.java
@@ -22,7 +22,8 @@ public class OptionalIntRejectedMessage extends AddressedPayloadMessage {
     int mti;
     int code;
     
-    @SuppressFBWarnings
+    @SuppressFBWarnings(value="NM_VERY_CONFUSING",
+            justification="Very confusing to have methods getMti() and getMTI()")
     @Deprecated
     public int getMti() {
         return mti;

--- a/src/org/openlcb/OptionalIntRejectedMessage.java
+++ b/src/org/openlcb/OptionalIntRejectedMessage.java
@@ -1,19 +1,18 @@
 package org.openlcb;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 // For annotations
-import net.jcip.annotations.*; 
-import edu.umd.cs.findbugs.annotations.*; 
+import net.jcip.annotations.Immutable;
+import net.jcip.annotations.ThreadSafe; 
 
 /**
  * Optional Interaction Rejected message
  *
  * @author  Bob Jacobsen   Copyright 2012
- * @version $Revision: 529 $
  */
 @Immutable
 @ThreadSafe
 public class OptionalIntRejectedMessage extends AddressedPayloadMessage {
-    
     public OptionalIntRejectedMessage(NodeID source, NodeID dest, int mti, int code) {
         super(source, dest, toPayload(mti, code));
         this.mti = mti;
@@ -23,9 +22,19 @@ public class OptionalIntRejectedMessage extends AddressedPayloadMessage {
     int mti;
     int code;
     
-    public int getMti() { return mti; }
+    @SuppressFBWarnings
+    @Deprecated
+    public int getMti() {
+        return mti;
+    }
     
-    public int getCode() { return code; }
+    public int getRejectMTI() {
+        return mti;
+    }
+    
+    public int getCode() {
+        return code;
+    }
 
     private static byte[] toPayload(int mti, int code) {
         byte[] b = new byte[4];
@@ -33,38 +42,42 @@ public class OptionalIntRejectedMessage extends AddressedPayloadMessage {
         Utilities.HostToNetworkUint16(b, 2, code);
         return b;
     }
-     /**
-      * To be equal, messages have to have the
-      * same type and content
-      */
-     public boolean equals(Object o) {
-        if (o == null) return false;
-        if (! (o instanceof OptionalIntRejectedMessage))
-            return false;
-        if (this.mti != ((OptionalIntRejectedMessage)o).getMti() ) return false;
-        if (this.code != ((OptionalIntRejectedMessage)o).getCode() ) return false;
-        return super.equals(o);
-     }
-
+    
     /**
-     * Implement message-type-specific
-     * processing when this message
-     * is received by a node.
-     *<p>
+     * To be equal, messages have to have the same type and content.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof OptionalIntRejectedMessage) {
+            return equals((OptionalIntRejectedMessage) o);
+        }
+        return false;
+    }
+
+    public boolean equals(OptionalIntRejectedMessage o) {
+        if ((o == null) || (this.mti != o.getRejectMTI()) || (this.code != o.getCode())) {
+            return false;
+        }
+        return super.equals(o);
+    }
+    
+    /**
+     * Implement message-type-specific processing when this message is received by a node.
+     * <p>
      * Default is to do nothing.
      */
-     @Override
-     public void applyTo(MessageDecoder decoder, Connection sender) {
+    @Override
+    public void applyTo(MessageDecoder decoder, Connection sender) {
         decoder.handleOptionalIntRejected(this, sender);
-     }
+    }
 
     @Override
     public String toString() {
         StringBuilder value = new StringBuilder(super.toString());
         value.append(" Optional Interaction Rejected for MTI 0x");  
-        value.append(Integer.toHexString((int)(getMti()&0xFFF)).toUpperCase());  
+        value.append(Integer.toHexString(getRejectMTI()&0xFFF).toUpperCase());  
         value.append(" code 0x");  
-        value.append(Integer.toHexString((int)(getCode()&0xFFFF)).toUpperCase());  
+        value.append(Integer.toHexString(getCode()&0xFFFF).toUpperCase());  
         return new String(value);   
     }
 

--- a/src/org/openlcb/protocols/TimeKeeper.java
+++ b/src/org/openlcb/protocols/TimeKeeper.java
@@ -7,77 +7,126 @@ package org.openlcb.protocols;
  *
  * Created by bracz on 9/26/18.
  */
-
 class TimeKeeper {
+    /**
+     * Gets the current real time.
+     * 
+     * @return the current real time.
+     */
     protected long currentTimeMillis() {
         return System.currentTimeMillis();
     }
 
-    /// @return the current fast time.
-    public long getTime() {
-        return getTime(currentTimeMillis());
+    /**
+     * Gets the current fast time.
+     * 
+     * @return the current fast time.
+     */
+    public synchronized long getTime() {
+        return translateRealToFastTime(currentTimeMillis());
     }
 
-    private long getTime(long current) {
-        if (!isRunning) {
-            return matchingFastTime;
-        }
-        long diff = current - realTimeAnchor;
-        long t = matchingFastTime + (long)(rate * diff);
-        return t;
-    }
-
-    /// Sets the current fast time. @param millis is time since epoch in milliseconds.
-    public synchronized void setTime(long millis) {
+    /**
+     * Sets the current fast time. @param millis is time since epoch in milliseconds.
+     * 
+     * @param fastTime to set.
+     */
+    public synchronized void setTime(long fastTime) {
         realTimeAnchor = currentTimeMillis();
-        matchingFastTime = millis;
+        matchingFastTime = fastTime;
     }
 
-    /// Stops the clock. Noop if the clock is already stopped.
+
+    /**
+     * Stops the clock. Noop if the clock is already stopped.
+     */
     public synchronized void stop() {
-        if (!isRunning) return;
-        long t = getTime();
-        matchingFastTime = t;
+        if (!isRunning) {
+            return;
+        }
+        
+        long currentRealTime = currentTimeMillis();
+        matchingFastTime = translateRealToFastTime(currentRealTime);
         isRunning = false;
     }
 
-    /// Starts the clock. Noop if the clock is already running.
+    /**
+     * Starts the clock. Noop if the clock is already running.
+     */
     public synchronized void start() {
-        if (isRunning) return;
+        if (isRunning) {
+            return;
+        }
+        
         realTimeAnchor = currentTimeMillis();
         isRunning = true;
     }
 
-    /// Sets the rate of the clock. The clock may be stopped or running.
+    /**
+     * Sets the rate of the clock. The clock may be stopped or running.
+     * 
+     * @param r rate to set.
+     */
     public synchronized void setRate(double r) {
-        if (rate == r) return;
-        long c = currentTimeMillis();
+        if (rate == r) {
+            return;
+        }
+        
         // need to re-anchor the clock first.
-        long t = getTime(c);
-        realTimeAnchor = c;
-        matchingFastTime = t;
+        long currentRealTime = currentTimeMillis();
+        long curentFastTime = translateRealToFastTime(currentRealTime);
+        realTimeAnchor = currentRealTime;
+        matchingFastTime = curentFastTime;
+        
         // then we can set the rate.
         rate = r;
     }
 
-    /// Translates a fast time timestamp to a real time when we will reach it (or have reached it).
-    /// @param fastTime is a millisecond timestamp in the fast time that is in the future
-    /// (i.e. ahead of getTime() if rate is positive, or below it if negative).
-    /// @return -1 if the clock is stopped or rate is zero. Otherwise it is
-    /// a real time millisecond timestamp when the given fast time will be reached.
-    public long translateFastToRealTime(long fastTime) {
-        if (!isRunning || rate == 0) return -1;
-        double delta = fastTime - matchingFastTime;
-        long deltaRealTime = (long) (delta / rate);
+    /**
+     * Translates a fast time timestamp to a real time when we will reach it (or have reached it).
+     * 
+     * @param fastTime is a millisecond timestamp in the fast time that is in the future
+     *        (i.e. ahead of getTime() if rate is positive, or below it if negative).
+     * @return -1 if the clock is stopped or rate is zero. Otherwise it is a real time
+     *         millisecond timestamp when the given fast time will be reached.
+     */
+    public synchronized long translateFastToRealTime(long fastTime) {
+        if (!isRunning || (rate == 0)) {
+            return -1;
+        }
+        
+        long deltaFastTime = fastTime - matchingFastTime;
+        long deltaRealTime = (long) (deltaFastTime / rate);
         return realTimeAnchor + deltaRealTime;
     }
 
-    /// true if the clock is running
+    /**
+     * Translates a real time timestamp to a fast time.
+     * 
+     * @param realTime is a millisecond timestamp in the real time.
+     * @return a fast time millisecond timestamp when the given real time will be reached.
+     */
+    public synchronized long translateRealToFastTime(long realTime) {
+        if (!isRunning) {
+            return matchingFastTime;
+        }
+        
+        long deltaRealTime = realTime - realTimeAnchor;
+        long deltaFastTime = (long) (deltaRealTime * rate);
+        return matchingFastTime + deltaFastTime;
+    }
+    
+    /** Is true if the clock is running. */
     boolean isRunning = true;
-    /// the real time for which we are storing the equivalent fast time. Ignored if !isRunning. Defined as msec since epoch.
+    
+    /** The real time for which we are storing the equivalent fast time. Ignored if !isRunning.
+     *  Defined as msec since epoch. */
     long realTimeAnchor = currentTimeMillis();
-    /// fast time matching the real time anchor, or the fast time when the clock was stopped. Defined as msec since epoch.
+    
+    /** Fast time matching the real time anchor, or the fast time when the clock was stopped.
+     *  Defined as msec since epoch. */
     long matchingFastTime = realTimeAnchor;
-    /// Rate of the fast clock, may be negative.
+    
+    /** Rate of the fast clock, may be negative. */
     double rate = 1.0;
 }

--- a/test/org/openlcb/EventIDTest.java
+++ b/test/org/openlcb/EventIDTest.java
@@ -1,18 +1,22 @@
 package org.openlcb;
 
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
 public class EventIDTest {
-
+    @SuppressFBWarnings
     @Test
     public void testNullArg() {
         try {
-            new EventID((byte[])null);
-        } catch (IllegalArgumentException e) { return; }
+            new EventID((byte[]) null);
+        } catch (IllegalArgumentException e) {
+            return;
+        }
         Assert.fail("Should have thrown exception");
     }
 
@@ -20,7 +24,9 @@ public class EventIDTest {
     public void testTooLongArg() {
         try {
             new EventID(new byte[]{1,2,3,4,5,6,7,8,9});
-        } catch (IllegalArgumentException e) { return; }
+        } catch (IllegalArgumentException e) {
+            return;
+        }
         Assert.fail("Should have thrown exception");
     }
 
@@ -28,13 +34,16 @@ public class EventIDTest {
     public void testTooShortArg() {
         try {
             new EventID(new byte[]{1,2,3,4,5,6,7});
-        } catch (IllegalArgumentException e) { return; }
+        } catch (IllegalArgumentException e) {
+            return;
+        }
         Assert.fail("Should have thrown exception");
     }
     
     @Test
     public void testOKLengthArg() {
-        new EventID(new byte[]{1,2,3,4,5,6,7,8});
+        EventID e = new EventID(new byte[]{1,2,3,4,5,6,7,8});
+        Assert.assertNotNull(e);
     }
     
     @Test
@@ -50,7 +59,6 @@ public class EventIDTest {
         EventID e1 = new EventID("1.2.3.4.5.6.7.8");
         EventID e2 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         Assert.assertTrue(e1.equals(e2));
-        
     }
 
     @Test
@@ -58,7 +66,6 @@ public class EventIDTest {
         EventID e1 = new EventID("1 2 3 4 5 6 7 8");
         EventID e2 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         Assert.assertTrue(e1.equals(e2));
-        
     }
 
     @Test
@@ -108,6 +115,7 @@ public class EventIDTest {
         Assert.assertTrue(!e1.equals(e2));
     }
 
+    @SuppressFBWarnings
     @Test
     public void testNodesAreNotEvents() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});

--- a/test/org/openlcb/EventIDTest.java
+++ b/test/org/openlcb/EventIDTest.java
@@ -9,7 +9,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * @author  Bob Jacobsen   Copyright 2009
  */
 public class EventIDTest {
-    @SuppressFBWarnings
+    @SuppressFBWarnings(value="NP_NONNULL_PARAM_VIOLATION",
+            justification="Null passed for non null parameter")
     @Test
     public void testNullArg() {
         try {
@@ -115,7 +116,8 @@ public class EventIDTest {
         Assert.assertTrue(!e1.equals(e2));
     }
 
-    @SuppressFBWarnings
+    @SuppressFBWarnings(value="EC_UNRELATED_TYPES",
+            justification="Call to equals with unrelated types")
     @Test
     public void testNodesAreNotEvents() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});

--- a/test/org/openlcb/GatewayTest.java
+++ b/test/org/openlcb/GatewayTest.java
@@ -13,14 +13,14 @@ public class GatewayTest {
 
     @Test    
     public void testCtor() {
-        getGateway();
+        Assert.assertNotNull(getGateway());
     }
 
     @Test    
     public void testGet() {
         g = getGateway();
-        g.getEastConnection();
-        g.getWestConnection();
+        Assert.assertNotNull(g.getEastConnection());
+        Assert.assertNotNull(g.getWestConnection());
     }
     
     protected boolean resultE;

--- a/test/org/openlcb/GatewayTest.java
+++ b/test/org/openlcb/GatewayTest.java
@@ -1,13 +1,12 @@
 package org.openlcb;
 
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
 public class GatewayTest {
-
     protected Gateway getGateway() {
         return new Gateway();
     }
@@ -20,8 +19,8 @@ public class GatewayTest {
     @Test    
     public void testGet() {
         g = getGateway();
-        Connection cE = g.getEastConnection();
-        Connection cW = g.getWestConnection();
+        g.getEastConnection();
+        g.getWestConnection();
     }
     
     protected boolean resultE;
@@ -33,9 +32,11 @@ public class GatewayTest {
     protected Connection cW;
     
     abstract class TestListener extends AbstractConnection {
+        @Override
         public void put(Message m, Connection n) {
             setResult();
         }
+        
         abstract void setResult();
     }
 
@@ -44,9 +45,11 @@ public class GatewayTest {
         resultE = false;
         resultW = false;
         tE = new TestListener() {
+            @Override
             void setResult() { resultE = true;}
         };
         tW = new TestListener() {
+            @Override
             void setResult() { resultW = true;}
         };
         g.registerWest(tW);
@@ -59,7 +62,8 @@ public class GatewayTest {
     public void testEastToWest() {
         buildGateway();
         Message m = new Message(new NodeID(new byte[]{1,2,3,4,5,6}))
-            {public int getMTI() {return 0; }};
+            {@Override
+            public int getMTI() {return 0; }};
 
         cE.put(m, tE);
         
@@ -77,7 +81,8 @@ public class GatewayTest {
     public void testWestToEast() {
         buildGateway();
         Message m = new Message(new NodeID(new byte[]{1,2,3,4,5,6}))
-            {public int getMTI() {return 0; }};
+            {@Override
+            public int getMTI() {return 0; }};
 
         cW.put(m, tW);
         
@@ -90,5 +95,4 @@ public class GatewayTest {
         resultE = false;
         resultW = false;
     }
-        
 }

--- a/test/org/openlcb/NodeIDTest.java
+++ b/test/org/openlcb/NodeIDTest.java
@@ -9,7 +9,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * @author  Bob Jacobsen   Copyright 2009
  */
 public class NodeIDTest {
-    @SuppressFBWarnings
+    @SuppressFBWarnings(value="NP_NONNULL_PARAM_VIOLATION",
+            justification="Null passed for non null parameter")
     @Test
     public void testNullArg() {
         try {
@@ -44,7 +45,8 @@ public class NodeIDTest {
         Assert.assertNotNull(e);
     }
     
-    @SuppressFBWarnings
+    @SuppressFBWarnings(value="NP_NONNULL_PARAM_VIOLATION",
+            justification="Null passed for non null parameter")
     @Test
     public void testNullStringArg() {
         try {
@@ -125,7 +127,8 @@ public class NodeIDTest {
         Assert.assertTrue(!e1.equals(e2));
     }
 
-    @SuppressFBWarnings
+    @SuppressFBWarnings(value="EC_UNRELATED_TYPES",
+            justification="Call to equals with unrelated types")
     @Test
     public void testNodesAreNotEvents() {
         NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6});

--- a/test/org/openlcb/NodeIDTest.java
+++ b/test/org/openlcb/NodeIDTest.java
@@ -1,52 +1,66 @@
 package org.openlcb;
 
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
 public class NodeIDTest {
-
+    @SuppressFBWarnings
     @Test
     public void testNullArg() {
         try {
-            new NodeID((byte[])null);
-        } catch (IllegalArgumentException e) { return; }
+            new NodeID((byte[]) null);
+        } catch (IllegalArgumentException e) {
+            return;
+        }
         Assert.fail("Should have thrown exception");
     }
 
     @Test
     public void testTooLongArg() {
         // shouldn't throw, just takes 1st part
-        new NodeID(new byte[]{1,2,3,4,5,6,7});
+        NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6,7});
+        NodeID e2 = new NodeID(new byte[]{1,2,3,4,5,6});
+        Assert.assertEquals(e1, e2);
     }
 
     @Test
     public void testTooShortArg() {
         try {
             new NodeID(new byte[]{1,2,3,4,5});
-        } catch (IllegalArgumentException e) { return; }
+        } catch (IllegalArgumentException e) {
+            return;
+        }
         Assert.fail("Should have thrown exception");
     }
     
     @Test
     public void testOKArg() {
-        new NodeID(new byte[]{1,2,3,4,5,6});
+        NodeID e = new NodeID(new byte[]{1,2,3,4,5,6});
+        Assert.assertNotNull(e);
     }
     
+    @SuppressFBWarnings
     @Test
     public void testNullStringArg() {
         try {
-            new NodeID((String)null);
-        } catch (IllegalArgumentException e) { return; }
+            new NodeID((String) null);
+        } catch (IllegalArgumentException e) {
+            return;
+        }
         Assert.fail("Should have thrown exception");
     }
 
     @Test
     public void testTooLongStringArg() {
         // shouldn't throw, just takes 1st part
-        new NodeID("1.2.3.4.5.6.7");
+        NodeID e1 = new NodeID("1.2.3.4.5.6.7");
+        NodeID e2 = new NodeID(new byte[]{1,2,3,4,5,6});
+        Assert.assertEquals(e1, e2);
     }
 
     @Test
@@ -59,7 +73,8 @@ public class NodeIDTest {
     
     @Test
     public void testOKStringArg() {
-        new NodeID("1.2.3.4.5.6");
+        NodeID e = new NodeID("1.2.3.4.5.6");
+        Assert.assertNotNull(e);
     }
     
     @Test
@@ -110,6 +125,7 @@ public class NodeIDTest {
         Assert.assertTrue(!e1.equals(e2));
     }
 
+    @SuppressFBWarnings
     @Test
     public void testNodesAreNotEvents() {
         NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6});
@@ -156,5 +172,4 @@ public class NodeIDTest {
         NodeID e1 = new NodeID(new byte[]{1,0x10,0x13,0x0D,(byte)0xD0,(byte)0xAB});
         Assert.assertEquals("01.10.13.0D.D0.AB", e1.toString());
     }
-
 }

--- a/test/org/openlcb/UtilitiesTest.java
+++ b/test/org/openlcb/UtilitiesTest.java
@@ -1,12 +1,12 @@
 package org.openlcb;
 
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
  */
 public class UtilitiesTest  {
-
     @Test
     public void testZeroString() {
         Assert.assertEquals("00", Utilities.toHexPair(0));
@@ -81,9 +81,20 @@ public class UtilitiesTest  {
     }
 
     boolean compareArrays(byte[] a, byte[]b) {
-        if (a == null && b == null) return true;
-        if (a.length != b.length) return false;
-        for (int i = 0; i <a.length; i++) if (a[i]!=b[i]) return false;
-        return true;
+        if ((a == null) && (b == null)) {
+            return true;
+        }
+        if ((a != null) && (b != null)) {
+            if (a.length != b.length) {
+                return false;
+            }
+            for (int i = 0; i <a.length; i++) {
+                if (a[i]!=b[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/test/org/openlcb/can/MessageBuilderTest.java
+++ b/test/org/openlcb/can/MessageBuilderTest.java
@@ -1,15 +1,37 @@
 package org.openlcb.can;
 
-import org.openlcb.*;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openlcb.AddressedMessage;
+import org.openlcb.AddressedPayloadMessage;
+import org.openlcb.DatagramAcknowledgedMessage;
+import org.openlcb.DatagramMessage;
+import org.openlcb.EventID;
+import org.openlcb.IdentifyEventsMessage;
+import org.openlcb.InitializationCompleteMessage;
+import org.openlcb.Message;
+import org.openlcb.NodeID;
+import org.openlcb.OptionalIntRejectedMessage;
+import org.openlcb.ProducerConsumerEventReportMessage;
+import org.openlcb.ProtocolIdentificationReplyMessage;
+import org.openlcb.SimpleNodeIdentInfoReplyMessage;
+import org.openlcb.StreamDataCompleteMessage;
+import org.openlcb.StreamDataProceedMessage;
+import org.openlcb.StreamInitiateReplyMessage;
+import org.openlcb.StreamInitiateRequestMessage;
+import org.openlcb.Utilities;
+import org.openlcb.VerifiedNodeIDNumberMessage;
+import org.openlcb.VerifyNodeIDNumberMessage;
 import org.openlcb.implementations.DatagramUtils;
 import org.openlcb.messages.TractionControlReplyMessage;
 import org.openlcb.messages.TractionControlRequestMessage;
 import org.openlcb.messages.TractionProxyReplyMessage;
 import org.openlcb.messages.TractionProxyRequestMessage;
-
-import java.util.List;
-
-import org.junit.*;
 
 /**
  * @author  Bob Jacobsen   Copyright 2010
@@ -27,7 +49,6 @@ public class MessageBuilderTest  {
      
     @Test	
     public void testInitializationCompleteMessage() {
-        
         Message m = new InitializationCompleteMessage(source);
         MessageBuilder b = new MessageBuilder(map);
         
@@ -40,9 +61,9 @@ public class MessageBuilderTest  {
         Assert.assertEquals("header", toHexString(0x19100123), toHexString(f0.getHeader()));
         compareContent(source.getContents(), f0);
     }
+    
     @Test	
     public void testVerifyNodeIDNumberMessageEmpty() {
-        
         Message m = new VerifyNodeIDNumberMessage(source);
         MessageBuilder b = new MessageBuilder(map);
         
@@ -55,9 +76,9 @@ public class MessageBuilderTest  {
         Assert.assertEquals("header", toHexString(0x19490123), toHexString(f0.getHeader()));
         compareContent(null, f0);
     }
+    
     @Test	
     public void testVerifyNodeIDNumberMessageWithContent() {
-        
         Message m = new VerifyNodeIDNumberMessage(source, source);
         MessageBuilder b = new MessageBuilder(map);
         
@@ -73,7 +94,6 @@ public class MessageBuilderTest  {
 
     @Test	
     public void testIdentifyEventsGlobal() {
-
         Message m = new IdentifyEventsMessage(source, null);
         MessageBuilder b = new MessageBuilder(map);
 
@@ -106,7 +126,6 @@ public class MessageBuilderTest  {
 
     @Test	
     public void testVerifiedNodeIDNumberMessage() {
-        
         Message m = new VerifiedNodeIDNumberMessage(source);
         MessageBuilder b = new MessageBuilder(map);
         
@@ -122,7 +141,6 @@ public class MessageBuilderTest  {
 
     @Test	
     public void testProducerConsumerEventReportMessage() {
-        
         Message m = new ProducerConsumerEventReportMessage(source, event);
         MessageBuilder b = new MessageBuilder(map);
         
@@ -159,7 +177,6 @@ public class MessageBuilderTest  {
         List<OpenLcbCanFrame> list = b.processMessage(m);
 
         Assert.assertEquals("count", 3, list.size());
-        CanFrame f0 = list.get(0);
         Assert.assertEquals("header", toHexString(0x195EB123), toHexString(list.get(0).getHeader()));
         Assert.assertEquals("header", toHexString(0x195EB123), toHexString(list.get(1).getHeader()));
         Assert.assertEquals("header", toHexString(0x195EB123), toHexString(list.get(2).getHeader()));
@@ -264,8 +281,7 @@ public class MessageBuilderTest  {
 
     @Test	
     public void testDatagramMessageNine() {
-        int[] data = new int[]{21,22,23,24,25,26,27,28, 
-                               31};
+        int[] data = new int[]{21,22,23,24,25,26,27,28,31};
                                
         Message m = new DatagramMessage(source, destination, data);
         MessageBuilder b = new MessageBuilder(map);
@@ -314,7 +330,6 @@ public class MessageBuilderTest  {
         compareContent(new byte[]{0x03, 0x21, (byte)0x80}, f0);
     }
 
-
     /** ****************************************************
      * Tests of messages into frames
      ***************************************************** */
@@ -349,6 +364,7 @@ public class MessageBuilderTest  {
         Assert.assertTrue(msg instanceof VerifyNodeIDNumberMessage); 
         Assert.assertEquals(new VerifyNodeIDNumberMessage(source), msg);
     }
+    
     @Test	
     public void testVerifyNodeContentFrame() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
@@ -446,7 +462,7 @@ public class MessageBuilderTest  {
         
         Assert.assertTrue(msg instanceof OptionalIntRejectedMessage);  
         
-        Assert.assertEquals(0x1234, ((OptionalIntRejectedMessage)msg).getMti());    
+        Assert.assertEquals(0x1234, ((OptionalIntRejectedMessage)msg).getRejectMTI());    
         Assert.assertEquals(0x5678, ((OptionalIntRejectedMessage)msg).getCode());    
     }
     
@@ -465,7 +481,7 @@ public class MessageBuilderTest  {
         
         Assert.assertTrue(msg instanceof OptionalIntRejectedMessage);  
         
-        Assert.assertEquals(0x1234, ((OptionalIntRejectedMessage)msg).getMti());    
+        Assert.assertEquals(0x1234, ((OptionalIntRejectedMessage)msg).getRejectMTI());    
         Assert.assertEquals(0x5678, ((OptionalIntRejectedMessage)msg).getCode());    
     }
     
@@ -484,7 +500,7 @@ public class MessageBuilderTest  {
         
         Assert.assertTrue(msg instanceof OptionalIntRejectedMessage);  
         
-        Assert.assertEquals(0x1234, ((OptionalIntRejectedMessage)msg).getMti());    
+        Assert.assertEquals(0x1234, ((OptionalIntRejectedMessage)msg).getRejectMTI());    
         Assert.assertEquals(0, ((OptionalIntRejectedMessage)msg).getCode());    
     }
     
@@ -546,8 +562,6 @@ public class MessageBuilderTest  {
         Assert.assertEquals(2, ((SimpleNodeIdentInfoReplyMessage)msg).getData().length);    
         Assert.assertEquals(0x12, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[0]);    
         Assert.assertEquals(0x34, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[1]);    
-        
-          
     }
 
     @Test	
@@ -645,7 +659,6 @@ public class MessageBuilderTest  {
 
     @Test	
     public void testAddressedMessageAliasExtraction() {
-    
         NodeID high = new NodeID(new byte[]{11,12,13,14,15,16});
         map.insert(0x0FFF, high);
         
@@ -691,6 +704,7 @@ public class MessageBuilderTest  {
         Assert.assertEquals("flags ",0,(f.getElement(4)<<8)+f.getElement(5));
         Assert.assertEquals("sourceStreamID ",4,f.getElement(6));
     }
+    
     @Test	
     public void testStreamInitiateReplyMessage() {
         NodeID high = new NodeID(new byte[]{11,12,13,14,15,16});
@@ -776,6 +790,7 @@ public class MessageBuilderTest  {
         Assert.assertEquals("destinationStreamID ",frame.getElement(3),6);
         Assert.assertEquals("flags ",(frame.getElement(4)<<8)+frame.getElement(5),0);
     }
+    
     @Test
     public void testStreamDataCompleteMessage() {
         NodeID high = new NodeID(new byte[]{11,12,13,14,15,16});
@@ -805,9 +820,9 @@ public class MessageBuilderTest  {
     }
     
     void compareContent(byte[] data, CanFrame f) {
-        if (data == null) 
+        if (data == null) {
             Assert.assertEquals("no data", 0, f.getNumDataElements());
-        else {
+        } else {
             Assert.assertEquals("data length", data.length, f.getNumDataElements());
             for (int i=0; i<data.length; i++) {
                 Assert.assertEquals("data byte "+i, DatagramUtils.byteToInt(data[i]),f.getElement
@@ -832,5 +847,4 @@ public class MessageBuilderTest  {
     public void tearDown(){
         map = null;
     }
-    
 }

--- a/test/org/openlcb/implementations/DatagramServiceTest.java
+++ b/test/org/openlcb/implementations/DatagramServiceTest.java
@@ -1,14 +1,21 @@
 package org.openlcb.implementations;
 
-import org.openlcb.*;
-
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openlcb.AbstractConnection;
+import org.openlcb.Connection;
+import org.openlcb.DatagramAcknowledgedMessage;
+import org.openlcb.DatagramMessage;
+import org.openlcb.DatagramRejectedMessage;
+import org.openlcb.Message;
+import org.openlcb.NodeID;
 
 /**
  * @author  Bob Jacobsen   Copyright 2012
  */
 public class DatagramServiceTest {
-    
     NodeID hereID = new NodeID(new byte[]{1,2,3,4,5,6});
     NodeID farID = new NodeID(new byte[]{1,2,3,4,5,7});
     Connection testConnection;
@@ -20,6 +27,7 @@ public class DatagramServiceTest {
     public void setUp() {
         messagesReceived = new java.util.ArrayList<Message>();
         testConnection = new AbstractConnection(){
+            @Override
             public void put(Message msg, Connection sender) {
                 messagesReceived.add(msg);
             }
@@ -50,13 +58,11 @@ public class DatagramServiceTest {
         Assert.assertTrue(m20.equals(m20));
         Assert.assertTrue(!m20.equals(null));
         Assert.assertTrue(!m20.equals(m21));
-        
     }
 
     @Test
     public void testXmtMemoIsRealClass() {
         class TestMemo extends DatagramService.DatagramServiceTransmitMemo {
-
             public TestMemo(NodeID dest, int[] data) {
                 super(dest, data);
             }
@@ -99,8 +105,6 @@ public class DatagramServiceTest {
         Assert.assertTrue(!m22.equals(m23));
         Assert.assertTrue(!m22.equals(m24));
         Assert.assertTrue(!m23.equals(m24));
-        
-        
     }
 
     @Test
@@ -113,15 +117,6 @@ public class DatagramServiceTest {
 
     @Test
     public void testReceiveDGbeforeReg() {
-        DatagramService.DatagramServiceReceiveMemo m20 = 
-            new DatagramService.DatagramServiceReceiveMemo(0x20){
-                @Override
-                public void handleData(NodeID n, int[] data, DatagramService.ReplyMemo service) {
-                    flag = true;
-                    service.acceptData(0); 
-                }
-            };
-        
         Message m = new DatagramMessage(farID, hereID, new int[]{0x020});
       
         Assert.assertEquals(0,messagesReceived.size());
@@ -235,7 +230,5 @@ public class DatagramServiceTest {
         Assert.assertTrue(flag);
 
         Assert.assertEquals("1st messages", 0, messagesReceived.size());
-        
     }
-    
 }

--- a/test/org/openlcb/implementations/StreamTransmitterTest.java
+++ b/test/org/openlcb/implementations/StreamTransmitterTest.java
@@ -1,14 +1,21 @@
 package org.openlcb.implementations;
 
-import org.openlcb.*;
-
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openlcb.AbstractConnection;
+import org.openlcb.Connection;
+import org.openlcb.Message;
+import org.openlcb.NodeID;
+import org.openlcb.StreamDataCompleteMessage;
+import org.openlcb.StreamDataProceedMessage;
+import org.openlcb.StreamDataSendMessage;
+import org.openlcb.StreamInitiateReplyMessage;
+import org.openlcb.StreamInitiateRequestMessage;
 
 /**
  * @author  Bob Jacobsen   Copyright 2009
  */
 public class StreamTransmitterTest {
-    
     NodeID hereID = new NodeID(new byte[]{1,2,3,4,5,6});
     NodeID farID  = new NodeID(new byte[]{1,1,1,1,1,1});
     byte destID = 13;
@@ -21,23 +28,23 @@ public class StreamTransmitterTest {
     public void testInitialization() {
         messagesReceived = new java.util.ArrayList<Message>();
         Connection testConnection = new AbstractConnection(){
+            @Override
             public void put(Message msg, Connection sender) {
                 messagesReceived.add(msg);
             }
         };
-        StreamTransmitter xmt = new StreamTransmitter(
-                                            hereID,farID,
-                                            64, data,
-                                            testConnection);
+        new StreamTransmitter(hereID, farID, 64, data, testConnection);
                                                     
         Assert.assertTrue(messagesReceived.size() == 1); // startup message
-        Assert.assertEquals(new StreamInitiateRequestMessage(hereID, farID, 64, (byte)4, (byte)0), messagesReceived.get(0));
+        Assert.assertEquals(new StreamInitiateRequestMessage(
+                hereID, farID, 64, (byte)4, (byte)0), messagesReceived.get(0));
     }
     
     @Test 
     public void testShortStream() {
         messagesReceived = new java.util.ArrayList<Message>();
         Connection testConnection = new AbstractConnection(){
+            @Override
             public void put(Message msg, Connection sender) {
                 messagesReceived.add(msg);
             }
@@ -45,14 +52,11 @@ public class StreamTransmitterTest {
         
         data = new int[256];
         
-        StreamTransmitter xmt = new StreamTransmitter(
-                                            hereID,farID,
-                                            256, data,
-                                            testConnection);
+        StreamTransmitter xmt = new StreamTransmitter(hereID,farID, 256, data, testConnection);
                                                     
         Assert.assertEquals("init messages", 1, messagesReceived.size());
         Assert.assertTrue(messagesReceived.get(0)
-                           .equals(new StreamInitiateRequestMessage(hereID, farID, 256, (byte)4, (byte)0)));
+                .equals(new StreamInitiateRequestMessage(hereID, farID, 256, (byte)4, (byte)0)));
                            
         // OK 256 byte buffers
         Message m = new StreamInitiateReplyMessage(farID, hereID, 256, (byte)4, destID);
@@ -61,16 +65,17 @@ public class StreamTransmitterTest {
         xmt.put(m, null);
 
         Assert.assertEquals("1st messages", 2, messagesReceived.size());
-        Assert.assertEquals(messagesReceived.get(0), new StreamDataSendMessage(hereID, farID,
-                destID, data));
-        Assert.assertEquals(messagesReceived.get(1), new StreamDataCompleteMessage(hereID, farID,
-                (byte)4, destID));
+        Assert.assertEquals(messagesReceived.get(0), new StreamDataSendMessage(
+                hereID, farID, destID, data));
+        Assert.assertEquals(messagesReceived.get(1), new StreamDataCompleteMessage(
+                hereID, farID, (byte)4, destID));
     }
     
     @Test 
     public void testTwoMsgStream() {
         messagesReceived = new java.util.ArrayList<Message>();
         Connection testConnection = new AbstractConnection(){
+            @Override
             public void put(Message msg, Connection sender) {
                 messagesReceived.add(msg);
             }
@@ -78,14 +83,11 @@ public class StreamTransmitterTest {
         
         data = new int[512];
         
-        StreamTransmitter xmt = new StreamTransmitter(
-                                            hereID,farID,
-                                            256, data,
-                                            testConnection);
+        StreamTransmitter xmt = new StreamTransmitter(hereID,farID, 256, data, testConnection);
                                                     
         Assert.assertEquals("init messages", 1, messagesReceived.size());
         Assert.assertTrue(messagesReceived.get(0)
-                           .equals(new StreamInitiateRequestMessage(hereID, farID, 256, (byte)4, (byte)0)));
+                .equals(new StreamInitiateRequestMessage(hereID, farID, 256, (byte)4, (byte)0)));
                            
         // OK 256 byte buffers
         Message m = new StreamInitiateReplyMessage(farID, hereID, 256, (byte)4, (byte)13);
@@ -96,8 +98,7 @@ public class StreamTransmitterTest {
         // should get a data message
         Assert.assertEquals("1st messages", 1, messagesReceived.size());
         Assert.assertTrue(messagesReceived.get(0)
-                           .equals(new StreamDataSendMessage(hereID, farID, (byte)13, new
-                                   int[256])));
+                .equals(new StreamDataSendMessage(hereID, farID, (byte)13, new int[256])));
 
         // reply to proceed
         m = new StreamDataProceedMessage(farID, hereID, (byte)4, (byte)0);
@@ -108,12 +109,8 @@ public class StreamTransmitterTest {
         // 2nd message should be followed by a Stream Data Complete message
         Assert.assertEquals("2nd messages", 2, messagesReceived.size());
         Assert.assertTrue(messagesReceived.get(0)
-                           .equals(new StreamDataSendMessage(hereID, farID, (byte)13, new
-                                   int[256])));
+                .equals(new StreamDataSendMessage(hereID, farID, (byte)13, new int[256])));
         Assert.assertTrue(messagesReceived.get(1)
-                           .equals(new StreamDataCompleteMessage(hereID, farID, (byte)4, (byte)
-                                   13)));
-
+                .equals(new StreamDataCompleteMessage(hereID, farID, (byte)4, (byte) 13)));
     }
-    
 }

--- a/test/org/openlcb/protocols/TimeBroadcastConsumerTest.java
+++ b/test/org/openlcb/protocols/TimeBroadcastConsumerTest.java
@@ -1,33 +1,36 @@
 package org.openlcb.protocols;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.internal.matchers.LessOrEqual;
-import org.openlcb.InterfaceTestBase;
-import org.openlcb.MockPropertyChangeListener;
-
-import java.util.Calendar;
-import java.util.TimeZone;
-
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openlcb.InterfaceTestBase;
+import org.openlcb.MockPropertyChangeListener;
+
 /**
  * Created by bracz on 9/27/18.
  */
 public class TimeBroadcastConsumerTest extends InterfaceTestBase {
+    @Override
     @Before
-    public void SetUp() {
+    public void setUp() {
+        super.setUp();
+        
         printAllSentMessages();
         tcslave = new TimeBroadcastConsumer(iface, TimeProtocol.ALT_CLOCK_1);
         expectFrame(":X194A4333N010100000102FFFF;");
@@ -36,9 +39,12 @@ public class TimeBroadcastConsumerTest extends InterfaceTestBase {
         expectNoFrames();
     }
 
+    @Override
     @After
-    public void TearDown() {
+    public void tearDown() {
         tcslave.dispose();
+        
+        super.tearDown();
     }
 
     @Test
@@ -196,13 +202,13 @@ public class TimeBroadcastConsumerTest extends InterfaceTestBase {
         assertEquals((double)expected,  (double)tcslave.timeKeeper.getTime(), 1);
         // Try time rollback after midnight has been passed
         tk.overrideTime += 2 * 60 * 1000 / 10;
-        assertEquals((double)expected + 120e3,  (double)tcslave.timeKeeper.getTime(), 1);
+        assertEquals(expected + 120e3,  tcslave.timeKeeper.getTime(), 1);
         sendFrame(":X195B4444N010100000102173b;"); // 23:59
         assertEquals((double)expected,  (double)tcslave.timeKeeper.getTime(), 1);
 
         sendFrame(":X195B4444N010100000102F003;"); // date rollover
         sendFrame(":X195B4444N0101000001020001;"); // 00:01
-        assertEquals((double)midnight + 60e3,  (double)tcslave.timeKeeper.getTime(), 1);
+        assertEquals(midnight + 60e3,  tcslave.timeKeeper.getTime(), 1);
         tk.overrideTime += 3000; // 3 real seconds later
 
         long t1 = tcslave.timeKeeper.getTime();
@@ -230,7 +236,7 @@ public class TimeBroadcastConsumerTest extends InterfaceTestBase {
         // Now we get the 00:01 but without the date rollover event.
         sendFrame(":X195B4444N0101000001020001;"); // 00:01
         // and end up one day before
-        assertEquals((double)midnight + 60e3 - 86400e3,  (double)tcslave.timeKeeper.getTime(),
+        assertEquals(midnight + 60e3 - 86400e3,  tcslave.timeKeeper.getTime(),
                 250);
 
         long t1 = tcslave.timeKeeper.getTime();
@@ -238,11 +244,10 @@ public class TimeBroadcastConsumerTest extends InterfaceTestBase {
         sendFrame(":X195B4444N010100000102291C;"); // 09/28 but now it isn't a noop.
         long t2 = tcslave.timeKeeper.getTime();
 
-        assertEquals((double)midnight + 60e3,  (double)t2,
+        assertEquals(midnight + 60e3,  t2,
                 1);
         // Time jumped forward about a day.
-        assertEquals((double)86400e3,  (double)t2-t1,
-                60e3);
+        assertEquals(86400e3,  (double)t2-t1, 60e3);
     }
 
     @Test
@@ -267,7 +272,7 @@ public class TimeBroadcastConsumerTest extends InterfaceTestBase {
         sendFrame(":X195B4444N010100000102F003;"); // date rollover
         sendFrame(":X195B4444N0101000001020001;"); // 00:01
 
-        assertEquals((double)expected + 60e3,  (double)tcslave.timeKeeper.getTime(), 1);
+        assertEquals(expected + 60e3,  tcslave.timeKeeper.getTime(), 1);
 
         tk.overrideTime += 3000;
         long t1 = tcslave.timeKeeper.getTime();
@@ -295,7 +300,7 @@ public class TimeBroadcastConsumerTest extends InterfaceTestBase {
 
         sendFrame(":X195B4444N010100000102F003;"); // date rollover
         sendFrame(":X195B4444N010100000102173b;"); // 23:59
-        assertEquals((double)midnight - 60e3,  (double)tcslave.timeKeeper.getTime(), 1);
+        assertEquals(midnight - 60e3,  tcslave.timeKeeper.getTime(), 1);
     }
 
     @Test

--- a/test/org/openlcb/protocols/TimeKeeperTest.java
+++ b/test/org/openlcb/protocols/TimeKeeperTest.java
@@ -11,7 +11,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 public class TimeKeeperTest {
     public static class FakeTimeKeeper extends TimeKeeper {
-        @SuppressFBWarnings
+        @SuppressFBWarnings(value="UR_UNINIT_READ_CALLED_FROM_SUPER_CONSTRUCTOR",
+                justification="Method does not get called in constructor of superclass")
         @Override
         protected long currentTimeMillis() {
             return overrideTime;

--- a/test/org/openlcb/protocols/TimeKeeperTest.java
+++ b/test/org/openlcb/protocols/TimeKeeperTest.java
@@ -1,14 +1,17 @@
 package org.openlcb.protocols;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Created by bracz on 9/27/18.
  */
 public class TimeKeeperTest {
     public static class FakeTimeKeeper extends TimeKeeper {
+        @SuppressFBWarnings
         @Override
         protected long currentTimeMillis() {
             return overrideTime;

--- a/test/org/openlcb/swing/networktree/NodeTreeRepTest.java
+++ b/test/org/openlcb/swing/networktree/NodeTreeRepTest.java
@@ -1,19 +1,26 @@
 package org.openlcb.swing.networktree;
 
+import java.awt.GraphicsEnvironment;
+import java.util.Collection;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import java.awt.GraphicsEnvironment;
-import org.openlcb.*;
-import java.util.Collection;
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeModel;
+import org.openlcb.AbstractConnection;
+import org.openlcb.Connection;
+import org.openlcb.EventID;
+import org.openlcb.EventState;
+import org.openlcb.Message;
+import org.openlcb.MimicNodeStore;
+import org.openlcb.NodeID;
+import org.openlcb.ProducerIdentifiedMessage;
 
 /**
- *
  * @author Paul Bender Copyright (C) 2017	
  */
 public class NodeTreeRepTest {
@@ -23,11 +30,11 @@ public class NodeTreeRepTest {
         Assume.assumeFalse(GraphicsEnvironment.isHeadless());
         MimicNodeStore store = null;
         NodeID nid1 = new NodeID(new byte[]{1,3,3,4,5,6});
-        NodeID nid2 = new NodeID(new byte[]{2,3,3,4,5,6});
     
         ProducerIdentifiedMessage pim1 = new ProducerIdentifiedMessage(nid1, 
                                          new EventID(new byte[]{1,0,0,0,0,0,1,0}), EventState.Unknown);
         Connection connection = new AbstractConnection() {
+            @Override
             public void put(Message msg, Connection sender) {
             }
         };
@@ -38,8 +45,10 @@ public class NodeTreeRepTest {
         DefaultMutableTreeNode nodes = new DefaultMutableTreeNode("OpenLCB Network");
         DefaultTreeModel treeModel = new DefaultTreeModel(nodes);
         NodeTreeRep.SelectionKeyLoader loader = new NodeTreeRep.SelectionKeyLoader() {
+                    @Override
                     public NodeTreeRep.SelectionKey cdiKey(String name, NodeID node) {
                         return new NodeTreeRep.SelectionKey(name, node) {
+                            @Override
                             public void select(DefaultMutableTreeNode rep) {
                                 System.out.println("Making special fuss over: "+rep+" for "+name+" on "+node);
                             }
@@ -60,5 +69,4 @@ public class NodeTreeRepTest {
     @After
     public void tearDown() {
     }
-
 }

--- a/test/scenarios/ConfigDemoApplet.java
+++ b/test/scenarios/ConfigDemoApplet.java
@@ -5,7 +5,13 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
-import javax.swing.*;
+
+import javax.swing.BoxLayout;
+import javax.swing.JApplet;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
 
 import org.openlcb.cdi.impl.ConfigRepresentation;
 import org.openlcb.cdi.impl.DemoReadWriteAccess;
@@ -18,7 +24,9 @@ import org.openlcb.cdi.swing.CdiPanel;
  * @version $Revision$
  */
 public class ConfigDemoApplet extends JApplet {
-    
+    /** Comment for <code>serialVersionUID</code>. */
+    private static final long serialVersionUID = 8760789187658487429L;
+
     public ConfigDemoApplet() {}
     
     /**
@@ -50,7 +58,8 @@ public class ConfigDemoApplet extends JApplet {
         f.setTitle("Configuration Demonstration");
         CdiPanel m = new CdiPanel();
 
-        ConfigRepresentation rep = new ConfigRepresentation(new DemoReadWriteAccess(), new org.openlcb.cdi.jdom.JdomCdiRep(
+        new ConfigRepresentation(
+                new DemoReadWriteAccess(), new org.openlcb.cdi.jdom.JdomCdiRep(
                 org.openlcb.cdi.jdom.SampleFactory.getBasicSample()
         ));
 
@@ -62,7 +71,6 @@ public class ConfigDemoApplet extends JApplet {
         f.pack();
         f.setVisible(true);
     }
-    
 
     // frame starting positions
     int hPos = 500;
@@ -92,14 +100,14 @@ public class ConfigDemoApplet extends JApplet {
     }
     
     // For running as a JUnit test
-    static public void runTest() {
+    public static void runTest() {
         ConfigDemoApplet app = new ConfigDemoApplet();
         app.start();
         app.startDemo();
     }
+    
     // Main entry point for standalone run
-    static public void main(String[] args) {
+    public static void main(String[] args) {
         runTest();
     }
-
 }

--- a/test/scenarios/ScenarioRunner.java
+++ b/test/scenarios/ScenarioRunner.java
@@ -1,13 +1,18 @@
 package scenarios;
 
-import javax.swing.*;
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
 
 /**
  * Simple interface to select which scenario to run
  *
  * @author  Bob Jacobsen   Copyright 2010
- * @version $Revision$
  */
 public class ScenarioRunner  {
 
@@ -26,19 +31,25 @@ public class ScenarioRunner  {
         JButton b;
         b = new JButton("Configuration Tool Demo");
         b.addActionListener(new ActionListener(){
+            @Override
             public void actionPerformed(ActionEvent e) {
                 try {
-                    scenarios.ConfigDemoApplet.main((String[])null);
-                } catch (Exception ex) {ex.printStackTrace();}
+                    scenarios.ConfigDemoApplet.main(new String[] {});
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                }
             }
         });
         p.add(b);
         b = new JButton("Blue/Gold Configuration Demo");
         b.addActionListener(new ActionListener(){
+            @Override
             public void actionPerformed(ActionEvent e) {
                 try {
-                    scenarios.BlueGoldCheck.main((String[])null);
-                } catch (Exception ex) {ex.printStackTrace();}
+                    scenarios.BlueGoldCheck.main(new String[] {});
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                }
             }
         });
         p.add(b);

--- a/test/tools/cansim/CanFrame.java
+++ b/test/tools/cansim/CanFrame.java
@@ -1,8 +1,6 @@
 package tools.cansim;
 
-import org.openlcb.implementations.DatagramUtils;
-
-import tools.*;
+import java.util.Arrays;
 
 /**
  * Carry and work with a simulated CAN frame.
@@ -12,10 +10,7 @@ import tools.*;
  * @author  Bob Jacobsen   Copyright 2009
  * @version $Revision$
  */
-
-
 public class CanFrame implements org.openlcb.can.CanFrame {
-
     int header;
     int[] bytes;
     
@@ -27,17 +22,26 @@ public class CanFrame implements org.openlcb.can.CanFrame {
     public CanFrame(int header, int[] bytes) {
         this(header);
         if (bytes.length > 8) {
-            throw new IllegalArgumentException("payload too long: "+bytes);
+            throw new IllegalArgumentException("payload too long: " + Arrays.toString(bytes));
         }
         this.bytes = bytes;
     }
     
-    public int getHeader() { return header; }
+    @Override
+    public int getHeader() {
+        return header;
+    }
+    
+    @Override
     public byte[] getData() { 
         byte[] t = new byte[bytes.length];
-        for (int i = 0; i < bytes.length; i++) t[i] = (byte)bytes[i];
+        for (int i = 0; i < bytes.length; i++) {
+            t[i] = (byte)bytes[i];
+        }
         return t; 
     }
+    
+    @Override
     public long bodyAsLong() {
         long retval = 0;
         for (int i = 0 ; i<bytes.length; i++) {
@@ -46,6 +50,7 @@ public class CanFrame implements org.openlcb.can.CanFrame {
         return retval;
     }
     
+    @Override
     public long dataAsLong() {
         long retval = 0;
         for (int i = 2 ; i<bytes.length; i++) {
@@ -54,27 +59,63 @@ public class CanFrame implements org.openlcb.can.CanFrame {
         return retval;
     }
     
-    public boolean isExtended() { return true; }    
-    public boolean isRtr() { return false; }
-    public int getNumDataElements() { return bytes.length; }
-    public int getElement(int n) { return bytes[n]; }
+    @Override
+    public boolean isExtended() {
+        return true;
+    }
     
+    @Override
+    public boolean isRtr() {
+        return false;
+    }
+    
+    @Override
+    public int getNumDataElements() {
+        return bytes.length;
+    }
+    
+    @Override
+    public int getElement(int n) {
+        return bytes[n];
+    }
+    
+    @Override
     public boolean equals(Object other) {
-        // try to cast, else not equal
-        try {
-            CanFrame c = (CanFrame) other;
-            if (this.header != c.header) return false;
-            if (this.bytes == null && c.bytes == null) return true;
-            if (this.bytes == null && c.bytes != null) return false;
-            if (this.bytes != null && c.bytes == null) return false;
-            if (this.bytes.length != c.bytes.length) return false;
-            for (int i = 0; i < this.bytes.length; i++) {
-                if (this.bytes[i] != c.bytes[i]) return false;
-            }
-            return true;
-        } catch (Exception e) {
-            return false;
+        if (other instanceof CanFrame) {
+            return equals((CanFrame) other);
         }
+        return false;
     }
         
+    public boolean equals(CanFrame other) {
+        if (this.header != other.header) {
+            return false;
+        }
+        if ((this.bytes == null) && (other.bytes == null)) {
+            return true;
+        }
+        if ((this.bytes != null) && (other.bytes != null)) {
+            if (this.bytes.length != other.bytes.length) {
+                return false;
+            }
+            for (int i = 0; i < this.bytes.length; i++) {
+                if (this.bytes[i] != other.bytes[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        long hash = header;
+        if (bytes != null) {
+            for (int i = 0; i < this.bytes.length; i++) {
+                hash = 7 * hash + bytes[i];
+            }
+        }
+        return Long.valueOf(hash).hashCode();
+    }
 }


### PR DESCRIPTION
Fix most of the spotbugs warnings. Some warnings in tests could not be fixed and are now suppressed. In the classes touched I also fixed warnings of eclipse IDE and improved code formatting.

Following classes needed bigger changes:
- MimicNodeStore (Timer handling)
- NIDaAlgorithm (Timer handling)
- OptionalIntRejectedMessage (deprecated getMti(), introduced  getRejectMTI())
- Util.waitForPropertyChange() (improve wait/notify)
- TimeKeeper (refactoring)

