### PR TITLE
Send AMD at end of alias sequence

### DIFF
--- a/src/org/openlcb/can/NIDaAlgorithm.java
+++ b/src/org/openlcb/can/NIDaAlgorithm.java
@@ -12,7 +12,7 @@ import org.openlcb.NodeID;
  * to and from the actual interface.
  * It also requires subclassing to provide a timer function.
  *
- * @author  Bob Jacobsen   Copyright 2009, 2010
+ * @author  Bob Jacobsen   Copyright 2009, 2010, 2023
  */
 public class NIDaAlgorithm implements CanFrameListener {
     /// Callback to invoke when the alias was successfully reserved.
@@ -70,7 +70,6 @@ public class NIDaAlgorithm implements CanFrameListener {
         } else if (index == 4) {
             f = new OpenLcbCanFrame(nida.getNIDa());
             f.setRIM(nida.getNIDa());
-            complete = true;
         } else if (index == 5) {
             f = new OpenLcbCanFrame(nida.getNIDa());
             f.setAMD(nida.getNIDa(), nid);
@@ -152,6 +151,7 @@ public class NIDaAlgorithm implements CanFrameListener {
             }
             scheduleTimer(200);
         } else if (index == 4) {
+            sendInterface.send(nextFrame());
             sendInterface.send(nextFrame());
             if (done != null) {
                 done.run();

--- a/src/org/openlcb/can/NIDaAlgorithm.java
+++ b/src/org/openlcb/can/NIDaAlgorithm.java
@@ -71,6 +71,10 @@ public class NIDaAlgorithm implements CanFrameListener {
             f = new OpenLcbCanFrame(nida.getNIDa());
             f.setRIM(nida.getNIDa());
             complete = true;
+        } else if (index == 5) {
+            f = new OpenLcbCanFrame(nida.getNIDa());
+            f.setAMD(nida.getNIDa(), nid);
+            complete = true;
         } else {
             // send nothing
             f = null;

--- a/test/org/openlcb/can/NIDaAlgorithmTest.java
+++ b/test/org/openlcb/can/NIDaAlgorithmTest.java
@@ -199,7 +199,7 @@ public class NIDaAlgorithmTest {
         alg1.nextFrame();
         alg1.nextFrame();
 
-        int expectedCount = 5;
+        int expectedCount = 6;
         int count = sequentialRunner(new NIDaAlgorithm[]{alg1, alg2}, expectedCount);
 
         debug("tSS2 converges " + count);

--- a/test/org/openlcb/can/NIDaAlgorithmTest.java
+++ b/test/org/openlcb/can/NIDaAlgorithmTest.java
@@ -52,15 +52,17 @@ public class NIDaAlgorithmTest {
     }
 
     @Test
-    public void testFifth() {
+    public void testSixth() {
         Assert.assertTrue("not complete", !alg.isComplete());
 
-        // seventh frame is RIM
+        // fifth frame is RIM
         Assert.assertTrue(alg.nextFrame().isCIM());
         Assert.assertTrue(alg.nextFrame().isCIM());
         Assert.assertTrue(alg.nextFrame().isCIM());
         Assert.assertTrue(alg.nextFrame().isCIM());
         Assert.assertTrue(alg.nextFrame().isRIM());
+
+        Assert.assertNotEquals(alg.nextFrame(), null); // AMD frame
 
         Assert.assertTrue("complete", alg.isComplete());
 
@@ -93,6 +95,9 @@ public class NIDaAlgorithmTest {
         t.setCIM(1, 0, 0);
         alg.processFrame(t);
         Assert.assertTrue(alg.nextFrame().isRIM());
+
+        // sixth is AMD
+        Assert.assertNotEquals((alg.nextFrame()), null);
 
         Assert.assertTrue("complete", alg.isComplete());
 
@@ -130,6 +135,9 @@ public class NIDaAlgorithmTest {
         f = alg.nextFrame();
         Assert.assertTrue(f.isRIM());
 
+        // sixth is AMD
+        Assert.assertNotEquals((f = alg.nextFrame()), null);
+
         Assert.assertTrue("complete", alg.isComplete());
 
         Assert.assertEquals((f = alg.nextFrame()), null);
@@ -156,6 +164,9 @@ public class NIDaAlgorithmTest {
         // fifth
         f = alg.nextFrame();
         Assert.assertTrue(f.isRIM());
+
+        // sixth is AMD
+        Assert.assertNotEquals((f = alg.nextFrame()), null);
 
         int nida = f.getSourceAlias();
         Assert.assertTrue("complete", alg.isComplete());


### PR DESCRIPTION
Fix for #121.

See discussion below for further work.

(Note: This commend originally talked about a missing delay between RID and AMD; that's not required by the Standard, so that part of this commented was removed in edit)
