### PR TITLE
Hub dispose - interrupt ServerSocket

### DIFF
--- a/src/org/openlcb/hub/Hub.java
+++ b/src/org/openlcb/hub/Hub.java
@@ -129,6 +129,7 @@ public class Hub {
             if ( service != null ) {
                 try {
                     service.close();
+                    service = null;
                 } catch (IOException e) {
                     logger.log(Level.SEVERE, "Exception closing Service", e);
                 }

--- a/src/org/openlcb/hub/Hub.java
+++ b/src/org/openlcb/hub/Hub.java
@@ -170,7 +170,9 @@ public class Hub {
         // use a new socket to interrupt existing ServerSocket service.accept , see
         // https://coderanch.com/t/560718/java/Socket-interrupt-serverSocket-accept
         try {
-            new Socket(service.getInetAddress(), service.getLocalPort()).close();
+            if ( service != null ) {
+                new Socket(service.getInetAddress(), service.getLocalPort()).close();
+            }
         } catch (IOException e) {
             logger.log(Level.SEVERE, "dispose exception", e);
         }


### PR DESCRIPTION
Currently when calling hub dispose, the ServerSocket does not unbind from the connection.

If a 2nd Hub instance is started following the dispose of a 1st instance, the connection is refused,
`java.net.BindException: Address already in use: NET_Bind`

This PR corrects this, enabling a 2nd instance to operate correctly following disposal of a 1st instance.