### PR TITLE
add EventID.toShortString()

### DIFF
--- a/src/org/openlcb/EventID.java
+++ b/src/org/openlcb/EventID.java
@@ -1,8 +1,8 @@
 package org.openlcb;
 
 // For annotations
-import net.jcip.annotations.*; 
-import edu.umd.cs.findbugs.annotations.*; 
+import net.jcip.annotations.*;
+import edu.umd.cs.findbugs.annotations.*;
 
 /**
  * Common EventID implementation.
@@ -17,16 +17,16 @@ import edu.umd.cs.findbugs.annotations.*;
 public class EventID {
 
     static final int BYTECOUNT = 8;
-    
+
     @CheckReturnValue
     public EventID(@NonNull NodeID node, int b7, int b8) {
         this.contents = new byte[BYTECOUNT];
         System.arraycopy(node.contents, 0, this.contents, 0, BYTECOUNT-2);
-            
+
         this.contents[6] = (byte)b7;
         this.contents[7] = (byte)b8;
     }
-    
+
     @CheckReturnValue
     public EventID(@NonNull byte[] contents) {
         if (contents == null)
@@ -36,7 +36,7 @@ public class EventID {
         this.contents = new byte[BYTECOUNT];
         System.arraycopy(contents, 0, this.contents, 0, BYTECOUNT);
     }
-    
+
     @CheckReturnValue
     public EventID(@NonNull String value) {
         if (value == null)
@@ -47,9 +47,9 @@ public class EventID {
         this.contents = new byte[BYTECOUNT];
         System.arraycopy(data, 0, this.contents, 0, BYTECOUNT);
     }
-    
+
     byte[] contents;
-    
+
     @CheckReturnValue
     @NonNull
     public byte[] getContents() {
@@ -71,7 +71,7 @@ public class EventID {
         } catch (Exception e) {
             return false;
         }
-    }  
+    }
 
     /// Checks whether a given Event ID comes from a given Node ID's space.
     public boolean startsWith(NodeID id) {
@@ -92,7 +92,7 @@ public class EventID {
             +(contents[5]<<6)
             +(contents[6]<<3)
             +(contents[7]);
-    } 
+    }
 
     @CheckReturnValue
     @NonNull
@@ -100,6 +100,19 @@ public class EventID {
     public String toString() {
         return "EventID:"
                 +Utilities.toHexPair(contents[0])+"."
+                +Utilities.toHexPair(contents[1])+"."
+                +Utilities.toHexPair(contents[2])+"."
+                +Utilities.toHexPair(contents[3])+"."
+                +Utilities.toHexPair(contents[4])+"."
+                +Utilities.toHexPair(contents[5])+"."
+                +Utilities.toHexPair(contents[6])+"."
+                +Utilities.toHexPair(contents[7]);
+    }
+
+    @CheckReturnValue
+    @NonNull
+    public String toShortString() {
+        return   Utilities.toHexPair(contents[0])+"."
                 +Utilities.toHexPair(contents[1])+"."
                 +Utilities.toHexPair(contents[2])+"."
                 +Utilities.toHexPair(contents[3])+"."

--- a/src/org/openlcb/EventID.java
+++ b/src/org/openlcb/EventID.java
@@ -99,27 +99,13 @@ public class EventID {
     @Override
     public String toString() {
         return "EventID:"
-                +Utilities.toHexPair(contents[0])+"."
-                +Utilities.toHexPair(contents[1])+"."
-                +Utilities.toHexPair(contents[2])+"."
-                +Utilities.toHexPair(contents[3])+"."
-                +Utilities.toHexPair(contents[4])+"."
-                +Utilities.toHexPair(contents[5])+"."
-                +Utilities.toHexPair(contents[6])+"."
-                +Utilities.toHexPair(contents[7]);
+                +Utilities.toHexDotsString(contents);
     }
 
     @CheckReturnValue
     @NonNull
     public String toShortString() {
-        return   Utilities.toHexPair(contents[0])+"."
-                +Utilities.toHexPair(contents[1])+"."
-                +Utilities.toHexPair(contents[2])+"."
-                +Utilities.toHexPair(contents[3])+"."
-                +Utilities.toHexPair(contents[4])+"."
-                +Utilities.toHexPair(contents[5])+"."
-                +Utilities.toHexPair(contents[6])+"."
-                +Utilities.toHexPair(contents[7]);
+        return Utilities.toHexDotsString(contents);
     }
 
     public long toLong() {

--- a/test/org/openlcb/EventIDTest.java
+++ b/test/org/openlcb/EventIDTest.java
@@ -40,13 +40,13 @@ public class EventIDTest {
         }
         Assert.fail("Should have thrown exception");
     }
-    
+
     @Test
     public void testOKLengthArg() {
         EventID e = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         Assert.assertNotNull(e);
     }
-    
+
     @Test
     public void testEqualsSame() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
@@ -54,7 +54,7 @@ public class EventIDTest {
         Assert.assertTrue(e1.equals(e2));
         Assert.assertEquals("hashcodes equal when equal",e1.hashCode(),e2.hashCode());
     }
-    
+
     @Test
     public void testStringArgDotted() {
         EventID e1 = new EventID("1.2.3.4.5.6.7.8");
@@ -72,13 +72,13 @@ public class EventIDTest {
     @Test
     public void testAltCtor() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
-        
+
         NodeID n = new NodeID(new byte[]{1,2,3,4,5,6});
         EventID e2 = new EventID(n, 7, 8);
 
         Assert.assertTrue(e1.equals(e2));
     }
-    
+
     @Test
     public void testEqualsCastSame() {
         Object e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
@@ -86,14 +86,14 @@ public class EventIDTest {
         Assert.assertTrue(e1.equals(e2));
         Assert.assertEquals("hashcodes equal when equal",e1.hashCode(),e2.hashCode());
     }
-    
+
     @Test
     public void testEqualsSelf() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         Assert.assertTrue(e1.equals(e1));
         Assert.assertEquals("hashcodes equal when equal",e1.hashCode(),e1.hashCode());
     }
-    
+
     @Test
     public void testEqualsCastSelf() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
@@ -101,14 +101,14 @@ public class EventIDTest {
         Assert.assertTrue(e1.equals(e2));
         Assert.assertEquals("hashcodes equal when equal",e1.hashCode(),e1.hashCode());
     }
-    
+
     @Test
     public void testNotEquals() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
         EventID e2 = new EventID(new byte[]{1,3,3,4,5,6,7,8});
         Assert.assertTrue(!e1.equals(e2));
     }
-    
+
     @Test
     public void testNotEqualsOtherType() {
         EventID e1 = new EventID(new byte[]{1,2,3,4,5,6,7,8});
@@ -129,6 +129,12 @@ public class EventIDTest {
     public void testOutputFormat() {
         EventID e1 = new EventID(new byte[]{0,0,1,0x10,0x13,0x0D,(byte)0xD0,(byte)0xAB});
         Assert.assertEquals(e1.toString(), "EventID:00.00.01.10.13.0D.D0.AB");
+    }
+
+    @Test
+    public void testShortOutputFormat() {
+        EventID e1 = new EventID(new byte[]{0,0,1,0x10,0x13,0x0D,(byte)0xD0,(byte)0xAB});
+        Assert.assertEquals(e1.toShortString(), "00.00.01.10.13.0D.D0.AB");
     }
 
     @Test


### PR DESCRIPTION
EventID.toString() adds a "EventID:" prefix to the event ID itself.  It would be useful to have a String version of the event ID without that.  Changing .toString() at this point doesn't seem like a good idea, so I added a .toShortString() method instead.