### PR TITLE
Address space improvements

### DIFF
--- a/src/org/openlcb/implementations/MemoryConfigurationService.java
+++ b/src/org/openlcb/implementations/MemoryConfigurationService.java
@@ -57,8 +57,8 @@ public class MemoryConfigurationService {
     public MemoryConfigurationService(NodeID here, DatagramService downstream) {
         retryTimer = new Timer("OpenLCB Memory Configuration Service Retry Timer");
         this.here = here;
-        this.downstream = downstream;   
-        
+        this.downstream = downstream;
+
         // connect to be notified of config service
         downstream.registerForReceive(new DatagramService.DatagramServiceReceiveMemo
                 (DATAGRAM_TYPE) {
@@ -77,9 +77,18 @@ public class MemoryConfigurationService {
                 if (addrSpaceMemo != null) {
                     // doesn't handle decode of desc string, but should
                     int space = data[2] & 0xFF;
-                    long highAddress = (((long) data[3] & 0xFF) << 24) | (((long) data[4] & 0xFF)
+
+                    long highAddress = 0; // ludicrous default for nodes who fail to send this info
+                    if (data.length >= 7) {
+                        highAddress= (((long) data[3] & 0xFF) << 24) | (((long) data[4] & 0xFF)
                             << 16) | (((long) data[5] & 0xFF) << 8) | ((long) data[6] & 0xFF);
-                    int flags = data[7] & 0xFF;
+                    }
+
+                    // some nodes don't send the 7th byte?
+                    int flags = 0;
+                    if (data.length>=8) {
+                        flags = data[7] & 0xFF;
+                    }
                     long lowAddress = 0;
                     if (data.length >= 11)
                         lowAddress = (((long) data[8] & 0xFF) << 24) | (((long) data[9] & 0xFF)
@@ -182,8 +191,8 @@ public class MemoryConfigurationService {
             }
         });
     }
-    
-    
+
+
     NodeID here;
     DatagramService downstream;
     private Timer retryTimer;
@@ -659,7 +668,7 @@ public class MemoryConfigurationService {
         ReadDatagramMemo dg = new ReadDatagramMemo(readMemo.dest, readMemo.space, readMemo.address, readMemo.count, readMemo);
         downstream.sendData(dg);
     }*/
-    
+
     // dph
     McsWriteStreamMemo writeStreamMemo;
     public void request(McsWriteStreamMemo memo) {
@@ -679,7 +688,7 @@ public class MemoryConfigurationService {
         ConfigDatagramMemo dg = new ConfigDatagramMemo(memo.dest, memo);
         downstream.sendData(dg);
     }
-    
+
     McsAddrSpaceMemo addrSpaceMemo;
     public void request(McsAddrSpaceMemo memo) {
         // forward as read Datagram
@@ -687,7 +696,7 @@ public class MemoryConfigurationService {
         AddrSpaceDatagramMemo dg = new AddrSpaceDatagramMemo(memo.dest, memo);
         downstream.sendData(dg);
     }
-    
+
     @Immutable
     @ThreadSafe
     static public abstract class McsWriteStreamMemo {
@@ -697,7 +706,7 @@ public class MemoryConfigurationService {
             this.dest = dest;
             this.srcStreamId = srcStreamId;
         }
-        
+
         //final int count;
         final long address;
         final int space;
@@ -714,12 +723,12 @@ public class MemoryConfigurationService {
             if (this.address != m.address) return false;
             return this.srcStreamId == m.srcStreamId;
         }
-        
+
         @Override
         public String toString() {
             return "McsWriteStreamMemo: "+address;
         }
-        
+
         @Override
         public int hashCode() { return dest.hashCode()+space+((int)address); }
 
@@ -748,7 +757,7 @@ public class MemoryConfigurationService {
           this.data[0] = DATAGRAM_TYPE;
           this.data[1] = 0x20;
           if (space >= 0xFD) this.data[1] |= space&0x3;
-          
+
           this.data[2] = (int)(address>>24)&0xFF;
           this.data[3] = (int)(address>>16)&0xFF;
           this.data[4] = (int)(address>>8 )&0xFF;
@@ -781,39 +790,39 @@ public class MemoryConfigurationService {
             memo.handleFailure("TxDatagram", errorCode);
         }
     }
-    
-    
+
+
     @Immutable
-    @ThreadSafe    
+    @ThreadSafe
     static public abstract class McsConfigMemo {
         public McsConfigMemo(NodeID dest) {
             this.dest = dest;
         }
 
         final NodeID dest;
-        
+
         @Override
         public boolean equals(Object o) {
             if (o == null) return false;
             if (! (o instanceof McsConfigMemo)) return false;
             McsConfigMemo m = (McsConfigMemo) o;
             return this.dest == m.dest;
-        } 
-    
+        }
+
         @Override
         public String toString() {
             return "McsConfigMemo";
         }
-        
+
         @Override
         public int hashCode() { return dest.hashCode(); }
-        
+
         /**
          * Overload this for notification of failure reply
          * @param code non-zero for error reply
          */
         public abstract void handleFailure(int code);
-        
+
         /**
          * Overload this for notification of data.
          * @param dest         remote node ID that sent us this reply
@@ -823,19 +832,19 @@ public class MemoryConfigurationService {
          * @param lowSpace     smallest supported address space number (not counting 0xFD..0xFF)
          * @param name         ?? any additional response bytes the node wanted to send to us
          */
-        public void handleConfigData(NodeID dest, int commands, int options, int highSpace, int lowSpace, String name) { 
+        public void handleConfigData(NodeID dest, int commands, int options, int highSpace, int lowSpace, String name) {
         }
 
     }
 
     @Immutable
-    @ThreadSafe    
+    @ThreadSafe
     public class ConfigDatagramMemo extends DatagramService.DatagramServiceTransmitMemo {
         ConfigDatagramMemo(NodeID dest, McsConfigMemo memo) {
             super(dest);
             this.data = new int[2];
             this.data[0] = DATAGRAM_TYPE;
-            this.data[1] = 0x80;                
+            this.data[1] = 0x80;
             this.memo = memo;
         }
         McsConfigMemo memo;
@@ -877,7 +886,7 @@ public class MemoryConfigurationService {
      *
      */
     @Immutable
-    @ThreadSafe    
+    @ThreadSafe
     static public class McsAddrSpaceMemo {
         public McsAddrSpaceMemo(NodeID dest, int space) {
             this.dest = dest;
@@ -886,28 +895,28 @@ public class MemoryConfigurationService {
 
         NodeID dest;
         int space;
-        
+
         public boolean equals(Object o) {
             if (o == null) return false;
             if (! (o instanceof McsAddrSpaceMemo)) return false;
             McsAddrSpaceMemo m = (McsAddrSpaceMemo) o;
             if (this.space != m.space) return false;
             return this.dest == m.dest;
-        } 
-    
+        }
+
         public String toString() {
             return "McsAddrSpaceMemo "+space;
         }
-        
+
         public int hashCode() { return dest.hashCode()+space; }
-        
+
         /**
          * Overload this for notification of failure reply
          * @param code non-zero for error reply
          */
-        public void handleWriteReply(int code) { 
+        public void handleWriteReply(int code) {
         }
-        
+
         /**
          * Overload this for notification of data.
          * @param dest          node that sent this reply
@@ -917,20 +926,20 @@ public class MemoryConfigurationService {
          * @param flags         address space flags (e.g. R/O, see standard)
          * @param desc          string description for this address space
          */
-        public void handleAddrSpaceData(NodeID dest, int space, long hiAddress, long lowAddress, int flags, String desc) { 
+        public void handleAddrSpaceData(NodeID dest, int space, long hiAddress, long lowAddress, int flags, String desc) {
         }
 
     }
 
     @Immutable
-    @ThreadSafe    
+    @ThreadSafe
     static public class AddrSpaceDatagramMemo extends DatagramService.DatagramServiceTransmitMemo {
         AddrSpaceDatagramMemo(NodeID dest, McsAddrSpaceMemo memo) {
             super(dest);
             this.data = new int[3];
             this.data[0] = DATAGRAM_TYPE;
-            this.data[1] = 0x84;                
-            this.data[2] = memo.space;                
+            this.data[1] = 0x84;
+            this.data[2] = memo.space;
             this.memo = memo;
         }
         McsAddrSpaceMemo memo;
@@ -948,7 +957,7 @@ public class MemoryConfigurationService {
         public void handleReply(int code) {
             memo.handleWriteReply(code);
         }
-        
+
 
     }
 


### PR DESCRIPTION
 - Improve how the Memory Configuration Service handles malformed reply messages that (unfortunately) come from some nodes
 - In the address space display (from swing.memconfig.MemConfigDescriptionPane), add a decimal display to the hex one.