### PR TITLE
Refactor the CDI window-close operation to allow useful overrides

### DIFF
--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -132,6 +132,7 @@ public class CdiPanel extends JPanel {
     private boolean _changeMade = false;    // set true when a write is done to the hardware.
     private boolean _unsavedRestore = false;    // set true when a restore is done.
     private boolean _panelChange = false;   // set true when a panel item changed.
+    private boolean _windowCloseCheckAlreadyHandled = false; // true skips unsaved-variables check on window close because handled externally
     private JButton _saveButton;
     private Color COLOR_DEFAULT;
     private List<util.CollapsiblePanel> segmentPanels = new ArrayList<>();
@@ -705,7 +706,32 @@ public class CdiPanel extends JPanel {
         segmentPanels.forEach(p -> p.setExpanded(false));
     }
 
-    private void targetWindowClosingEvent(WindowEvent e) {
+    protected void targetWindowClosingEvent(WindowEvent evt) { // evt is ignored here
+        boolean closeWindow = true;
+        if (!_windowCloseCheckAlreadyHandled) {
+            closeWindow = checkOnWindowClosing(); // result true -> close the Window
+        }
+        if (closeWindow) { // OK to close the window, proceed
+            release();
+            JFrame f = (JFrame)SwingUtilities.getAncestorOfClass(JFrame.class, this);
+            f.dispose();
+        }
+    }
+    
+    /**
+     * Used when the check for unsaved changes et al has already been run, and 
+     * shouldn't be repeated when the window closes.  E.g. a program shutdown
+     * routine has already done the check through calling checkOnWindowClosing.
+     */
+    public void setWindowCloseCheckAlreadyHandled() {
+        _windowCloseCheckAlreadyHandled = true;
+    }
+    
+    /**
+     * Construct and display a cancel/proceed dialog, as needed for e.g. window closing
+     * @return true means that the window is OK to close; false means user has cancelled
+     */
+    public boolean checkOnWindowClosing() {
         StringBuilder sb = new StringBuilder();
         if (_unsavedRestore) {
             sb.append("The configuration was restored but not saved.");
@@ -742,7 +768,7 @@ public class CdiPanel extends JPanel {
                     "Unsaved changes", JOptionPane.DEFAULT_OPTION, JOptionPane.WARNING_MESSAGE,
                     null, options, options[1]);
             if (confirm != 0) {
-                return;
+                return false; // user cancelled
             }
         } else if (_panelChange) {
             JOptionPane.showMessageDialog(this, sb.toString(),
@@ -752,11 +778,9 @@ public class CdiPanel extends JPanel {
         if (_changeMade) {
             runUpdateComplete();
         }
-        release();
-        JFrame f = (JFrame)SwingUtilities.getAncestorOfClass(JFrame.class, this);
-        f.dispose();
+        return true;
     }
-
+    
     /**
      * Updates the save changes button to mark the dialog dirty.
      */


### PR DESCRIPTION
This breaks the CDI window-operation into several parts and gives more granular controls.  This lets JMRI override the behavior at end-of-program so that "Cancel" properly brings you back to normal operation, aborting the shutdown.