### PR TITLE
Add info message to save complete, backup complete

### DIFF
--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -388,6 +388,8 @@ public class CdiPanel extends JPanel {
             }
         }
         checkForSave();
+
+        logger.info("Save changes done.");
     }
 
     private void checkForSave() {
@@ -446,6 +448,7 @@ public class CdiPanel extends JPanel {
             e.printStackTrace();
             logger.severe("Failed to write variables to file " + fci.getSelectedFile().getPath() + ": " + e.toString());
         }
+            logger.info("Config backup done.");
     }
 
     private String generateFileName() {


### PR DESCRIPTION
This adds info messages to the log when the "Save Changes" or "Backup" button's operation is complete, similar to the existing message from a "Restore" operation.

Requested by a JMRI user.