### PR TITLE
Fix order of code and mti in OptionalInteractionRejected message

### DIFF
--- a/test/org/openlcb/can/MessageBuilderTest.java
+++ b/test/org/openlcb/can/MessageBuilderTest.java
@@ -39,8 +39,8 @@ import org.openlcb.messages.TractionProxyRequestMessage;
  * @author  Bob Jacobsen   Copyright 2010
  */
 public class MessageBuilderTest  {
-   
-    @Test	
+
+    @Test
     public void testCtor() {
         Assert.assertNotNull("exists",new MessageBuilder(map));
     }
@@ -63,51 +63,51 @@ public class MessageBuilderTest  {
     /** ****************************************************
      * Tests of messages into frames
      ***************************************************** */
-     
-    @Test	
+
+    @Test
     public void testInitializationCompleteMessage() {
         Message m = new InitializationCompleteMessage(source);
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<OpenLcbCanFrame> list = b.processMessage(m);
-        
+
         // looking for [19100123] 01 02 03 04 05 06
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         CanFrame f0 = list.get(0);
         Assert.assertEquals("header", toHexString(0x19100123), toHexString(f0.getHeader()));
         compareContent(source.getContents(), f0);
 
         testDecoding(m, list);
     }
-    
-    @Test	
+
+    @Test
     public void testVerifyNodeIDNumberMessageEmpty() {
         Message m = new VerifyNodeIDNumberMessage(source);
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<OpenLcbCanFrame> list = b.processMessage(m);
-        
+
         // looking for [19490123]
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         CanFrame f0 = list.get(0);
         Assert.assertEquals("header", toHexString(0x19490123), toHexString(f0.getHeader()));
         compareContent(null, f0);
 
         testDecoding(m, list);
     }
-    
-    @Test	
+
+    @Test
     public void testVerifyNodeIDNumberMessageWithContent() {
         Message m = new VerifyNodeIDNumberMessage(source, source);
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<OpenLcbCanFrame> list = b.processMessage(m);
-        
+
         // looking for [19490123]
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         CanFrame f0 = list.get(0);
         Assert.assertEquals("header", toHexString(0x19490123), toHexString(f0.getHeader()));
         compareContent(source.getContents(), f0);
@@ -115,7 +115,7 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testIdentifyEventsGlobal() {
         Message m = new IdentifyEventsGlobalMessage(source);
         MessageBuilder b = new MessageBuilder(map);
@@ -153,7 +153,7 @@ public class MessageBuilderTest  {
         testDecoding(dm, list);
     }
 
-    @Test	
+    @Test
     public void testIdentifyEventsAddressed() {
         Message m = new IdentifyEventsAddressedMessage(source, destination);
         MessageBuilder b = new MessageBuilder(map);
@@ -171,16 +171,16 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testVerifiedNodeIDNumberMessage() {
         Message m = new VerifiedNodeIDNumberMessage(source);
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<OpenLcbCanFrame> list = b.processMessage(m);
-        
+
         // looking for [19170123] 01 02 03 04 05 06
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         CanFrame f0 = list.get(0);
         Assert.assertEquals("header", toHexString(0x19170123), toHexString(f0.getHeader()));
         compareContent(source.getContents(), f0);
@@ -188,16 +188,16 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testProducerConsumerEventReportMessage() {
         Message m = new ProducerConsumerEventReportMessage(source, event);
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<OpenLcbCanFrame> list = b.processMessage(m);
-        
+
         // looking for [195B4123] 11 12 13 14 15 16 17 18
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         CanFrame f0 = list.get(0);
         Assert.assertEquals("header", toHexString(0x195B4123), toHexString(f0.getHeader()));
         compareContent(event.getContents(), f0);
@@ -205,7 +205,7 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testTractionControlRequestMessageSingle() {
         Message m = new TractionControlRequestMessage(source, destination, new byte[]{(byte)0xCC,
                 (byte)0xAA, 0x55, 4, 5, 6});
@@ -221,7 +221,7 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testTractionControlRequestMessageMulti() {
         Message m = new TractionControlRequestMessage(source, destination, new byte[]{(byte)0xCC,
                 (byte)0xAA, 0x55, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14});
@@ -240,7 +240,7 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testTractionControlReplyMessage() {
         Message m = new TractionControlReplyMessage(source, destination, new byte[]{(byte)0xCC,
                 (byte)0xAA, 0x55, 4, 5, 6});
@@ -256,7 +256,7 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testTractionProxyRequestMessage() {
         Message m = new TractionProxyRequestMessage(source, destination, new byte[]{(byte)0xCC,
                 (byte)0xAA, 0x55, 4, 5, 6});
@@ -272,7 +272,7 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testTractionProxyReplyMessage() {
         Message m = new TractionProxyReplyMessage(source, destination, new byte[]{(byte)0xCC,
                 (byte)0xAA, 0x55, 4, 5, 6});
@@ -288,15 +288,15 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testDatagramMessageShort() {
         int[] data = new int[]{21,22,23};
         Message m = new DatagramMessage(source, destination, data);
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<OpenLcbCanFrame> list = b.processMessage(m);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         CanFrame f0 = list.get(0);
 
         Assert.assertEquals("header", toHexString(0x1A321123), toHexString(f0.getHeader()));
@@ -305,15 +305,15 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testDatagramMessageEight() {
         int[] data = new int[]{21,22,23,24,25,26,27,28};
         Message m = new DatagramMessage(source, destination, data);
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<OpenLcbCanFrame> list = b.processMessage(m);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         CanFrame f0 = list.get(0);
 
         Assert.assertEquals("header", toHexString(0x1A321123), toHexString(f0.getHeader()));
@@ -322,18 +322,18 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testDatagramMessageTwoFrame() {
-        int[] data = new int[]{21,22,23,24,25,26,27,28, 
+        int[] data = new int[]{21,22,23,24,25,26,27,28,
                                31,32,33,34,35,36,37,38};
-                               
+
         Message m = new DatagramMessage(source, destination, data);
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<OpenLcbCanFrame> list = b.processMessage(m);
-        
-        
-        Assert.assertEquals("count", 2, list.size()); 
+
+
+        Assert.assertEquals("count", 2, list.size());
 
         CanFrame f0 = list.get(0);
         Assert.assertEquals("f0 header", toHexString(0x1B321123), toHexString(f0.getHeader()));
@@ -346,17 +346,17 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testDatagramMessageNine() {
         int[] data = new int[]{21,22,23,24,25,26,27,28,31};
-                               
+
         Message m = new DatagramMessage(source, destination, data);
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<OpenLcbCanFrame> list = b.processMessage(m);
-        
-        
-        Assert.assertEquals("count", 2, list.size()); 
+
+
+        Assert.assertEquals("count", 2, list.size());
 
         CanFrame f0 = list.get(0);
         Assert.assertEquals("f0 header", toHexString(0x1B321123), toHexString(f0.getHeader()));
@@ -369,7 +369,7 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testDatagramOKMessage() {
         Message m = new DatagramAcknowledgedMessage(source, destination, 0x0);
         MessageBuilder b = new MessageBuilder(map);
@@ -386,7 +386,7 @@ public class MessageBuilderTest  {
         testDecoding(m, list);
     }
 
-    @Test	
+    @Test
     public void testDatagramOKMessageWithPayload() {
         Message m = new DatagramAcknowledgedMessage(source, destination, 0x80);
         MessageBuilder b = new MessageBuilder(map);
@@ -459,19 +459,19 @@ public class MessageBuilderTest  {
      * Tests of frames into messages
      ***************************************************** */
 
-    @Test	
+    @Test
     public void testInitializationCompleteFrame() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x19100123);
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
-        Assert.assertTrue(msg instanceof InitializationCompleteMessage);        
+
+        Assert.assertTrue(msg instanceof InitializationCompleteMessage);
     }
 
     @Test
@@ -489,78 +489,78 @@ public class MessageBuilderTest  {
         Assert.assertTrue(msg instanceof IdentifyEventsGlobalMessage);
     }
 
-    @Test	
+    @Test
     public void testVerifyNodeEmptyFrame() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x19490123);
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
-        Assert.assertTrue(msg instanceof VerifyNodeIDNumberMessage); 
+
+        Assert.assertTrue(msg instanceof VerifyNodeIDNumberMessage);
         Assert.assertEquals(new VerifyNodeIDNumberMessage(source), msg);
     }
-    
-    @Test	
+
+    @Test
     public void testVerifyNodeContentFrame() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x19490123);
         frame.setData(new byte[]{1,2,3,4,5,6});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
-        Assert.assertTrue(msg instanceof VerifyNodeIDNumberMessage);        
+
+        Assert.assertTrue(msg instanceof VerifyNodeIDNumberMessage);
         Assert.assertEquals(new VerifyNodeIDNumberMessage(source, source), msg);
     }
 
-    @Test	
+    @Test
     public void testSingleFrameDatagram() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x1A321123);
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
-        Assert.assertTrue(msg instanceof DatagramMessage);        
+
+        Assert.assertTrue(msg instanceof DatagramMessage);
         Assert.assertEquals("source", source, msg.getSourceNodeID());
         Assert.assertEquals("destination", destination, ((AddressedMessage)msg).getDestNodeID());
     }
-    
-    @Test	
+
+    @Test
     public void testTwoFrameDatagram() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x1B321123);
         frame.setData(new byte[]{1,2});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertNull(list); 
-        
+
+        Assert.assertNull(list);
+
         frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x1D321123);
         frame.setData(new byte[]{11,12,13});
-                
+
         list = b.processFrame(frame);
 
-        Assert.assertEquals("count", 1, list.size()); 
+        Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        Assert.assertTrue(msg instanceof DatagramMessage);  
-        int[] data =  ((DatagramMessage)msg).getData();   
+        Assert.assertTrue(msg instanceof DatagramMessage);
+        int[] data =  ((DatagramMessage)msg).getData();
         Assert.assertEquals(5, data.length);
         Assert.assertEquals(1,data[0]);
         Assert.assertEquals(2,data[1]);
@@ -568,143 +568,143 @@ public class MessageBuilderTest  {
         Assert.assertEquals(12,data[3]);
         Assert.assertEquals(13,data[4]);
     }
-    
-    @Test	
+
+    @Test
     public void testPipReplyFrame() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
-        frame.setHeader(0x19668071); 
+        frame.setHeader(0x19668071);
         frame.setData(new byte[]{0x02, (byte)0xB4, (byte)0xD5, 0x00, 0x00, 0x00, 0x00, 0x00});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
-        Assert.assertTrue(msg instanceof ProtocolIdentificationReplyMessage);  
-        
-        Assert.assertTrue(((ProtocolIdentificationReplyMessage)msg).getValue() == 0xD50000000000L);    
+
+        Assert.assertTrue(msg instanceof ProtocolIdentificationReplyMessage);
+
+        Assert.assertTrue(((ProtocolIdentificationReplyMessage)msg).getValue() == 0xD50000000000L);
     }
-    
-    @Test	
+
+    @Test
     public void testOptionalRejectFrame1() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
-        frame.setHeader(0x19068071); 
+        frame.setHeader(0x19068071);
         frame.setData(new byte[]{0x02, 0x02, (byte)0x12, 0x34, 0x56, 0x78, 0x00, 0x00});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
-        Assert.assertTrue(msg instanceof OptionalIntRejectedMessage);  
-        
-        Assert.assertEquals(0x1234, ((OptionalIntRejectedMessage)msg).getRejectMTI());    
-        Assert.assertEquals(0x5678, ((OptionalIntRejectedMessage)msg).getCode());    
+
+        Assert.assertTrue(msg instanceof OptionalIntRejectedMessage);
+
+        Assert.assertEquals(0x1234, ((OptionalIntRejectedMessage)msg).getCode());
+        Assert.assertEquals(0x5678, ((OptionalIntRejectedMessage)msg).getRejectMTI());
     }
-    
-    @Test	
+
+    @Test
     public void testOptionalRejectFrame2() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
-        frame.setHeader(0x19068071); 
+        frame.setHeader(0x19068071);
         frame.setData(new byte[]{0x02, 0x02, (byte)0x12, 0x34, 0x56, 0x78});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
-        Assert.assertTrue(msg instanceof OptionalIntRejectedMessage);  
-        
-        Assert.assertEquals(0x1234, ((OptionalIntRejectedMessage)msg).getRejectMTI());    
-        Assert.assertEquals(0x5678, ((OptionalIntRejectedMessage)msg).getCode());    
+
+        Assert.assertTrue(msg instanceof OptionalIntRejectedMessage);
+
+        Assert.assertEquals(0x1234, ((OptionalIntRejectedMessage)msg).getCode());
+        Assert.assertEquals(0x5678, ((OptionalIntRejectedMessage)msg).getRejectMTI());
     }
-    
-    @Test	
+
+    @Test
     public void testOptionalRejectFrame3() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
-        frame.setHeader(0x19068071); 
+        frame.setHeader(0x19068071);
         frame.setData(new byte[]{0x02, 0x02, (byte)0x12, 0x34});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
-        Assert.assertTrue(msg instanceof OptionalIntRejectedMessage);  
-        
-        Assert.assertEquals(0x1234, ((OptionalIntRejectedMessage)msg).getRejectMTI());    
-        Assert.assertEquals(0, ((OptionalIntRejectedMessage)msg).getCode());    
+
+        Assert.assertTrue(msg instanceof OptionalIntRejectedMessage);
+
+        Assert.assertEquals(0x1234, ((OptionalIntRejectedMessage)msg).getCode());
+        Assert.assertEquals(0, ((OptionalIntRejectedMessage)msg).getRejectMTI());
     }
-    
-    @Test	
+
+    @Test
     public void testBogusMti() {
         // should emit "failed to parse MTI 0x541"
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
-        frame.setHeader(0x19541071); 
+        frame.setHeader(0x19541071);
         frame.setData(new byte[]{0x02, 0x02, (byte)0x12, 0x34});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         System.out.println("Expect next line to be \" failed to parse MTI 0x541\"");
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 0, list.size()); 
+
+        Assert.assertEquals("count", 0, list.size());
     }
 
-    @Test	
+    @Test
     public void testAccumulateSniipReply() {
         // start frame
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
-        frame.setHeader(0x19A08071); 
+        frame.setHeader(0x19A08071);
         frame.setData(new byte[]{0x12, 0x02, 0x12, 0x34});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 0, list.size()); 
-        
+
+        Assert.assertEquals("count", 0, list.size());
+
         // end frame
         frame = new OpenLcbCanFrame(0x123);
-        frame.setHeader(0x19A08071); 
+        frame.setHeader(0x19A08071);
         frame.setData(new byte[]{0x22, 0x02, 0x56, 0x78});
-                
+
         list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        Assert.assertTrue(msg instanceof SimpleNodeIdentInfoReplyMessage);  
-        
-        Assert.assertEquals(0x12, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[0]);    
-        Assert.assertEquals(0x34, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[1]);    
-        Assert.assertEquals(0x56, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[2]);    
-        Assert.assertEquals(0x78, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[3]);  
-        
+        Assert.assertTrue(msg instanceof SimpleNodeIdentInfoReplyMessage);
+
+        Assert.assertEquals(0x12, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[0]);
+        Assert.assertEquals(0x34, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[1]);
+        Assert.assertEquals(0x56, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[2]);
+        Assert.assertEquals(0x78, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[3]);
+
         // check for no stored state
         frame = new OpenLcbCanFrame(0x123);
-        frame.setHeader(0x19A08071); 
+        frame.setHeader(0x19A08071);
         frame.setData(new byte[]{0x02, 0x02, 0x12, 0x34});
 
         list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         msg = list.get(0);
-        Assert.assertTrue(msg instanceof SimpleNodeIdentInfoReplyMessage);  
-        
-        Assert.assertEquals(2, ((SimpleNodeIdentInfoReplyMessage)msg).getData().length);    
-        Assert.assertEquals(0x12, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[0]);    
-        Assert.assertEquals(0x34, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[1]);    
+        Assert.assertTrue(msg instanceof SimpleNodeIdentInfoReplyMessage);
+
+        Assert.assertEquals(2, ((SimpleNodeIdentInfoReplyMessage)msg).getData().length);
+        Assert.assertEquals(0x12, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[0]);
+        Assert.assertEquals(0x34, ((SimpleNodeIdentInfoReplyMessage)msg).getData()[1]);
     }
 
-    @Test	
+    @Test
     public void testTractionControlRequestParseSingle() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x195EB123);
@@ -720,7 +720,7 @@ public class MessageBuilderTest  {
         Assert.assertEquals("payload", "12 34", Utilities.toHexSpaceString(((AddressedPayloadMessage)msg).getPayload()));
     }
 
-    @Test	
+    @Test
     public void testTractionProxyReplyParseMulti() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x191E8123);
@@ -754,29 +754,29 @@ public class MessageBuilderTest  {
         Assert.assertEquals("dstnode", destination, ((AddressedPayloadMessage) msg).getDestNodeID());
     }
 
-    @Test	
+    @Test
     public void testAliasExtraction() {
-    
+
         NodeID high = new NodeID(new byte[]{11,12,13,14,15,16});
         map.insert(0x0FFF, high);
-        
+
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x1AFFF123);
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
-        Assert.assertTrue(msg instanceof DatagramMessage);        
+
+        Assert.assertTrue(msg instanceof DatagramMessage);
 
         Assert.assertEquals("source", source, msg.getSourceNodeID());
         Assert.assertEquals("destination", high, ((AddressedMessage)msg).getDestNodeID());
     }
 
-    @Test	
+    @Test
     public void testDatagramOKFrame() {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x19A28123);
@@ -797,30 +797,30 @@ public class MessageBuilderTest  {
         Assert.assertEquals(0x80, dmsg.getFlags());
     }
 
-    @Test	
+    @Test
     public void testAddressedMessageAliasExtraction() {
         NodeID high = new NodeID(new byte[]{11,12,13,14,15,16});
         map.insert(0x0FFF, high);
-        
+
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x19A28123);
         frame.setData(new byte[]{(byte)0x0F, (byte)0xFF});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
-        Assert.assertEquals("count", 1, list.size()); 
+
+        Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
-        Assert.assertTrue(msg instanceof AddressedMessage);        
+
+        Assert.assertTrue(msg instanceof AddressedMessage);
 
         Assert.assertEquals("source", source, msg.getSourceNodeID());
         Assert.assertEquals("destination", high, ((AddressedMessage)msg).getDestNodeID());
     }
