### PR TITLE
Decodes traction request and reply messages for the monitor window

### DIFF
--- a/src/org/openlcb/NodeID.java
+++ b/src/org/openlcb/NodeID.java
@@ -50,6 +50,13 @@ public class NodeID {
             this.contents[i] = contents[i];
     }
 
+    @CheckReturnValue
+    public NodeID(long value) {
+        byte[] c = new byte[BYTECOUNT];
+        Utilities.HostToNetworkUint48(c, 0, value);
+        contents = c;
+    }
+
     byte[] contents;
 
     @CheckReturnValue

--- a/src/org/openlcb/Utilities.java
+++ b/src/org/openlcb/Utilities.java
@@ -128,7 +128,7 @@ public class Utilities {
     }
 
     static public int NetworkToHostUint8(byte[] arr, int offset) {
-        if (arr == null || arr.length < offset) {
+        if (arr == null || arr.length <= offset) {
             return 0;
         }
         int r = arr[offset];
@@ -141,7 +141,7 @@ public class Utilities {
     }
 
     static public int NetworkToHostUint16(byte[] arr, int offset) {
-        if (arr == null || arr.length < (offset+1)) {
+        if (arr == null || arr.length <= (offset+1)) {
             return 0;
         }
         return ((((int)arr[offset]) & 0xff) << 8) |
@@ -153,8 +153,23 @@ public class Utilities {
         arr[offset+1] = (byte) (value & 0xff);
     }
 
+    static public int NetworkToHostUint24(byte[] arr, int offset) {
+        if (arr == null || arr.length <= (offset+2)) {
+            return 0;
+        }
+        return (((((int)arr[offset]) & 0xff) << 16) |
+                ((((int)arr[offset+1]) & 0xff) << 8) |
+                (((int)arr[offset+2]) & 0xff));
+    }
+
+    static public void HostToNetworkUint24(byte[] arr, int offset, int value) {
+        arr[offset] = (byte) ((value >> 16) & 0xff);
+        arr[offset+1] = (byte) ((value >> 8) & 0xff);
+        arr[offset+2] = (byte) (value & 0xff);
+    }
+
     static public long NetworkToHostUint32(byte[] arr, int offset) {
-        if (arr == null || arr.length < (offset+3)) {
+        if (arr == null || arr.length <= (offset+3)) {
             return 0;
         }
         long ret = 0;
@@ -176,7 +191,7 @@ public class Utilities {
     }
 
     static public long NetworkToHostUint48(byte[] arr, int offset) {
-        if (arr == null || arr.length < (offset+5)) {
+        if (arr == null || arr.length <= (offset+5)) {
             return 0;
         }
         long ret = 0;

--- a/src/org/openlcb/implementations/throttle/Float16.java
+++ b/src/org/openlcb/implementations/throttle/Float16.java
@@ -56,7 +56,7 @@ public class Float16 {
             }
         }
         
-        int ch =  ((int)(d*1024.))&0x3FF;
+        int ch =  ((int)(d*1024. + 0.5))&0x3FF;
         if ((((int)(d*1024.))&0x400) != 0x400) logger.log(Level.WARNING, "normalization failed with d={0} exp={1}", new Object[]{d, exp});
         int bits = ch | (exp<<10);
         if (!positive) bits = bits | 0x8000;
@@ -92,5 +92,10 @@ public class Float16 {
         int sign = ( (byte1 & 0x80) !=0 ) ? -1 : +1;
         return (float)(((double)ch)/1024.0*(Math.pow(2, exp)))*sign;
     }
-    
+
+    /// @return true if this is a positive number (meaning forward speed), false if it is
+    /// negative (reverse speed).
+    public boolean isPositive() {
+        return (byte1 & 0x80) == 0;
+    }
 }

--- a/src/org/openlcb/implementations/throttle/TractionThrottle.java
+++ b/src/org/openlcb/implementations/throttle/TractionThrottle.java
@@ -48,9 +48,14 @@ public class TractionThrottle extends MessageDecoder {
         @Override
         public void update(Float t) {
             if (!enabled) return;
-
-            Message m = TractionControlRequestMessage.createSetSpeed(iface.getNodeId(),
-                    trainNode.getNodeId(), Math.copySign(1.0, t) >= 0, t);
+            Message m;
+            if (Float.isNaN(t)) {
+                m = TractionControlRequestMessage.createSetEstop(iface.getNodeId(),
+                        trainNode.getNodeId());
+            } else {
+                m = TractionControlRequestMessage.createSetSpeed(iface.getNodeId(),
+                        trainNode.getNodeId(), Math.copySign(1.0, t) >= 0, t);
+            }
             iface.getOutputConnection().put(m, TractionThrottle.this);
 
         }

--- a/src/org/openlcb/messages/TractionControlRequestMessage.java
+++ b/src/org/openlcb/messages/TractionControlRequestMessage.java
@@ -362,6 +362,4 @@ public class TractionControlRequestMessage extends AddressedPayloadMessage {
         }
         return p.toString();
     }
-
-
 }

--- a/src/org/openlcb/messages/TractionControlRequestMessage.java
+++ b/src/org/openlcb/messages/TractionControlRequestMessage.java
@@ -42,9 +42,10 @@ public class TractionControlRequestMessage extends AddressedPayloadMessage {
     public final static int CONSIST_FLAG_FN0 = 0x04;
     public final static int CONSIST_FLAG_FNN = 0x08;
 
-    public final static byte CMD_MGMT = 0x20;
+    public final static byte CMD_MGMT = 0x40;
     public final static byte SUBCMD_MGMT_RESERVE = 1;
     public final static byte SUBCMD_MGMT_RELEASE = 2;
+    public final static byte SUBCMD_MGMT_NOOP = 3;
 
     /// 1 scale mph in meters per second for the getspeed/setspeed commands
     public final static double MPH = 0.44704;
@@ -213,6 +214,49 @@ public class TractionControlRequestMessage extends AddressedPayloadMessage {
                     p.append(String.format("get fn %d", fn));
                     break;
                 }
+                case CMD_CONTROLLER: {
+                    switch(getSubCmd()) {
+                        case SUBCMD_CONTROLLER_ASSIGN: {
+                            long nid = Utilities.NetworkToHostUint48(payload, 3);
+                            p.append("assign controller ");
+                            p.append(new NodeID(nid).toString());
+                            int flags = Utilities.NetworkToHostUint8(payload, 2);
+                            if(flags != 0) {
+                                p.append(String.format(" flags 0x%02x", flags));
+                            }
+                            break;
+                        }
+                        case SUBCMD_CONTROLLER_RELEASE: {
+                            long nid = Utilities.NetworkToHostUint48(payload, 3);
+                            p.append("release controller ");
+                            p.append(new NodeID(nid).toString());
+                            int flags = Utilities.NetworkToHostUint8(payload, 2);
+                            if(flags != 0) {
+                                p.append(String.format(" flags 0x%02x", flags));
+                            }
+                            break;
+                        }
+                        case SUBCMD_CONTROLLER_QUERY: {
+                            p.append("query controller");
+                            break;
+                        }
+                        case SUBCMD_CONTROLLER_CHANGE: {
+                            long nid = Utilities.NetworkToHostUint48(payload, 3);
+                            p.append("notify controller change to ");
+                            p.append(new NodeID(nid).toString());
+                            int flags = Utilities.NetworkToHostUint8(payload, 2);
+                            if(flags != 0) {
+                                p.append(String.format(" flags 0x%02x", flags));
+                            }
+                            break;
+                        }
+                        default:
+                            return super.toString();
+                    }
+                    break;
+                }
+                default:
+                    return super.toString();
             }
 
         } catch (ArrayIndexOutOfBoundsException e) {

--- a/test/org/openlcb/NodeIDTest.java
+++ b/test/org/openlcb/NodeIDTest.java
@@ -78,7 +78,15 @@ public class NodeIDTest {
         NodeID e = new NodeID("1.2.3.4.5.6");
         Assert.assertNotNull(e);
     }
-    
+
+    @Test
+    public void testLongArg() {
+        NodeID e = new NodeID(0x998877FFEEDDL);
+        Assert.assertNotNull(e);
+        Assert.assertEquals(0x998877FFEEDDL, e.toLong());
+        Assert.assertEquals("99.88.77.FF.EE.DD", e.toString());
+    }
+
     @Test
     public void testEqualsSame() {
         NodeID e1 = new NodeID(new byte[]{1,2,3,4,5,6});

--- a/test/org/openlcb/UtilitiesTest.java
+++ b/test/org/openlcb/UtilitiesTest.java
@@ -64,9 +64,15 @@ public class UtilitiesTest  {
         Utilities.HostToNetworkUint8(b, 2, 168);
         Assert.assertEquals("00 00 A8 00 00", Utilities.toHexSpaceString(b));
         Assert.assertEquals(168, Utilities.NetworkToHostUint8(b, 2));
+
         Utilities.HostToNetworkUint16(b, 1, 43766);
         Assert.assertEquals("00 AA F6 00 00", Utilities.toHexSpaceString(b));
         Assert.assertEquals(43766, Utilities.NetworkToHostUint16(b, 1));
+
+        Utilities.HostToNetworkUint24(b, 1, 12298956);
+        Assert.assertEquals("00 BB AA CC 00", Utilities.toHexSpaceString(b));
+        Assert.assertEquals(12298956, Utilities.NetworkToHostUint24(b, 1));
+
         Utilities.HostToNetworkUint32(b, 1, 17);
         Assert.assertEquals("00 00 00 00 11", Utilities.toHexSpaceString(b));
         Assert.assertEquals(17, Utilities.NetworkToHostUint32(b, 1));
@@ -78,6 +84,17 @@ public class UtilitiesTest  {
         Utilities.HostToNetworkUint48(b, 0, 0x0501010118DAL);
         Assert.assertEquals("05 01 01 01 18 DA", Utilities.toHexSpaceString(b));
         Assert.assertEquals(0x0501010118DAL, Utilities.NetworkToHostUint48(b, 0));
+
+        Utilities.HostToNetworkUint48(b, 0, 0xDDEEFFAABBCCL);
+        Assert.assertEquals("DD EE FF AA BB CC", Utilities.toHexSpaceString(b));
+        Assert.assertEquals(0xDDEEFFAABBCCL, Utilities.NetworkToHostUint48(b, 0));
+
+        // These have their offfset out of bounds.
+        Assert.assertEquals(0, Utilities.NetworkToHostUint48(b, 1));
+        Assert.assertEquals(0, Utilities.NetworkToHostUint32(b, 3));
+        Assert.assertEquals(0, Utilities.NetworkToHostUint24(b, 4));
+        Assert.assertEquals(0, Utilities.NetworkToHostUint16(b, 5));
+        Assert.assertEquals(0, Utilities.NetworkToHostUint8(b, 6));
     }
 
     boolean compareArrays(byte[] a, byte[]b) {

--- a/test/org/openlcb/implementations/throttle/Float16Test.java
+++ b/test/org/openlcb/implementations/throttle/Float16Test.java
@@ -26,12 +26,14 @@ public class Float16Test {
     public void testZeroAsBits() {
         f = new Float16(0.0f);
         Assert.assertEquals("zero", 0, f.getInt());
+        Assert.assertTrue(f.isPositive());
     }
     
     @Test 
     public void testNegZeroAsBits() {
         f = new Float16(0.0, false);
         Assert.assertEquals("neg zero", 0x8000, f.getInt());
+        Assert.assertFalse(f.isPositive());
     }
     
     @Test 
@@ -44,12 +46,14 @@ public class Float16Test {
     public void testTwoAsBits() {
         f = new Float16(2.0f);
         Assert.assertEquals("two", 0x4000, f.getInt());
+        Assert.assertTrue(f.isPositive());
     }
     
     @Test 
     public void testNegTwoAsBits() {
         f = new Float16(-2.0f);
         Assert.assertEquals("-two", 0xC000, f.getInt());
+        Assert.assertFalse(f.isPositive());
     }
     
     @Test 

--- a/test/org/openlcb/messages/TractionControlReplyMessageTest.java
+++ b/test/org/openlcb/messages/TractionControlReplyMessageTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.openlcb.*;
+import static org.openlcb.messages.TractionControlRequestMessage.MPH;
 
 /**
  *
@@ -14,10 +15,11 @@ import org.openlcb.*;
  */
 public class TractionControlReplyMessageTest {
 
+    NodeID src = new NodeID(new byte[]{6,5,5,4,4,3});
+    NodeID dst = new NodeID(new byte[]{2,2,2,4,4,4});
+
     @Test
     public void testCTor() {
-        NodeID src = new NodeID(new byte[]{6,5,5,4,4,3});
-        NodeID dst = new NodeID(new byte[]{2,2,2,4,4,4});
         byte[] payload = new byte[]{0x40,0x01,0x00}; // Traciton Management Reply message
         TractionControlReplyMessage t = new TractionControlReplyMessage(src,dst,payload);
         Assert.assertNotNull("exists",t);
@@ -25,11 +27,161 @@ public class TractionControlReplyMessageTest {
  
     @Test
     public void testGetcommand(){
-        NodeID src = new NodeID(new byte[]{6,5,5,4,4,3});
-        NodeID dst = new NodeID(new byte[]{2,2,2,4,4,4});
         byte[] payload = new byte[]{0x40,0x01,0x00}; // Traciton Management Reply message
         TractionControlReplyMessage t = new TractionControlReplyMessage(src,dst,payload);
         Assert.assertEquals("command",0x40,t.getCmd());
+    }
+
+    @Test
+    public void testSpeedReply(){
+        TractionControlReplyMessage t = new TractionControlReplyMessage(src,dst,
+                Utilities.bytesFromHexString("10 45 D0 00"));
+        Assert.assertEquals("command",0x10,t.getCmd());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "speed reply F 13 mph",t.toString());
+        Assert.assertEquals(13 * MPH, t.getSetSpeed().getFloat(), 0.01);
+        t = new TractionControlReplyMessage(src,dst, Utilities.bytesFromHexString("10 00 00 01"));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "speed reply F 0 mph estop",t.toString());
+        t = new TractionControlReplyMessage(src,dst, Utilities.bytesFromHexString("10 80 00 01"));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "speed reply R 0 mph estop",t.toString());
+        t = new TractionControlReplyMessage(src,dst, Utilities.bytesFromHexString("10 80 00 00 " +
+                "45 D0 C5 D0"));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "speed reply R 0 mph commanded speed F 13 mph actual speed R 13 mph",t.toString());
+        Assert.assertEquals(-0.0 * MPH, t.getSetSpeed().getFloat(), 0.01);
+        Assert.assertEquals(13 * MPH, t.getCommandedSpeed().getFloat(), 0.01);
+        Assert.assertEquals(-13 * MPH, t.getActualSpeed().getFloat(), 0.01);
+    }
+
+    @Test
+    public void testFnReply() {
+        TractionControlReplyMessage t = new TractionControlReplyMessage(src, dst,
+                Utilities.bytesFromHexString("11 00 00 0B 00 01"));
+        Assert.assertEquals("command", 0x11, t.getCmd());
+        Assert.assertEquals("function num", 11, t.getFnNumber());
+        Assert.assertEquals("function value", 1, t.getFnVal());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "fn 11 is 1", t.toString());
+        t = new TractionControlReplyMessage(src, dst,
+                Utilities.bytesFromHexString("11 BB AA 99 DD BA"));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "fn 12298905 is 56762", t.toString());
+        Assert.assertEquals("function num", 12298905, t.getFnNumber());
+        Assert.assertEquals("function value", 56762, t.getFnVal());
+    }
+
+    @Test
+    public void testControllerAssignReply() {
+        TractionControlReplyMessage t = new TractionControlReplyMessage(src, dst,
+                Utilities.bytesFromHexString("20 01 00"));
+        Assert.assertEquals("command", 0x20, t.getCmd());
+        Assert.assertEquals("subcommand", 0x01, t.getSubCmd());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "controller assign OK", t.toString());
+        t = new TractionControlReplyMessage(src, dst,
+                Utilities.bytesFromHexString("20 01 01"));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "controller assign fail 0x01", t.toString());
+    }
+
+    @Test
+    public void testControllerQueryReply() {
+        TractionControlReplyMessage t = new TractionControlReplyMessage(src, dst,
+                Utilities.bytesFromHexString("20 03 00 09 00 99 FF EE DD"));
+        Assert.assertEquals("command", 0x20, t.getCmd());
+        Assert.assertEquals("subcommand", 0x03, t.getSubCmd());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "controller is 09.00.99.FF.EE.DD", t.toString());
+        Assert.assertEquals("controller ID", 0x090099FFEEDDL,
+                t.getCurrentControllerReply().toLong());
+    }
+
+    @Test
+    public void testListenerAttachReply() {
+        TractionControlReplyMessage t = new TractionControlReplyMessage(src, dst,
+                Utilities.bytesFromHexString("30 01 09 00 99 DD EE FF 00 00"));
+        Assert.assertEquals("command", 0x30, t.getCmd());
+        Assert.assertEquals("subcommand", 0x01, t.getSubCmd());
+        Assert.assertEquals("code", 0, t.getConsistAttachCode());
+        Assert.assertEquals("node ID", 0x090099DDEEFFL, t.getConsistAttachNodeID().toLong());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "listener attach 09.00.99.DD.EE.FF result 0x0000", t.toString());
+
+        t = new TractionControlReplyMessage(src, dst, Utilities.bytesFromHexString("30 01 09 00 " +
+                "99 DD EE FF 20 30"));
+        Assert.assertEquals("code", 0x2030, t.getConsistAttachCode());
+        Assert.assertEquals("node ID", 0x090099DDEEFFL, t.getConsistAttachNodeID().toLong());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "listener attach 09.00.99.DD.EE.FF result 0x2030", t.toString());
+    }
+
+    @Test
+    public void testListenerDetachReply() {
+        TractionControlReplyMessage t = new TractionControlReplyMessage(src, dst,
+                Utilities.bytesFromHexString("30 02 09 00 99 DD EE FF 00 00"));
+        Assert.assertEquals("command", 0x30, t.getCmd());
+        Assert.assertEquals("subcommand", 0x02, t.getSubCmd());
+        Assert.assertEquals("code", 0, t.getConsistAttachCode());
+        Assert.assertEquals("node ID", 0x090099DDEEFFL, t.getConsistAttachNodeID().toLong());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "listener detach 09.00.99.DD.EE.FF result 0x0000", t.toString());
+
+        t = new TractionControlReplyMessage(src, dst, Utilities.bytesFromHexString("30 02 09 00 " +
+                "99 DD EE FF 20 30"));
+        Assert.assertEquals("code", 0x2030, t.getConsistAttachCode());
+        Assert.assertEquals("node ID", 0x090099DDEEFFL, t.getConsistAttachNodeID().toLong());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "listener detach 09.00.99.DD.EE.FF result 0x2030", t.toString());
+    }
+
+    @Test
+    public void testListenerQueryReply() {
+        TractionControlReplyMessage t = new TractionControlReplyMessage(src, dst,
+                Utilities.bytesFromHexString("30 03 13"));
+        Assert.assertEquals("command", 0x30, t.getCmd());
+        Assert.assertEquals("subcommand", 0x03, t.getSubCmd());
+        Assert.assertEquals("count", 0x13, t.getConsistLength());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "listener is count 19", t.toString());
+
+        t = new TractionControlReplyMessage(src, dst, Utilities.bytesFromHexString("30 03 13 04 " +
+                "82 09 00 99 DD EE FF"));
+        Assert.assertEquals("command", 0x30, t.getCmd());
+        Assert.assertEquals("subcommand", 0x03, t.getSubCmd());
+        Assert.assertEquals("count", 0x13, t.getConsistLength());
+        Assert.assertEquals("index", 4, t.getConsistIndex());
+        Assert.assertEquals("node ID", 0x090099DDEEFFL, t.getConsistQueryNodeID().toLong());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "listener is count 19 index 4 flags reverse,hide is 09.00.99.DD.EE.FF",
+                t.toString());
+    }
+
+    @Test
+    public void testReserveReply() {
+        TractionControlReplyMessage t = new TractionControlReplyMessage(src, dst,
+                Utilities.bytesFromHexString("40 01 00"));
+        Assert.assertEquals("command", 0x40, t.getCmd());
+        Assert.assertEquals("subcommand", 0x01, t.getSubCmd());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "reserve reply OK", t.toString());
+        t = new TractionControlReplyMessage(src, dst,
+                Utilities.bytesFromHexString("40 01 5A"));
+        Assert.assertEquals("command", 0x40, t.getCmd());
+        Assert.assertEquals("subcommand", 0x01, t.getSubCmd());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "reserve reply error 0x5a", t.toString());
+    }
+
+    @Test
+    public void testHeartbeatRequest() {
+        TractionControlReplyMessage t = new TractionControlReplyMessage(src, dst,
+                Utilities.bytesFromHexString("40 03 05"));
+        Assert.assertEquals("command", 0x40, t.getCmd());
+        Assert.assertEquals("subcommand", 0x03, t.getSubCmd());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlReply " +
+                "heartbeat request in 5 seconds", t.toString());
     }
 
     // The minimal setup for log4J

