### PR TITLE
Allow override of default backup filename

### DIFF
--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -448,23 +448,30 @@ public class CdiPanel extends JPanel {
         }
     }
 
+    // Class that generates the filename for a Backup operation.
+    public static class FileNameGenerator {
+        public String generateFileName(ConfigRepresentation rep, String nodeName) {
+            String fileName = rep.getRemoteNodeAsString();
+            if (!nodeName.isEmpty()) {
+                fileName += "-"+nodeName;
+            }
+            if (rep.getCdiRep() != null && rep.getCdiRep().getIdentification() != null) {
+                // info not present if configuration hasn't been read yet
+                fileName += "-"+rep.getCdiRep().getIdentification().getSoftwareVersion();
+            }
+            fileName += "-"+java.time.LocalDate.now();
+            fileName += "-"+java.time.LocalTime.now().format( // use default time zone
+                            java.time.format.DateTimeFormatter.ofPattern("HH-mm-ss")
+                        );
+
+            fileName = fileName.replace(" ", "_"); // don't use spaces in file names!
+
+            return "config." + fileName + ".txt";
+        }
+    }
+    public static FileNameGenerator fileNameGenerator = new FileNameGenerator(); // this can be replaced to change the generated file name pattern
     private String generateFileName() {
-        String fileName = rep.getRemoteNodeAsString();
-        if (!nodeName.isEmpty()) {
-            fileName += "-"+nodeName;
-        }
-        if (rep.getCdiRep() != null && rep.getCdiRep().getIdentification() != null) {
-            // info not present if configuration hasn't been read yet
-            fileName += "-"+rep.getCdiRep().getIdentification().getSoftwareVersion();
-        }
-        fileName += "-"+java.time.LocalDate.now();
-        fileName  += "-"+java.time.LocalTime.now().format( // use default time zone
-                        java.time.format.DateTimeFormatter.ofPattern("HH-mm-ss")
-                    );
-
-        fileName = fileName.replace(" ", "_"); // don't use spaces in file names!
-
-        return "config." + fileName + ".txt";
+        return fileNameGenerator.generateFileName(rep, nodeName);
     }
 
 


### PR DESCRIPTION
When you do a "Backup..." operation from `CdiPane`, it creates a (long) default filename.  People have different opinions about what should be in this name.  

This PR allows e.g. a JMRI script to override the code that generates that filename. This in turn allows users to provide their own algorithm for generating a default filename.

A companion PR in JMRI/JMRI will provide a sample Jython script. 