### PR TITLE
Adds popup menu to Event Pane with "Make Sensor" and "Trigger" actions

### DIFF
--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -8,6 +8,8 @@ import org.openlcb.cdi.cmd.RestoreConfig;
 import org.openlcb.cdi.impl.ConfigRepresentation;
 import org.openlcb.implementations.EventTable;
 import org.openlcb.swing.EventIdTextField;
+import org.openlcb.ProducerConsumerEventReportMessage;
+import org.openlcb.*;
 
 import java.awt.AWTException;
 import java.awt.Color;
@@ -1640,6 +1642,20 @@ public class CdiPanel extends JPanel {
         @Override
         protected void additionalButtons() {
             final JTextField tf = textField;
+
+            /// DPH add Send-button
+            JButton bb = factory.handleProduceButton(new JButton("Send"));
+            bb.setToolTipText("Click to fire this event.");
+            bb.addActionListener(new java.awt.event.ActionListener() {
+                @Override
+                public void actionPerformed(java.awt.event.ActionEvent e) {
+                    NodeID node = rep.getConnection().getNodeId();
+                    EventID ev = new EventID(org.openlcb.Utilities.bytesFromHexString((String)textField.getText()));
+                    rep.getConnection().getOutputConnection().put(new ProducerConsumerEventReportMessage(node, ev), null);
+                }
+            });
+            p3.add(bb);            
+            
             p3.add(Box.createHorizontalStrut(5));
             addCopyPasteButtons(p3, textField);
             p3.add(Box.createHorizontalStrut(5));
@@ -1845,6 +1861,10 @@ public class CdiPanel extends JPanel {
         }
         public JButton handleWriteButton(JButton button) {
             return button;
+        }
+        /// DPH add send button
+        public JButton handleProduceButton(JButton button) {
+           return button;
         }
         public void handleGroupPaneStart(JPanel pane) {
             return;

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -344,6 +344,7 @@ public class CdiPanel extends JPanel {
         moreMenu.show(moreButton, 0, moreButton.getHeight());
     }
 
+
     /**
      * Refreshes all memory variable entries directly from the hardware node.
      */
@@ -489,6 +490,7 @@ public class CdiPanel extends JPanel {
     boolean loadingIsPacked = false;
     JScrollPane scrollPane;
     JPanel contentPanel;
+
     JPanel buttonBar;
     JPopupMenu moreMenu = new JPopupMenu();
     JButton moreButton;
@@ -1528,6 +1530,9 @@ public class CdiPanel extends JPanel {
         // the current key. value: the user name coming from the respective string valued field.
         Map<String, String> parentVisibleKeys = new TreeMap<>(Collections.reverseOrder());
 
+        JPopupMenu eventidMoreMenu = new JPopupMenu();
+        JButton eventidMoreButton;
+
         EventIdPane(ConfigRepresentation.EventEntry e) {
             super(e, "EventID");
             entry = e;
@@ -1641,10 +1646,10 @@ public class CdiPanel extends JPanel {
 
         @Override
         protected void additionalButtons() {
-            final JTextField tf = textField;
 
-            /// DPH add Send-button
-            JButton bb = factory.handleProduceButton(new JButton("Send"));
+            final JTextField tf = textField;
+  
+            JButton bb = factory.handleProduceButton(new JButton("Trigger"));
             bb.setToolTipText("Click to fire this event.");
             bb.addActionListener(new java.awt.event.ActionListener() {
                 @Override
@@ -1653,9 +1658,19 @@ public class CdiPanel extends JPanel {
                     EventID ev = new EventID(org.openlcb.Utilities.bytesFromHexString((String)textField.getText()));
                     rep.getConnection().getOutputConnection().put(new ProducerConsumerEventReportMessage(node, ev), null);
                 }
-            });
-            p3.add(bb);            
-            
+            });   
+            addButtonToEventidMoreFunctions(bb);
+
+            JButton bAS = factory.handleProduceButton(new JButton("Make Sensor"));
+            bAS.setToolTipText("Add a JMRI sensor with the eventid.");
+            bAS.addActionListener(new java.awt.event.ActionListener() {
+                @Override
+                public void actionPerformed(java.awt.event.ActionEvent e) { 
+                    factory.makeSensor(textField.getText(), getEventName());
+                }
+            }); 
+            addButtonToEventidMoreFunctions(bAS);        
+
             p3.add(Box.createHorizontalStrut(5));
             addCopyPasteButtons(p3, textField);
             p3.add(Box.createHorizontalStrut(5));
@@ -1668,6 +1683,32 @@ public class CdiPanel extends JPanel {
             });
             p3.add(b);
             p3.add(Box.createHorizontalStrut(5));
+        }
+
+        private void addButtonToEventidMoreFunctions(final JButton b) {
+            if (eventidMoreButton == null) {
+                eventidMoreButton = new JButton("More...");
+                eventidMoreButton.setToolTipText("Additional actions you can do with this eventid.");
+                eventidMoreButton.addActionListener(new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent actionEvent) {
+                        showEventidMoreFunctionsMenu();
+                    }
+                });
+                p3.add(eventidMoreButton);
+            }
+            Action a = new AbstractAction(b.getText()) {
+                @Override
+                public void actionPerformed(ActionEvent actionEvent) {
+                    b.doClick();
+                }
+            };
+            eventidMoreMenu.add(a);
+            
+        }
+
+        private void showEventidMoreFunctionsMenu() {
+            eventidMoreMenu.show(eventidMoreButton, 0, eventidMoreButton.getHeight());
         }
 
         @Override
@@ -1862,9 +1903,14 @@ public class CdiPanel extends JPanel {
         public JButton handleWriteButton(JButton button) {
             return button;
         }
-        /// DPH add send button
+        public JButton handleEventidMoreButton(JButton button) {
+            return button;
+         } 
         public JButton handleProduceButton(JButton button) {
            return button;
+        }
+        public void makeSensor(String ev, String mdesc) {
+            return;
         }
         public void handleGroupPaneStart(JPanel pane) {
             return;

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -2,6 +2,7 @@ package org.openlcb.cdi.swing;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.openlcb.EventID;
+import org.openlcb.NodeID;
 import org.openlcb.cdi.CdiRep;
 import org.openlcb.cdi.cmd.BackupConfig;
 import org.openlcb.cdi.cmd.RestoreConfig;
@@ -9,7 +10,6 @@ import org.openlcb.cdi.impl.ConfigRepresentation;
 import org.openlcb.implementations.EventTable;
 import org.openlcb.swing.EventIdTextField;
 import org.openlcb.ProducerConsumerEventReportMessage;
-import org.openlcb.*;
 
 import java.awt.AWTException;
 import java.awt.Color;
@@ -1656,13 +1656,13 @@ public class CdiPanel extends JPanel {
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     NodeID node = rep.getConnection().getNodeId();
                     EventID ev = new EventID(org.openlcb.Utilities.bytesFromHexString((String)textField.getText()));
-                    rep.getConnection().getOutputConnection().put(new ProducerConsumerEventReportMessage(node, ev), null);
+                    rep.getConnection().getOutputConnection().put(new ProducerConsumerEventReportMessage(node, ev), rep.getConnection().getOutputConnection());
                 }
             });   
             addButtonToEventidMoreFunctions(bb);
 
             JButton bAS = factory.handleProduceButton(new JButton("Make Sensor"));
-            bAS.setToolTipText("Add a JMRI sensor with the eventid.");
+            bAS.setToolTipText("Add a JMRI sensor with the Event ID.");
             bAS.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) { 
@@ -1688,7 +1688,7 @@ public class CdiPanel extends JPanel {
         private void addButtonToEventidMoreFunctions(final JButton b) {
             if (eventidMoreButton == null) {
                 eventidMoreButton = new JButton("More...");
-                eventidMoreButton.setToolTipText("Additional actions you can do with this eventid.");
+                eventidMoreButton.setToolTipText("Additional actions you can do with this Event ID");
                 eventidMoreButton.addActionListener(new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent actionEvent) {


### PR DESCRIPTION
Added a "More..." button to EventID-items in CDI, which, on click, creates a dropdown, with:  
 -- "Trigger" item, which, on click, sends a PCER message to the bus;
 -- "Make Sensor" item, which, on click, creates a Sensor in JMRI with the single eventID, and a description (generated if no formal associated description field). 

These require support functions in JMRI, and there is am associated "morebutton" change set that needs to incorporated into JMRI.  