--- a/test/org/openlcb/messages/TractionControlRequestMessageTest.java
+++ b/test/org/openlcb/messages/TractionControlRequestMessageTest.java
@@ -96,13 +96,50 @@ public class TractionControlRequestMessageTest  {
 
     @Test
     public void testAssignController() throws Exception {
-        TractionControlRequestMessage msg = TractionControlRequestMessage.createAssignController
-                (src,
-                dst);
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createAssignController(
+                src, dst);
         byte[] payload = msg.getPayload();
         Assert.assertEquals("20 01 00 06 05 05 04 04 03", Utilities.toHexSpaceString(payload));
         Assert.assertEquals(src, msg.getSourceNodeID());
         Assert.assertEquals(dst, msg.getDestNodeID());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "assign controller 06.05.05.04.04.03", msg.toString());
+    }
+
+    @Test
+    public void testReleaseController() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createReleaseController(
+                src, dst);
+        byte[] payload = msg.getPayload();
+        Assert.assertEquals("20 02 00 06 05 05 04 04 03", Utilities.toHexSpaceString(payload));
+        Assert.assertEquals(src, msg.getSourceNodeID());
+        Assert.assertEquals(dst, msg.getDestNodeID());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "release controller 06.05.05.04.04.03", msg.toString());
+    }
+
+    @Test
+    public void testQueryController() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createQueryController(
+                src, dst);
+        byte[] payload = msg.getPayload();
+        Assert.assertEquals("20 03", Utilities.toHexSpaceString(payload));
+        Assert.assertEquals(src, msg.getSourceNodeID());
+        Assert.assertEquals(dst, msg.getDestNodeID());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "query controller", msg.toString());
+    }
+
+    @Test
+    public void testNotifyControllerChange() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createControllerChangeNotify(
+                src, dst, new NodeID(0x090099112233L));
+        byte[] payload = msg.getPayload();
+        Assert.assertEquals("20 04 00 09 00 99 11 22 33", Utilities.toHexSpaceString(payload));
+        Assert.assertEquals(src, msg.getSourceNodeID());
+        Assert.assertEquals(dst, msg.getDestNodeID());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "notify controller change to 09.00.99.11.22.33", msg.toString());
     }
 
 }

