### PR TITLE
Adds keyboard navigation between segments

### DIFF
--- a/src/util/CollapsiblePanel.java
+++ b/src/util/CollapsiblePanel.java
@@ -153,6 +153,10 @@ public class CollapsiblePanel extends JPanel {
 		contentPanel_.setVisible(selected);
 	}
 
+	public JPanel getHeader() {
+		return headerPanel_;
+	}
+
 	public void toggleSelection() {
 		selected = !selected;
 		contentPanel_.setVisible(selected);


### PR DESCRIPTION
This PR adds keyboard bindings for F6 and Shift+F6 with the implementation that pressing these buttons navigates up and down between the CDI segments.

This is an accessibility feature for users who are not able to use a mouse to quickly navigate between segments.