### PR TITLE
Add copy and paste to tabs in the CDI display

### DIFF
--- a/src/org/openlcb/Utilities.java
+++ b/src/org/openlcb/Utilities.java
@@ -226,6 +226,8 @@ public class Utilities {
     @CheckReturnValue
     @NonNull
     static public String longestLeadingSubstring(@NonNull java.util.List<String> list) {
+        if (list.size()==0) return "";
+        
         String result = list.get(0);
         for (int entry = 1; entry < list.size(); entry++) {
             for (int index = Math.min(result.length(), list.get(entry).length()); index >= 0; index--) {

--- a/src/org/openlcb/Utilities.java
+++ b/src/org/openlcb/Utilities.java
@@ -9,8 +9,9 @@ import edu.umd.cs.findbugs.annotations.*;
  * <p>
  * NodeID objects are immutable once created.
  *
- * @author  Bob Jacobsen   Copyright 2009, 2010, 2011 2012
- * @version $Revision$
+ * @see org.openlcb.cdi.cmd.Util
+ *
+ * @author  Bob Jacobsen   Copyright 2009, 2010, 2011, 2012, 2023
  */
 @Immutable
 @ThreadSafe
@@ -216,6 +217,26 @@ public class Utilities {
         arr[offset+3] = (byte) ((value >> 16) & 0xff);
         arr[offset+4] = (byte) ((value >> 8) & 0xff);
         arr[offset+5] = (byte) ((value) & 0xff);
+    }
+
+    /** 
+     * Find the longest starting substring of a List of Strings.
+     * This is useful for finding e.g. the common prefix of a replication dump
+     */
+    @CheckReturnValue
+    @NonNull
+    static public String longestLeadingSubstring(@NonNull java.util.List<String> list) {
+        String result = list.get(0);
+        for (int entry = 1; entry < list.size(); entry++) {
+            for (int index = Math.min(result.length(), list.get(entry).length()); index >= 0; index--) {
+                if (list.get(entry).startsWith(result.substring(0,index))) {
+                    // found longest match
+                    result = result.substring(0, index);
+                    break;
+                }
+            }
+        }
+        return result;
     }
 
 }

--- a/src/org/openlcb/Version.java
+++ b/src/org/openlcb/Version.java
@@ -9,9 +9,8 @@ package org.openlcb;
  * two places.
  * <P>
  * You have to manually keep this synchronized with the manifest file.
- * <P>
+ * 
  * @author  Bob Jacobsen   Copyright 2011 - 2012
- * @version $Revision: 17977 $
  */
 
 public class Version {

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -7,7 +7,6 @@ package org.openlcb.cdi;
  * object implementing this interface.
  *
  * @author  Bob Jacobsen   Copyright 2011
- * @version $Revision: -1 $
  */
 public interface CdiRep {
 

--- a/src/org/openlcb/cdi/cmd/BackupConfig.java
+++ b/src/org/openlcb/cdi/cmd/BackupConfig.java
@@ -7,6 +7,7 @@ import org.openlcb.cdi.impl.ConfigRepresentation;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -17,12 +18,12 @@ import java.nio.file.Paths;
 public class BackupConfig {
 
 
-    static public void writeEntry(BufferedWriter outFile, String key, String value) {
+    static public void writeEntry(BufferedWriter writer, String key, String value) {
         try {
-            outFile.write(Util.escapeString(key));
-            outFile.write('=');
-            outFile.write(Util.escapeString(value));
-            outFile.write('\n');
+            writer.write(Util.escapeString(key));
+            writer.write('=');
+            writer.write(Util.escapeString(value));
+            writer.write('\n');
         } catch (IOException e1) {
             e1.printStackTrace();
             System.exit(1);
@@ -35,25 +36,34 @@ public class BackupConfig {
 
         outFile = Files.newBufferedWriter(Paths.get(fileName), Charset.forName("UTF-8"));
         final BufferedWriter finalOutFile = outFile;
+        
+        writeConfigToWriter(finalOutFile, repr);
+        
+        outFile.close();
+    }
+
+    public static void writeConfigToWriter(Writer writer, ConfigRepresentation repr) throws
+            IOException {
+
+        final BufferedWriter finalWriter = new BufferedWriter(writer);;
         repr.visit(new ConfigRepresentation.Visitor() {
                        @Override
                        public void visitString(ConfigRepresentation.StringEntry e) {
-                           writeEntry(finalOutFile, e.key, e.getValue());
+                           writeEntry(finalWriter, e.key, e.getValue());
                        }
 
                        @Override
                        public void visitInt(ConfigRepresentation.IntegerEntry e) {
-                           writeEntry(finalOutFile, e.key, Long.toString(e.getValue()));
+                           writeEntry(finalWriter, e.key, Long.toString(e.getValue()));
                        }
 
                        @Override
                        public void visitEvent(ConfigRepresentation.EventEntry e) {
-                           writeEntry(finalOutFile, e.key, Utilities.toHexDotsString(e.getValue
+                           writeEntry(finalWriter, e.key, Utilities.toHexDotsString(e.getValue
                                    ().getContents()));
                        }
                    }
         );
-        outFile.close();
     }
 
 

--- a/src/org/openlcb/cdi/cmd/BackupConfig.java
+++ b/src/org/openlcb/cdi/cmd/BackupConfig.java
@@ -64,6 +64,8 @@ public class BackupConfig {
                        }
                    }
         );
+        
+        finalWriter.close();
     }
 
 

--- a/src/org/openlcb/cdi/cmd/BackupConfig.java
+++ b/src/org/openlcb/cdi/cmd/BackupConfig.java
@@ -45,7 +45,7 @@ public class BackupConfig {
     public static void writeConfigToWriter(Writer writer, ConfigRepresentation repr) throws
             IOException {
 
-        final BufferedWriter finalWriter = new BufferedWriter(writer);;
+        final BufferedWriter finalWriter = new BufferedWriter(writer);
         repr.visit(new ConfigRepresentation.Visitor() {
                        @Override
                        public void visitString(ConfigRepresentation.StringEntry e) {

--- a/src/org/openlcb/cdi/cmd/BackupConfig.java
+++ b/src/org/openlcb/cdi/cmd/BackupConfig.java
@@ -32,20 +32,22 @@ public class BackupConfig {
 
     public static void writeConfigToFile(String fileName, ConfigRepresentation repr) throws
             IOException {
-        BufferedWriter outFile = null;
-
-        outFile = Files.newBufferedWriter(Paths.get(fileName), Charset.forName("UTF-8"));
-        final BufferedWriter finalOutFile = outFile;
         
-        writeConfigToWriter(finalOutFile, repr);
+        BufferedWriter outFile = Files.newBufferedWriter(Paths.get(fileName), Charset.forName("UTF-8"));
+        
+        writeConfigToWriter(outFile, repr);
         
         outFile.close();
     }
 
-    public static void writeConfigToWriter(Writer writer, ConfigRepresentation repr) throws
+    /**
+     * @param writer Receives output.  Flushed at end, but not closed.
+     * @param repr Representation containing contents to be written.
+     */
+    public static void writeConfigToWriter(BufferedWriter writer, ConfigRepresentation repr) throws
             IOException {
 
-        final BufferedWriter finalWriter = new BufferedWriter(writer);
+        final BufferedWriter finalWriter = writer;
         repr.visit(new ConfigRepresentation.Visitor() {
                        @Override
                        public void visitString(ConfigRepresentation.StringEntry e) {
@@ -65,7 +67,7 @@ public class BackupConfig {
                    }
         );
         
-        finalWriter.close();
+        finalWriter.flush();
     }
 
 

--- a/src/org/openlcb/cdi/cmd/RestoreConfig.java
+++ b/src/org/openlcb/cdi/cmd/RestoreConfig.java
@@ -32,9 +32,13 @@ public class RestoreConfig {
             callback.onError("Failed to open input file: " + e.toString());
             return;
         }
+        parseConfigFromReader(inFile, callback);
+    }
+
+    public static void parseConfigFromReader(@NonNull BufferedReader reader, @NonNull ConfigCallback callback) {
         String line = null;
         try {
-            while ((line = inFile.readLine()) != null) {
+            while ((line = reader.readLine()) != null) {
                 if (line.charAt(0) == '#') continue;
                 int pos = line.indexOf('=');
                 if (pos < 0) {
@@ -46,9 +50,9 @@ public class RestoreConfig {
                 callback.onConfigEntry(key, value);
             }
 
-            inFile.close();
+            reader.close();
         } catch (IOException x) {
-            callback.onError("Error reading input file: " + x.toString());
+            callback.onError("Error reading for restore: " + x.toString());
             return;
         }
     }

--- a/src/org/openlcb/cdi/cmd/Util.java
+++ b/src/org/openlcb/cdi/cmd/Util.java
@@ -11,6 +11,8 @@ import org.openlcb.can.impl.OlcbConnection;
 
 /**
  * Created by bracz on 4/9/16.
+ *
+ * @see org.openlcb.Utilities
  */
 public class Util {
     private final static Logger logger = Logger.getLogger(Util.class.getName());

--- a/src/org/openlcb/cdi/jdom/CdiMemConfigReader.java
+++ b/src/org/openlcb/cdi/jdom/CdiMemConfigReader.java
@@ -15,7 +15,6 @@ import org.openlcb.implementations.*;
  * by call back.
  *
  * @author	Bob Jacobsen   Copyright (C) 2012
- * @version	$Revision$
  */
 public class CdiMemConfigReader  {
     private final static Logger logger = getLogger(CdiMemConfigReader.class.getName());

--- a/src/org/openlcb/cdi/jdom/JdomCdiReader.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiReader.java
@@ -11,7 +11,6 @@ import org.openlcb.cdi.*;
  * JDOM-based OpenLCB loader
  *
  * @author Bob Jacobsen Copyright 2011
- * @version $Revision: -1 $
  */
 public class JdomCdiReader {
 

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -9,7 +9,6 @@ import org.openlcb.cdi.CdiRep;
  * JDOM for reading the underlying XML.
  *
  * @author  Bob Jacobsen   Copyright 2011
- * @version $Revision: -1 $
  */
 public class JdomCdiRep implements CdiRep {
 

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -1212,15 +1212,12 @@ public class CdiPanel extends JPanel {
             List<String> list = java.util.Arrays.asList(newContentLines);
             String prefix = Utilities.longestLeadingSubstring(list);
             // That prefix should end with "(1)."
-            System.out.println("Prefix:  \""+prefix+"\"");
             
             // replace and rebuild the lines
             StringBuilder processedContentSB = new StringBuilder();
             for (int i = 0; i<newContentLines.length; i++) {
-                System.out.println("rep.key  \""+rep.key+"\"");
                 newContentLines[i] = rep.key+"."+newContentLines[i].substring(prefix.length())+"\n";
                 processedContentSB.append(newContentLines[i]);
-                System.out.println("Store:   \""+newContentLines[i]+"\"");    
             }
             // at this point, processedContent has the new values to restore
             String processedContent = new String(processedContentSB);

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -749,6 +749,10 @@ public class CdiPanel extends JPanel {
         });
     }
 
+    /**
+     * Visitor class to find a full name for changed elements
+     * that have not been saved.
+     */
     private class GetEntryNameVisitor extends ConfigRepresentation.Visitor {
         CdiRep.Item item;
         int segNum = 1;
@@ -1002,13 +1006,16 @@ public class CdiPanel extends JPanel {
             final String name = (item.getRepName() != null ? (item.getRepName()) : "Group") + " "
                     + (e.index);
             //currentPane.setBorder(BorderFactory.createTitledBorder(name));
+            
+            // set the name of this pane, which names the tab
             currentPane.setName(name);
-
+            
             // Finds a string field that could be used as a caption.
             FindDescriptorVisitor vv = new FindDescriptorVisitor();
             vv.visitContainer(e);
 
             if (vv.foundEntry != null) {
+                // here a unique descriptor has been found
                 final JPanel tabPanel = currentPane;
                 final ConfigRepresentation.StringEntry source = vv.foundEntry;
                 final JTabbedPane parentTabs = currentTabbedPane;
@@ -1054,6 +1061,12 @@ public class CdiPanel extends JPanel {
             // add this new pane to the combined tab pane
             currentTabbedPane.add(currentPane);
             tabsByKey.put(e.key, currentTabbedPane);
+            
+            // set the tab to a label with copy/pasteValue
+            int index = currentTabbedPane.indexOfComponent(currentPane);
+            JComponent tabLabel = getTabLabel(currentTabbedPane, index, name, e);
+            currentTabbedPane.setTabComponentAt(index, tabLabel);
+            
         }
 
         /**

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -1201,6 +1201,9 @@ public class CdiPanel extends JPanel {
             // this version just checks the line count, more could be added here
             if (previousContentLines.length != newContentLines.length) {
                 logger.log(Level.WARNING, "Cannot paste into a mis-matching entry type");
+                // provide a system alert to notify user
+                Toolkit.getDefaultToolkit().beep();
+                // end of attempt to paste
                 return;
             }
             

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -2214,8 +2214,13 @@ public class CdiPanel extends JPanel {
          */
         @NonNull
         protected String getCurrentValue() {
-            String s = (box == null) ? (String) textField.getText()
-                    : ""+box.getSelectedIndex();
+            String s;
+            if (box!=null) {
+                s = (String) textField.getText();
+            } else {
+                String entry = (String) box.getSelectedItem();
+                s = map.getKey(entry);  
+            }
             return s == null ? "" : s;
         }
 

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -1209,12 +1209,15 @@ public class CdiPanel extends JPanel {
             List<String> list = java.util.Arrays.asList(newContentLines);
             String prefix = Utilities.longestLeadingSubstring(list);
             // That prefix should end with "(1)."
+            System.out.println("Prefix:  \""+prefix+"\"");
             
             // replace and rebuild the lines
             StringBuilder processedContentSB = new StringBuilder();
             for (int i = 0; i<newContentLines.length; i++) {
-                newContentLines[i] = newContentLines[i].substring(0, prefix.length()-4)+"("+index+")."+newContentLines[i].substring(prefix.length())+"\n";
+                System.out.println("rep.key  \""+rep.key+"\"");
+                newContentLines[i] = rep.key+"."+newContentLines[i].substring(prefix.length())+"\n";
                 processedContentSB.append(newContentLines[i]);
+                System.out.println("Store:   \""+newContentLines[i]+"\"");    
             }
             // at this point, processedContent has the new values to restore
             String processedContent = new String(processedContentSB);
@@ -2215,7 +2218,7 @@ public class CdiPanel extends JPanel {
         @NonNull
         protected String getCurrentValue() {
             String s;
-            if (box!=null) {
+            if (box==null) {
                 s = (String) textField.getText();
             } else {
                 String entry = (String) box.getSelectedItem();

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -396,7 +396,7 @@ public class CdiPanel extends JPanel {
     }
 
     /**
-     * Triggers a warning at the close of this dialog that a Senor has been made.
+     * Triggers a warning at the close of this dialog that a Sensor has been made.
      * This triggers a message the panel file needs to be saved in JMRI.
      *
      * @param uName unused.
@@ -1186,7 +1186,7 @@ public class CdiPanel extends JPanel {
                 try {
                     newContentString = (String)t.getTransferData( DataFlavor.stringFlavor );
                 } catch (UnsupportedFlavorException | IOException e) {
-                    // this can never happen as we checked bafore
+                    // this can never happen as we checked before
                     return;
                 }
             } // this should always have succeeded, but if it doesn't the match below will fail

--- a/src/org/openlcb/implementations/DatagramMeteringBuffer.java
+++ b/src/org/openlcb/implementations/DatagramMeteringBuffer.java
@@ -24,10 +24,8 @@ import org.openlcb.*;
  *<li>Does not parallelize Datagrams to separate nodes
  *<li>Needs to timeout and resume operation if no reply received
  *</ul>
- *<p>
  *
  * @author  Bob Jacobsen   Copyright 2012
- * @version $Revision$
  */
 public class DatagramMeteringBuffer extends MessageDecoder {
 

--- a/src/org/openlcb/implementations/DatagramReceiver.java
+++ b/src/org/openlcb/implementations/DatagramReceiver.java
@@ -4,10 +4,8 @@ import org.openlcb.*;
 
 /**
  * Example of receiving a OpenLCB datagram.
- *<p>
  *
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
 public class DatagramReceiver extends MessageDecoder {
     public DatagramReceiver(NodeID here, NodeID far, Connection c) {

--- a/src/org/openlcb/implementations/DatagramTransmitter.java
+++ b/src/org/openlcb/implementations/DatagramTransmitter.java
@@ -4,10 +4,8 @@ import org.openlcb.*;
 
 /**
  * Example of sending a OpenLCB datagram.
- *<p>
  *
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
 public class DatagramTransmitter extends MessageDecoder {
 

--- a/src/org/openlcb/implementations/StreamReceiver.java
+++ b/src/org/openlcb/implementations/StreamReceiver.java
@@ -4,10 +4,8 @@ import org.openlcb.*;
 
 /**
  * Example of receiving a OpenLCB stream.
- *<p>
  *
  * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
  */
 public class StreamReceiver extends MessageDecoder {
     public StreamReceiver(NodeID here, NodeID far, Connection c) {

--- a/src/org/openlcb/swing/networktree/NodeTreeRep.java
+++ b/src/org/openlcb/swing/networktree/NodeTreeRep.java
@@ -15,10 +15,8 @@ import org.openlcb.SimpleNodeIdent;
 
 /**
  * Represent a single node for the tree display
- *<p>
  *
  * @author	Bob Jacobsen   Copyright (C) 2010, 2012
- * @version	$Revision$
  */
 public class NodeTreeRep extends DefaultMutableTreeNode  {
     /** Comment for <code>serialVersionUID</code>. */

--- a/src/org/openlcb/swing/networktree/TreePane.java
+++ b/src/org/openlcb/swing/networktree/TreePane.java
@@ -45,10 +45,8 @@ import org.openlcb.VerifyNodeIDNumberMessage;
 
 /**
  * Pane for monitoring an entire OpenLCB network as a logical tree
- *<p>
  *
  * @author	Bob Jacobsen   Copyright (C) 2010, 2012
- * @version	$Revision$
  */
 public class TreePane extends JPanel  {
     /** Comment for <code>serialVersionUID</code>. */

--- a/test/org/openlcb/UtilitiesTest.java
+++ b/test/org/openlcb/UtilitiesTest.java
@@ -1,5 +1,7 @@
 package org.openlcb;
 
+import java.util.ArrayList;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -114,4 +116,17 @@ public class UtilitiesTest  {
         }
         return false;
     }
+
+    @Test
+    public void testLongestLeadingSubstring() {
+        ArrayList<String> list = new ArrayList<>();
+        list.add("Port I/O.Line(1).Line Description");
+        list.add("Port I/O.Line(1).Output Function");
+        list.add("Port I/O.Line(1).Receiving the configured Command (C)");
+        
+        String result = Utilities.longestLeadingSubstring(list);
+        
+        Assert.assertTrue(result.equals("Port I/O.Line(1)."));        
+    }
+    
 }


### PR DESCRIPTION
This adds a contextual menu (right click, ctrl click) to tabs in the CDI display that contains "Copy" and "Paste" options.  Copy and paste works both within one window and across windows.  You can only paste into a tab of the same type from which you copied.  The data stored in the clipboard is in the format of the usual backup files.