### PR TITLE
Implements sending message to unknown alias 

### DIFF
--- a/src/org/openlcb/can/AliasMap.java
+++ b/src/org/openlcb/can/AliasMap.java
@@ -2,6 +2,8 @@ package org.openlcb.can;
 
 import org.openlcb.NodeID;
 
+import java.util.ArrayList;
+
 /**
  * Maintains a 2-way map between nodes and CAN node ID aliases.
  *<p>
@@ -16,7 +18,18 @@ public class AliasMap {
     }
     java.util.HashMap<NodeID, Integer> iMap = new java.util.HashMap<NodeID, Integer>();
     java.util.HashMap<Integer, NodeID> nMap = new java.util.HashMap<Integer, NodeID>();
-    
+    java.util.List<Watcher> watchers = new ArrayList<>();
+
+    /// This interface allows an external component to watch for newly discovered aliases.
+    public interface Watcher {
+        /// Called when a new alias was discovered.
+        void aliasAdded(NodeID id, int alias);
+    }
+
+    public synchronized void addWatcher(Watcher w) {
+        watchers.add(w);
+    }
+
     public void processFrame(OpenLcbCanFrame f) {
         // check type
         if (f.isInitializationComplete() || f.isVerifiedNID() || f.isAliasMapDefinition()) {
@@ -30,23 +43,28 @@ public class AliasMap {
     }
     
     public void insert(int alias, NodeID nid) {
-        nMap.put(alias, nid);
-        iMap.put(nid, alias);
+        synchronized (this) {
+            nMap.put(alias, nid);
+            iMap.put(nid, alias);
+        }
+        for (Watcher w: watchers) {
+            w.aliasAdded(nid, alias);
+        }
     }
     
-    public void remove(int alias) {
+    public synchronized void remove(int alias) {
         NodeID nid = getNodeID(alias);
         if (nid == null) return;
         nMap.remove(alias);
         iMap.remove(nid);
     }
     
-    public NodeID getNodeID(int alias) {
+    public synchronized NodeID getNodeID(int alias) {
         NodeID retVal = nMap.get(Integer.valueOf(alias));
         if (retVal != null) return retVal;
         else return new NodeID();
     }
-    public int getAlias(NodeID nid) {
+    public synchronized int getAlias(NodeID nid) {
         Integer r = iMap.get(nid);
         if (r == null) return -1;
         else return r.intValue();

--- a/src/org/openlcb/can/CanInterface.java
+++ b/src/org/openlcb/can/CanInterface.java
@@ -150,6 +150,9 @@ public class CanInterface {
             aliasWatcher.send(frame);
             aliasMap.processFrame(new OpenLcbCanFrame(frame));
             List<Message> l = messageBuilder.processFrame(frame);
+            if (messageBuilder.foundUnblockedMessage()) {
+                olcbInterface.getOutputConnection().put(messageBuilder.getTriggerMessage(), null);
+            }
             if (l == null) return;
             for (Message m : l) {
                 olcbInterface.getInputConnection().put(m, null);

--- a/src/org/openlcb/can/CanInterface.java
+++ b/src/org/openlcb/can/CanInterface.java
@@ -16,7 +16,7 @@ import java.util.logging.Logger;
 
 /**
  * CanInterface collects all objects necessary to operate a standards-compliant node that connects
- * via CAN-bus.
+ * via CAN-bus. It creates the OlcbInterface internally.
  *
  * Created by bracz on 12/27/15.
  */
@@ -64,7 +64,7 @@ public class CanInterface {
         this.nodeId = interfaceId;
 
         // Creates high-level OpenLCB interface.
-        olcbInterface = new OlcbInterface(nodeId, frameRenderer,threadPool);
+        olcbInterface = new OlcbInterface(nodeId, frameRenderer, threadPool);
 
         // Creates CAN-level OpenLCB objects.
         aliasMap = new AliasMap();

--- a/test/org/openlcb/can/AliasMapTest.java
+++ b/test/org/openlcb/can/AliasMapTest.java
@@ -51,5 +51,34 @@ public class AliasMapTest  {
         Assert.assertEquals("get Alias", -1, map.getAlias(new NodeID(new byte[]{0,1,2,3,4,5})));
         Assert.assertEquals("get NodeID", new NodeID(), map.getNodeID(0));
     }
-    
+
+    @Test
+    public void testWatcher() {
+        AliasMap map = new AliasMap();
+
+        NodeID nid = new NodeID(new byte[]{1,2,3,4,5,6});
+        int a = 432;
+
+        final boolean[] found = {false};
+        map.addWatcher(new AliasMap.Watcher() {
+            @Override
+            public void aliasAdded(NodeID id, int alias) {
+                found[0] = true;
+                Assert.assertEquals(nid, id);
+                Assert.assertEquals(a, alias);
+            }
+        });
+
+        map.insert(a, nid);
+        Assert.assertTrue(found[0]);
+
+        found[0] = false;
+
+        OpenLcbCanFrame f = new OpenLcbCanFrame(a);
+        f.setInitializationComplete(a, nid);
+        map.processFrame(f);
+
+        Assert.assertTrue(found[0]);
+    }
+
 }


### PR DESCRIPTION
This PR adds code to support the case when an outgoing message addresses a Node for which we do not have a valid alias in the AliasMap. This can happen in multiple cases, some more frequent than others:
- There was a network partition thus we did not see that node at the time when we pre-filled the alias map after startup.
- The node purposefully released its alias using an AMR frame (this is standards compliant).
- The target node is a virtual node that does not yet exist, such as a train node operated by a command station.

The mechanism to do this is the following:
- The AliasMap has a new API to listen to all(...) calls. The MessageBuilder sings up for getting notifications like this.
- The MessageBuilder class, when seeing a miss in the AliasMap lookup for an outgoing addressed message, will put this message into a queue by destination ID. It emits a global verify node ID for the given target node ID instead of the specific message.
- Normally, the target node answers this, and that answer initializes its entry in the AliasMap.
- When this new alias is added to the AliasMap, the MessageBuilder is invoked and takes the pending messages out of the queue ("unblocked messages").
- Upon sending *any* outgoing message, the MessageBuilder first flushes any unblocked messages it has in the queue.
- An additional mechanism is added to MessageBuilder and CanInterface that allows waking up the output message processing thread when an unblocked message is found ("trigger message"). This is needed because the openlcb library does not make an assumption on what the threading model of the application is.


Misc fixes:
- makes AliasMap thread-safe.
- Fixes some comments.