### PR TITLE
Retry CDI Read (when possible)

### DIFF
--- a/src/org/openlcb/cdi/jdom/CdiMemConfigReader.java
+++ b/src/org/openlcb/cdi/jdom/CdiMemConfigReader.java
@@ -64,7 +64,12 @@ public class CdiMemConfigReader  {
 
                 @Override
                 public void handleFailure(int code) {
-                     // see if we can retry
+                    // code 0x1082 is "read of of bounds", which doesn't need a retry
+                    if (code == 0x1082) {
+                        done();
+                        return;
+                    }
+                    // see if we can retry
                     retryCount++; // count from 1
                     if (retryCount > 3) {
                         // fail - don't do another request

--- a/test/org/openlcb/cdi/jdom/CdiMemConfigReaderTest.java
+++ b/test/org/openlcb/cdi/jdom/CdiMemConfigReaderTest.java
@@ -23,7 +23,6 @@ public class CdiMemConfigReaderTest {
     MemoryConfigurationService service;
 
     DatagramService dgs;
-    String testString = "string to be checked which involves more than 64 characters, so its three datagrams at least, because two originally worked and perhaps three did not ";
     byte[] content;
     
     @Before
@@ -32,6 +31,23 @@ public class CdiMemConfigReaderTest {
         dgs = new DatagramService(null, null);
         
         store.addNode(nidThere);
+            
+    }
+    
+    @After
+    public void tearDown() {
+       store.dispose();
+       service.dispose();
+       store = null;
+       service = null;
+    }
+         
+    java.io.Reader rdr;
+    long bytesRead;
+    
+    @Test
+    public void testLongCycle() throws java.io.IOException {
+        String testString = "string to be checked which involves more than 64 characters, so its three datagrams at least, because two originally worked and perhaps three did not ";
         
         content = testString.getBytes();
         content[content.length-1] = 0;
@@ -45,33 +61,7 @@ public class CdiMemConfigReaderTest {
                 cb.handleReadData(nidThere, space, address, data);
             }
         };
-        
-    }
-    
-    @After
-    public void tearDown() {
-       store.dispose();
-       service.dispose();
-       store = null;
-       service = null;
-    }
-         
-    @Test
-    @Ignore("setup doesn't actually configure the class under test, and we have a constructor test")
-    public void testSetup() {
-        Assert.assertNotNull("exists",service);
-    }
-          
-    @Test 
-    public void testCtor() {
-        CdiMemConfigReader cmcr = new CdiMemConfigReader(nidHere, store, service);   
-        Assert.assertNotNull("exists",cmcr);
-    }
 
-    java.io.Reader rdr;
-    long bytesRead;
-    @Test
-    public void testCycle() throws java.io.IOException {
         CdiMemConfigReader cmcr = new CdiMemConfigReader(nidHere, store, service);
         CdiMemConfigReader.ReaderAccess a = new CdiMemConfigReader.ReaderAccess() {
             @Override
@@ -94,4 +84,82 @@ public class CdiMemConfigReaderTest {
         while (rdr.read() > 0) count++;
         Assert.assertEquals("length", testString.length()-1, count); // -1 for trailing zero on input
     }
+    
+    @Test
+    public void test64ByteRead() throws java.io.IOException {
+    
+        String test64String = "1234567890123456789012345678901234567890123456789012345678901234"; // length = 64
+        content = test64String.getBytes();
+        content[content.length-1] = 0;
+
+        service = new MemoryConfigurationService(nidHere, dgs) {
+            public void requestRead(NodeID dest, int space, long address, int len, McsReadHandler
+                    cb) {
+                byte[] data = new byte[Math.min(len, (int)(content.length - address))];
+                System.arraycopy(content, (int)address, data, 0, data.length);
+                cb.handleReadData(nidThere, space, address, data);
+            }
+        };
+        
+        CdiMemConfigReader cmcr = new CdiMemConfigReader(nidHere, store, service);
+        CdiMemConfigReader.ReaderAccess a = new CdiMemConfigReader.ReaderAccess() {
+            @Override
+            public void progressNotify(long _bytesRead, long totalBytes) {
+                bytesRead = _bytesRead;
+            }
+
+            public void provideReader(java.io.Reader r) {
+                rdr = r;
+            }
+        };
+        
+        rdr = null;
+        cmcr.startLoadReader(a);
+        Assert.assertTrue(rdr != null);
+        Assert.assertEquals("1", test64String.getBytes()[0], rdr.read());
+        Assert.assertEquals("2", test64String.getBytes()[1], rdr.read());
+        Assert.assertEquals(test64String.length()-1, bytesRead);
+        int count = 2;
+        while (rdr.read() > 0) count++;
+        Assert.assertEquals("length", test64String.length()-1, count); // -1 for trailing zero on input
+    }
+
+    @Test
+    public void testShortRead() throws java.io.IOException {
+    
+        String testShortString = "123456789012345678901234567890"; // length = 30
+        content = testShortString.getBytes();
+        content[content.length-1] = 0;
+
+        service = new MemoryConfigurationService(nidHere, dgs) {
+            public void requestRead(NodeID dest, int space, long address, int len, McsReadHandler
+                    cb) {
+                byte[] data = new byte[Math.min(len, (int)(content.length - address))];
+                System.arraycopy(content, (int)address, data, 0, data.length);
+                cb.handleReadData(nidThere, space, address, data);
+            }
+        };
+        CdiMemConfigReader cmcr = new CdiMemConfigReader(nidHere, store, service);
+        CdiMemConfigReader.ReaderAccess a = new CdiMemConfigReader.ReaderAccess() {
+            @Override
+            public void progressNotify(long _bytesRead, long totalBytes) {
+                bytesRead = _bytesRead;
+            }
+
+            public void provideReader(java.io.Reader r) {
+                rdr = r;
+            }
+        };
+        
+        rdr = null;
+        cmcr.startLoadReader(a);
+        Assert.assertTrue(rdr != null);
+        Assert.assertEquals("1", testShortString.getBytes()[0], rdr.read());
+        Assert.assertEquals("2", testShortString.getBytes()[1], rdr.read());
+        Assert.assertEquals(testShortString.length()-1, bytesRead);
+        int count = 2;
+        while (rdr.read() > 0) count++;
+        Assert.assertEquals("length", testShortString.length()-1, count); // -1 for trailing zero on input
+    }
+
 }


### PR DESCRIPTION
Will retry CDI reads that fail for several times before giving up. See #42

This retry doesn't always work, c.f. #128 where the datagram machine locks up.  But at least it will try now.

Closes #42