### PR TITLE
Avoid re-trying interactions.

### DIFF
--- a/src/org/openlcb/Interaction.java
+++ b/src/org/openlcb/Interaction.java
@@ -9,7 +9,7 @@ public abstract class Interaction {
      * Timeout after each sendRequest for the interaction to be completed before
      * the onTimeout is called.
      */
-    int deadlineMsec = 700;
+    int deadlineMsec = 3000;
 
     /**
      * Set to true by the system when a cancel/complete call arrives for this

--- a/src/org/openlcb/Interaction.java
+++ b/src/org/openlcb/Interaction.java
@@ -9,7 +9,7 @@ public abstract class Interaction {
      * Timeout after each sendRequest for the interaction to be completed before
      * the onTimeout is called.
      */
-    int deadlineMsec = 3000;
+    int deadlineMsec = 700;
 
     /**
      * Set to true by the system when a cancel/complete call arrives for this

--- a/src/org/openlcb/MimicNodeStore.java
+++ b/src/org/openlcb/MimicNodeStore.java
@@ -237,7 +237,7 @@ public class MimicNodeStore extends AbstractConnection {
                 }
                 pIdent = new ProtocolIdentification(node, id);
                 pipInteraction = new Interaction() {
-                    int numTriesLeft = 3;
+                    int numTriesLeft = 1;
 
                     @Override
                     void sendRequest(Connection downstream) {
@@ -295,7 +295,7 @@ public class MimicNodeStore extends AbstractConnection {
             if (pSimpleNode == null) {
                 pSimpleNode = new SimpleNodeIdent(node, id);
                 snipInteraction = new Interaction() {
-                    int numTriesLeft = 3;
+                    int numTriesLeft = 1;
 
                     @Override
                     void sendRequest(Connection downstream) {


### PR DESCRIPTION
- Eliminates re-tries from the pip and snip request for the MimicNodeStore. OpenLCB is a guaranteed-delivery protocol, so re-trying is not useful.

Current re-try behavior causes errors when multiple responses arrive.