### PR TITLE
Config Node displays more info as needed

### DIFF
--- a/src/org/openlcb/swing/NodeSelector.java
+++ b/src/org/openlcb/swing/NodeSelector.java
@@ -40,6 +40,15 @@ public class NodeSelector extends JPanel  {
 
 
     /**
+     * Constructor with default displayed ID consisting of NodeID,
+     * User Name and User Description.
+     * @param store Node store containing the existing network
+     */
+    public NodeSelector(MimicNodeStore store) {
+        this(store, 2);
+    }
+
+    /**
      * Constructor that allows you to set the number of properties displayed
      * after the NodeID.
      *
@@ -50,17 +59,8 @@ public class NodeSelector extends JPanel  {
      * @param termCount Number of ID terms to include in the displayed ID
      */
     public NodeSelector(MimicNodeStore store, int termCount) {
-        this(store);
-        this.termCount = termCount;
-    }
-
-    /**
-     * Constructor with default displayed ID consisting of NodeID,
-     * User Name and User Description.
-     * @param store Node store containing the existing network
-     */
-    public NodeSelector(MimicNodeStore store) {
         this.store = store;
+        this.termCount = termCount;
 
         this.setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
 


### PR DESCRIPTION
Currently, Configure Nodes displays the user-provided name and description.  These are blank for JMRI nodes.

This PR will display the manufacturer name and model if the user provided info is blank.  This will show e.g. "JMRI - PanelPro" for JMRI nodes.  it's also useful for certain hardware nodes before they've been configured. 