--- a/test/org/openlcb/messages/TractionControlRequestMessageTest.java
+++ b/test/org/openlcb/messages/TractionControlRequestMessageTest.java
@@ -142,4 +142,86 @@ public class TractionControlRequestMessageTest  {
                 "notify controller change to 09.00.99.11.22.33", msg.toString());
     }
 
+    @Test
+    public void testConsistAttach() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createConsistAttach(
+                src, dst, new NodeID(0x090099112233L),
+                TractionControlRequestMessage.CONSIST_FLAG_HIDE | TractionControlRequestMessage.CONSIST_FLAG_FN0);
+        byte[] payload = msg.getPayload();
+        Assert.assertEquals("30 01 84 09 00 99 11 22 33", Utilities.toHexSpaceString(payload));
+        Assert.assertEquals(src, msg.getSourceNodeID());
+        Assert.assertEquals(dst, msg.getDestNodeID());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "listener attach 09.00.99.11.22.33 flags link-f0,hide", msg.toString());
+    }
+
+    @Test
+    public void testConsistDetach() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createConsistDetach(
+                src, dst, new NodeID(0x090099112233L));
+        byte[] payload = msg.getPayload();
+        Assert.assertEquals("30 02 00 09 00 99 11 22 33", Utilities.toHexSpaceString(payload));
+        Assert.assertEquals(src, msg.getSourceNodeID());
+        Assert.assertEquals(dst, msg.getDestNodeID());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "listener detach 09.00.99.11.22.33", msg.toString());
+    }
+
+    @Test
+    public void testConsistLengthQuery() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createConsistLengthQuery(
+                src, dst);
+        byte[] payload = msg.getPayload();
+        Assert.assertEquals("30 03", Utilities.toHexSpaceString(payload));
+        Assert.assertEquals(src, msg.getSourceNodeID());
+        Assert.assertEquals(dst, msg.getDestNodeID());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "listener query", msg.toString());
+    }
+
+    @Test
+    public void testConsistIndexQuery() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createConsistIndexQuery(
+                src, dst,4);
+        byte[] payload = msg.getPayload();
+        Assert.assertEquals("30 03 04", Utilities.toHexSpaceString(payload));
+        Assert.assertEquals(src, msg.getSourceNodeID());
+        Assert.assertEquals(dst, msg.getDestNodeID());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "listener query index 4", msg.toString());
+    }
+
+    @Test
+    public void testMgmtReserve() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createReserve(src, dst);
+        byte[] payload = msg.getPayload();
+        Assert.assertEquals("40 01", Utilities.toHexSpaceString(payload));
+        Assert.assertEquals(src, msg.getSourceNodeID());
+        Assert.assertEquals(dst, msg.getDestNodeID());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "management reserve", msg.toString());
+    }
+
+    @Test
+    public void testMgmtRelease() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createRelease(src, dst);
+        byte[] payload = msg.getPayload();
+        Assert.assertEquals("40 02", Utilities.toHexSpaceString(payload));
+        Assert.assertEquals(src, msg.getSourceNodeID());
+        Assert.assertEquals(dst, msg.getDestNodeID());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "management release", msg.toString());
+    }
+
+    @Test
+    public void testMgmtNoop() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createNoop(src, dst);
+        byte[] payload = msg.getPayload();
+        Assert.assertEquals("40 03", Utilities.toHexSpaceString(payload));
+        Assert.assertEquals(src, msg.getSourceNodeID());
+        Assert.assertEquals(dst, msg.getDestNodeID());
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "noop/heartbeat", msg.toString());
+    }
+
 }

