### PR TITLE
Avoids adding an empty group to the output display.

### DIFF
--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -871,16 +871,18 @@ public class CdiPanel extends JPanel {
             super.visitGroup(e);
             factory.handleGroupPaneEnd(groupPane);
 
-            if (oldPane instanceof SegmentPane) {
-                // we make toplevel groups collapsible.
-                groupPane.setBorder(null);
-                JPanel ret = new util.CollapsiblePanel(groupPane.getName(), groupPane);
-                // ret.setBorder(BorderFactory.createLineBorder(java.awt.Color.RED)); //debugging
-                ret.setAlignmentY(Component.TOP_ALIGNMENT);
-                ret.setAlignmentX(Component.LEFT_ALIGNMENT);
-                oldPane.add(ret);
-            } else {
-                oldPane.add(groupPane);
+            if (groupPane.getComponentCount() > 0) {
+                if (oldPane instanceof SegmentPane) {
+                    // we make toplevel groups collapsible.
+                    groupPane.setBorder(null);
+                    JPanel ret = new util.CollapsiblePanel(groupPane.getName(), groupPane);
+                    // ret.setBorder(BorderFactory.createLineBorder(java.awt.Color.RED)); //debugging
+                    ret.setAlignmentY(Component.TOP_ALIGNMENT);
+                    ret.setAlignmentX(Component.LEFT_ALIGNMENT);
+                    oldPane.add(ret);
+                } else {
+                    oldPane.add(groupPane);
+                }
             }
 
             // restore stack


### PR DESCRIPTION
When the CDI contains a group that has no name, no description and no data elements, we skip rendering an empty box.