-    
+
     // dph Stream tests
-    @Test	
+    @Test
     public void testStreamInitiateRequestMessage() {
         NodeID high = new NodeID(new byte[]{11,12,13,14,15,16});
         map.insert(0x0FFF, high);
@@ -828,24 +828,24 @@ public class MessageBuilderTest  {
         f.setHeader(0x19CC8123);
         // dest(2), maxBuffer(2),flags(2),sourceStream, reserved
         f.setData(new byte[]{(byte)0x0F, (byte)0xFF, 0, 6, 0, 0, 4, 0});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(f);
-        
+
         Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
+
         Assert.assertTrue(msg instanceof StreamInitiateRequestMessage);
-        
+
         Assert.assertEquals("source", source, msg.getSourceNodeID());
         Assert.assertEquals("destination", high, ((StreamInitiateRequestMessage)msg).getDestNodeID());
         Assert.assertEquals("max buffer ",6,(f.getElement(2)<<8)+f.getElement(3));
         Assert.assertEquals("flags ",0,(f.getElement(4)<<8)+f.getElement(5));
         Assert.assertEquals("sourceStreamID ",4,f.getElement(6));
     }
-    
-    @Test	
+
+    @Test
     public void testStreamInitiateReplyMessage() {
         NodeID high = new NodeID(new byte[]{11,12,13,14,15,16});
         map.insert(0x0FFF, high);
@@ -853,14 +853,14 @@ public class MessageBuilderTest  {
         f.setHeader(0x19868123);
         // dest(2), bufferesize(2), flags(2),sourceStream, destinationStream
         f.setData(new byte[]{(byte)0x0F, (byte)0xFF, 0, 64, 0, 0, 4, 6});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(f);
-        
+
         Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
+
         Assert.assertTrue(msg instanceof StreamInitiateReplyMessage);
         //int[] data =  ((DatagramMessage)msg).getData();
         Assert.assertEquals("source", source, msg.getSourceNodeID());
@@ -877,19 +877,19 @@ public class MessageBuilderTest  {
         OpenLcbCanFrame frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x1F321123);
         frame.setData(new byte[]{1,2,3,4,5});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
+
         Assert.assertNull(list);
-        
+
         frame = new OpenLcbCanFrame(0x123);
         frame.setHeader(0x1F321123);
         frame.setData(new byte[]{11,12,13,14,15});
-        
+
         list = b.processFrame(frame);
-        
+
         Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
         Assert.assertTrue(msg instanceof DatagramMessage);
@@ -906,7 +906,7 @@ public class MessageBuilderTest  {
         Assert.assertEquals(14,data[8]);
         Assert.assertEquals(15,data[9]);
     }
- 
+
     @Test
     public void testStreamDataProceedMessage() {
         NodeID high = new NodeID(new byte[]{11,12,13,14,15,16});
@@ -915,14 +915,14 @@ public class MessageBuilderTest  {
         frame.setHeader(0x19888123);
         // sourceStream, destinationStream, flags(2)
         frame.setData(new byte[]{(byte)0x0F, (byte)0xFF, 4, 6, 0, 0});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
+
         Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
+
         Assert.assertTrue(msg instanceof StreamDataProceedMessage);
         Assert.assertEquals("source", source, msg.getSourceNodeID());
         Assert.assertEquals("destination", high, ((StreamDataProceedMessage)msg).getDestNodeID());
@@ -930,7 +930,7 @@ public class MessageBuilderTest  {
         Assert.assertEquals("destinationStreamID ",frame.getElement(3),6);
         Assert.assertEquals("flags ",(frame.getElement(4)<<8)+frame.getElement(5),0);
     }
-    
+
     @Test
     public void testStreamDataCompleteMessage() {
         NodeID high = new NodeID(new byte[]{11,12,13,14,15,16});
@@ -939,14 +939,14 @@ public class MessageBuilderTest  {
         frame.setHeader(0x198A8123);
         // sourceStream, destinationStream, flags(2)
         frame.setData(new byte[]{(byte)0x0F, (byte)0xFF, 4, 6, 0, 0});
-        
+
         MessageBuilder b = new MessageBuilder(map);
-        
+
         List<Message> list = b.processFrame(frame);
-        
+
         Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
-        
+
         Assert.assertTrue(msg instanceof StreamDataCompleteMessage);
         Assert.assertEquals("source", source, msg.getSourceNodeID());
         Assert.assertEquals("destination", high, ((StreamDataCompleteMessage)msg).getDestNodeID());
@@ -954,11 +954,11 @@ public class MessageBuilderTest  {
         Assert.assertEquals("destinationStreamID ",frame.getElement(3),6);
         Assert.assertEquals("flags ",(frame.getElement(4)<<8)+frame.getElement(5),0);
     }
-    
+
     String toHexString(int n) {
         return Integer.toHexString(n);
     }
-    
+
     void compareContent(byte[] data, CanFrame f) {
         if (data == null) {
             Assert.assertEquals("no data", 0, f.getNumDataElements());
@@ -970,13 +970,13 @@ public class MessageBuilderTest  {
             }
         }
     }
-    
+
     NodeID source = new NodeID(new byte[]{1,2,3,4,5,6});
     NodeID destination = new NodeID(new byte[]{6,5,4,3,2,1});
     EventID event = new EventID(new byte[]{11,12,13,14,15,16,17,18});
     AliasMap map = new AliasMap();
-   
-    @Before 
+
+    @Before
     public void setUp() {
         map = new AliasMap();
         map.insert(0x0123, source);


### PR DESCRIPTION
MessageBuilder was taking the error code and rejected MTI from the wrong fields in the message.  This fixes that.