### PR TITLE
Process <repname> as described in draft documents

### DIFF
--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -45,7 +45,7 @@ public interface CdiRep {
     public static interface Group extends Item {
         public java.util.List<Item> getItems();
         public int getReplication();
-        public String getRepName(int index);
+        public String getRepName(int index, int replications);
     }
 
     public static interface Map {

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -45,7 +45,7 @@ public interface CdiRep {
     public static interface Group extends Item {
         public java.util.List<Item> getItems();
         public int getReplication();
-        public String getRepName();
+        public String getRepName(int index);
     }
 
     public static interface Map {

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -309,6 +309,7 @@ public class JdomCdiRep implements CdiRep {
         // Return the offset of the 1st digit character
         // Return -1 if not found
         int indexOfFirstTrailingDigit(String input) {
+            if ( input.isEmpty() ) return -1;
             if (! Character.isDigit(input.charAt(input.length()-1)) ) return -1;
             
             // so there is at least one digit at end, scan for first non-digit

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -991,8 +991,7 @@ public class CdiPanel extends JPanel {
             currentPane.setLayout(new BoxLayout(currentPane, BoxLayout.Y_AXIS));
             currentPane.setAlignmentX(Component.LEFT_ALIGNMENT);
             CdiRep.Group item = e.group;
-            final String name = (item.getRepName() != null ? (item.getRepName()) : "Group") + " "
-                    + (e.index);
+            final String name = item.getRepName(e.index);
             //currentPane.setBorder(BorderFactory.createTitledBorder(name));
             currentPane.setName(name);
 

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -991,7 +991,7 @@ public class CdiPanel extends JPanel {
             currentPane.setLayout(new BoxLayout(currentPane, BoxLayout.Y_AXIS));
             currentPane.setAlignmentX(Component.LEFT_ALIGNMENT);
             CdiRep.Group item = e.group;
-            final String name = item.getRepName(e.index);
+            final String name = item.getRepName(e.index, item.getReplication());
             //currentPane.setBorder(BorderFactory.createTitledBorder(name));
             currentPane.setName(name);
 

--- a/test/org/openlcb/cdi/swing/CdiPanelDemo.java
+++ b/test/org/openlcb/cdi/swing/CdiPanelDemo.java
@@ -32,7 +32,7 @@ public class CdiPanelDemo {
         File file;
         if (fileName == null) {
             // find file & load file
-            fci.setDialogTitle("Find desired script file");
+            fci.setDialogTitle("Find desired CDI file");
             fci.rescanCurrentDirectory();
 
             int retVal = fci.showOpenDialog(null);
@@ -70,7 +70,7 @@ public class CdiPanelDemo {
      * We always use the same file chooser in this class, so that the user's
      * last-accessed directory remains available.
      */
-    static JFileChooser fci = new JFileChooser();
+    static JFileChooser fci = new JFileChooser(".");
 
     // Main entry point
     static public void main(String[] args) {


### PR DESCRIPTION
This adds `<repname>` element as described in the draft S&TN:
 - Allow multiple `<repname>` elements
 - Extend the last one as needed
   - By incrementing integer suffix is present
   - Otherwise numbering 1..N as now
   - And respecting whitespace

This is in use in JMRI 5.5.4 and initial feedback is good.

Contains small update to test/org/openlcb/cdi/swing/CdiPanelDemo.java which was used during development