### PR TITLE
Automate sizing of NodeSelector JComboBox

### DIFF
--- a/src/org/openlcb/swing/NodeSelector.java
+++ b/src/org/openlcb/swing/NodeSelector.java
@@ -66,9 +66,6 @@ public class NodeSelector extends JPanel  {
 
         box = new JComboBox<ModelEntry>(model);
         add(box);
-        box.setPrototypeDisplayValue(new ModelEntry("01.02.03.04.05.06"
-                + " - East Pershing Tower Node"
-                + " - Some Description Here"));
 
         // listen for newly arrived nodes
         propertyChangeListener = new PropertyChangeListener() {
@@ -88,6 +85,12 @@ public class NodeSelector extends JPanel  {
         // add existing nodes
         for (MimicNodeStore.NodeMemo memo : store.getNodeMemos() ) {
             newNodeInList(memo);
+        }
+
+        // If there are no nodes added, manually set the size
+        // to a reasonable value
+        if (box.getItemCount() == 0) {
+            box.setPrototypeDisplayValue(new ModelEntry(new String(new char[70])));
         }
 
         addHierarchyListener(new HierarchyListener() {


### PR DESCRIPTION
This changes the handling of the JComboBox in org.openlcb.swing.NodeSelector so that it automatically sizes itself to the largest selection string available when the NodeSelector is created.

 - If there are no known nodes, a default of 70 spaces wide it used
 
 - The JComboBox does not resize if additional nodes are discovered after it's been created to prevent the GUI from moving around spontaneously.
 