--- a/test/org/openlcb/messages/TractionControlRequestMessageTest.java
+++ b/test/org/openlcb/messages/TractionControlRequestMessageTest.java
@@ -13,6 +13,8 @@ public class TractionControlRequestMessageTest  {
     protected NodeID src = new NodeID(new byte[]{6,5,5,4,4,3});
     protected NodeID dst = new NodeID(new byte[]{2,2,2,4,4,4});
 
+    public static final double MPH = TractionControlRequestMessage.MPH;
+
     @Test
     public void testGetSpeed() throws Exception {
         double speed = 13.5;
@@ -22,6 +24,75 @@ public class TractionControlRequestMessageTest  {
         Float16 sp = msg.getSpeed();
         Assert.assertEquals(13.5, sp.getFloat(), 0.01);
     }
+
+    @Test
+    public void testCreateSetSpeed() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createSetSpeed(src, dst
+                , true, 13 * MPH);
+        Assert.assertEquals("00 45 D0", Utilities.toHexSpaceString(msg.getPayload()));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "set speed F 13 mph", msg.toString());
+
+        msg = TractionControlRequestMessage.createSetSpeed(src, dst, false, 13 * MPH);
+        Assert.assertEquals("00 C5 D0", Utilities.toHexSpaceString(msg.getPayload()));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "set speed R 13 mph", msg.toString());
+
+        msg = TractionControlRequestMessage.createSetSpeed(src, dst, true, 126 * MPH);
+        Assert.assertEquals("00 53 0A", Utilities.toHexSpaceString(msg.getPayload()));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "set speed F 126 mph", msg.toString());
+
+        msg = TractionControlRequestMessage.createSetSpeed(src, dst, false, 126 * MPH);
+        Assert.assertEquals("00 D3 0A", Utilities.toHexSpaceString(msg.getPayload()));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "set speed R 126 mph", msg.toString());
+    }
+
+    @Test
+    public void testCreateGetSpeed() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createGetSpeed(src, dst);
+        Assert.assertEquals("10", Utilities.toHexSpaceString(msg.getPayload()));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "get speed", msg.toString());
+    }
+
+    @Test
+    public void testCreateEstop() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createSetEstop(src, dst);
+        Assert.assertEquals("02", Utilities.toHexSpaceString(msg.getPayload()));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "set estop", msg.toString());
+    }
+
+    @Test
+    public void testCreateSetFn() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createSetFn(src, dst,
+                11, 1);
+        Assert.assertEquals("01 00 00 0B 00 01", Utilities.toHexSpaceString(msg.getPayload()));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "set fn 11 to 1", msg.toString());
+
+        msg = TractionControlRequestMessage.createSetFn(src, dst,
+                12298905, 56762);
+        Assert.assertEquals("01 BB AA 99 DD BA", Utilities.toHexSpaceString(msg.getPayload()));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "set fn 12298905 to 56762", msg.toString());
+    }
+
+    @Test
+    public void testCreateGetFn() throws Exception {
+        TractionControlRequestMessage msg = TractionControlRequestMessage.createGetFn(src, dst, 11);
+        Assert.assertEquals("11 00 00 0B", Utilities.toHexSpaceString(msg.getPayload()));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "get fn 11", msg.toString());
+
+        msg = TractionControlRequestMessage.createGetFn(src, dst, 12298905);
+        Assert.assertEquals("11 BB AA 99", Utilities.toHexSpaceString(msg.getPayload()));
+        Assert.assertEquals("06.05.05.04.04.03 - 02.02.02.04.04.04 TractionControlRequest " +
+                "get fn 12298905", msg.toString());
+    }
+
 
     @Test
     public void testAssignController() throws Exception {


### PR DESCRIPTION
This PR adds toString() methods to the TractionControlRequest and TractionControlReply messages. These tostring methods are used by the OpenLCB/LCC monitor log in JMRI. The decoding interprets the message command, subcommand and renders the arguments in text form.

Adds unit tests for untested parts of the traction messages, including creators and accessors.
Adds a few missing details from the TractionWM to the traction request/reply classes.

Misc supporting changes:
- Fixes bugs in the Utilities.NetworkToHostUintXX methods.
- Adds 24-bit Utilities.NetworkToHostUintXX method.
- Adds a constructor to NodeID that takes a long argument.
- Fixes missing rounding in the Float16 constructor (it was truncating to zero instead of rounding).
- Adds isPositive to Float16 class.