### PR TITLE
Prevents creating two loadingListeners.

### DIFF
--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -519,6 +519,7 @@ public class CdiPanel extends JPanel {
 
     private void addLoadingListener() {
         synchronized(rep) {
+            if (loadingListener != null) return;
             loadingListener = new PropertyChangeListener() {
                 @Override
                 public void propertyChange(PropertyChangeEvent event) {
@@ -545,9 +546,12 @@ public class CdiPanel extends JPanel {
     }
 
     private void displayLoadingProgress() {
-        if (loadingPanel == null) createLoadingPane();
-        contentPanel.add(loadingPanel);
+        if (loadingPanel == null) {
+            createLoadingPane();
+            contentPanel.add(loadingPanel);
+        }
         addLoadingListener();
+        loadingPanel.setVisible(true);
     }
 
     private void displayCdi() {


### PR DESCRIPTION
In one of the two typical paths the displayLoadingProgress is called twice.
If we create two loadingListeners, we leak one and this causes the CdiPanel
to be never garbage collected. As a result the java VM heap grows a lot and
eventually JMRI crashes with out of memory.