### PR TITLE
Implement Event-with-payload Working Note

### DIFF
--- a/src/org/openlcb/MessageTypeIdentifier.java
+++ b/src/org/openlcb/MessageTypeIdentifier.java
@@ -56,7 +56,10 @@ public enum MessageTypeIdentifier {
         IdentifyEventsGlobal        ( false, false, true,  0, 2, 11, 0, "IdentifyEventsGlobal"),
         
         LearnEvent                  ( false, true,  true,  0, 1, 12, 0, "LearnEvent"),
-        ProducerConsumerEventReport ( false, true,  true,  0, 1, 13, 0, "ProducerConsumerEventReport"),
+        ProducerConsumerEventReport ( false, true,  true,  0, 1, 13, 0, "ProducerConsumerEventReport"), // This is also the CAN PCER-only
+        PCERfirst                   ( false, true,  true,  0, 1, 13, 3, "PCERfirst"),                   // This is CAN only
+        PCERmiddle                  ( false, true,  true,  0, 1, 13, 2, "PCERmiddle"),                  // This is CAN only
+        PCERlast                    ( false, true,  true,  0, 1, 13, 1, "PCERlast"),                    // This is CAN only
 
         TractionControlRequest      (  true, false, false, 0, 1, 15, 3, "TractionControlRequest" ),
         TractionControlReply        (  true, false, false, 0, 0, 15, 1, "TractionControlReply" ),

--- a/src/org/openlcb/ProducerConsumerEventReportMessage.java
+++ b/src/org/openlcb/ProducerConsumerEventReportMessage.java
@@ -25,9 +25,17 @@ public class ProducerConsumerEventReportMessage extends EventMessage {
         payload = null;
     }
 
-    public ProducerConsumerEventReportMessage(NodeID source, EventID eventID, List<Integer> payload) {
+    public ProducerConsumerEventReportMessage(NodeID source, EventID eventID, List<Byte> payload) {
         super(source, eventID);
         this.payload = payload;
+    }
+
+    public ProducerConsumerEventReportMessage(NodeID source, EventID eventID, byte[] bytes) {
+        super(source, eventID);
+        payload = new ArrayList<Byte>();
+        for (byte value : bytes) {
+            payload.add(value);
+        }
     }
 
     /**
@@ -42,7 +50,7 @@ public class ProducerConsumerEventReportMessage extends EventMessage {
         decoder.handleProducerConsumerEventReport(this, sender);
     }
     
-    List<Integer> payload;
+    List<Byte> payload;
     
     /**
      * Get the size of the payload, which doesn't include
@@ -58,9 +66,24 @@ public class ProducerConsumerEventReportMessage extends EventMessage {
      * @return unmodifiable list
      */
     @NonNull
-    public List getPayload() {
-        if (payload == null) return Collections.unmodifiableList(new ArrayList<Integer>()); // zero length list by default
+    public List getPayloadList() {
+        if (payload == null) return Collections.unmodifiableList(new ArrayList<Byte>()); // zero length list by default
         return Collections.unmodifiableList(payload);
+    }
+    
+    /**
+     * Get the payload
+     * @return dedicated aray
+     */
+    @NonNull
+    public byte[] getPayloadArray() {
+        if (payload == null) return new byte[0]; // zero length by default
+        byte[] result = new byte[payload.size()];
+        int i = 0;
+        for (Byte b : payload) {
+            result[i++] = (byte)b;
+        }
+        return result;
     }
     
     @Override
@@ -78,7 +101,7 @@ public class ProducerConsumerEventReportMessage extends EventMessage {
             // check for empty payload other end
             if (p.payload == null || p.payload.size() == 0) return true;
         }
-        return (getPayload().equals(p.getPayload()) );
+        return (getPayloadList().equals(p.getPayloadList()) );
     }
 
     @Override

--- a/src/org/openlcb/ProducerConsumerEventReportMessage.java
+++ b/src/org/openlcb/ProducerConsumerEventReportMessage.java
@@ -4,11 +4,14 @@ package org.openlcb;
 import net.jcip.annotations.*; 
 import edu.umd.cs.findbugs.annotations.*; 
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Collections;
+
 /**
  * Producer Consumer Event Report message implementation
  *
- * @author  Bob Jacobsen   Copyright 2009
- * @version $Revision$
+ * @author  Bob Jacobsen   Copyright 2009, 2023
  */
 @Immutable
 @ThreadSafe
@@ -17,6 +20,12 @@ public class ProducerConsumerEventReportMessage extends EventMessage {
     public ProducerConsumerEventReportMessage(NodeID source, EventID eventID) {
         super(source, eventID);
     }
+
+    public ProducerConsumerEventReportMessage(NodeID source, EventID eventID, List<Integer> payload) {
+        super(source, eventID);
+        this.payload = payload;
+    }
+
     /**
      * Implement message-type-specific
      * processing when this message
@@ -29,14 +38,27 @@ public class ProducerConsumerEventReportMessage extends EventMessage {
         decoder.handleProducerConsumerEventReport(this, sender);
     }
     
+    private List<Integer> payload = null;
+    
     /**
      * Get the size of the payload, which doesn't include
      * the eight bytes of the event ID itself
      */
     public int getPayloadSize() {
-        return 0;
+        if (payload == null) return 0;
+        return payload.size();
     }
 
+    /**
+     * Get the payload
+     * @return unmodifiable list
+     */
+    @NonNull
+    public List getPayload() {
+        if (payload == null) payload = new ArrayList<Integer>(); // zero length list by default
+        return Collections.unmodifiableList(payload);
+    }
+    
     public String toString() {
         return super.toString()
                 +" Producer/Consumer Event Report  "+eventID.toString()

--- a/src/org/openlcb/ProducerConsumerEventReportMessage.java
+++ b/src/org/openlcb/ProducerConsumerEventReportMessage.java
@@ -28,10 +28,19 @@ public class ProducerConsumerEventReportMessage extends EventMessage {
     public void applyTo(MessageDecoder decoder, Connection sender) {
         decoder.handleProducerConsumerEventReport(this, sender);
     }
+    
+    /**
+     * Get the size of the payload, which doesn't include
+     * the eight bytes of the event ID itself
+     */
+    public int getPayloadSize() {
+        return 0;
+    }
 
     public String toString() {
         return super.toString()
-                +" Producer/Consumer Event Report  "+eventID.toString();     
+                +" Producer/Consumer Event Report  "+eventID.toString()
+                +" payload of "+getPayloadSize();     
     }
     
     public int getMTI() { return MTI_PC_EVENT_REPORT; }

--- a/src/org/openlcb/ProducerConsumerEventReportMessage.java
+++ b/src/org/openlcb/ProducerConsumerEventReportMessage.java
@@ -11,6 +11,9 @@ import java.util.Collections;
 /**
  * Producer Consumer Event Report message implementation
  *
+ * This goes to some trouble to _not_ have an internal list, 
+ * unless one is specified, for performance reasons
+ *
  * @author  Bob Jacobsen   Copyright 2009, 2023
  */
 @Immutable
@@ -19,6 +22,7 @@ public class ProducerConsumerEventReportMessage extends EventMessage {
     
     public ProducerConsumerEventReportMessage(NodeID source, EventID eventID) {
         super(source, eventID);
+        payload = null;
     }
 
     public ProducerConsumerEventReportMessage(NodeID source, EventID eventID, List<Integer> payload) {
@@ -38,7 +42,7 @@ public class ProducerConsumerEventReportMessage extends EventMessage {
         decoder.handleProducerConsumerEventReport(this, sender);
     }
     
-    private List<Integer> payload = null;
+    List<Integer> payload;
     
     /**
      * Get the size of the payload, which doesn't include
@@ -55,14 +59,33 @@ public class ProducerConsumerEventReportMessage extends EventMessage {
      */
     @NonNull
     public List getPayload() {
-        if (payload == null) payload = new ArrayList<Integer>(); // zero length list by default
+        if (payload == null) return Collections.unmodifiableList(new ArrayList<Integer>()); // zero length list by default
         return Collections.unmodifiableList(payload);
     }
     
+    @Override
     public String toString() {
         return super.toString()
                 +" Producer/Consumer Event Report  "+eventID.toString()
                 +" payload of "+getPayloadSize();     
+    }
+    
+    public boolean equals(Object o) {
+        if (!super.equals(o)) return false; // checks eventID
+        if (!(o instanceof ProducerConsumerEventReportMessage)) return false;
+        ProducerConsumerEventReportMessage p = (ProducerConsumerEventReportMessage) o;
+        if (payload == null) {
+            // check for empty payload other end
+            if (p.payload == null || p.payload.size() == 0) return true;
+        }
+        return (getPayload().equals(p.getPayload()) );
+    }
+
+    @Override
+    public int hashCode() {
+        int payloadHash = 0;
+        if (payload != null && payload.size() != 0) payloadHash = payload.hashCode();
+        return super.hashCode() | payloadHash;
     }
     
     public int getMTI() { return MTI_PC_EVENT_REPORT; }

--- a/src/org/openlcb/can/MessageBuilder.java
+++ b/src/org/openlcb/can/MessageBuilder.java
@@ -381,7 +381,7 @@ public class MessageBuilder implements AliasMap.Watcher {
             list = new ArrayList<Byte>();
             pcerData.put(source, list);
         } else {
-            logger.warning("datagram already in process for only-segment");
+            logger.warning("PCER already in process for only-segment");
         }
         EventID eid = getEventID(f);
         pcerEventID.put(source, eid);
@@ -392,7 +392,7 @@ public class MessageBuilder implements AliasMap.Watcher {
         // PCER middle-segment
         List<Byte> list = pcerData.get(source);
         if (list == null) {
-            // this is actually an error, should be already started
+            logger.warning("PCER not started for middle segment");
             list = new ArrayList<Byte>();
             pcerData.put(source, list);
         }

--- a/src/org/openlcb/can/OpenLcbCanFrame.java
+++ b/src/org/openlcb/can/OpenLcbCanFrame.java
@@ -259,14 +259,24 @@ public class OpenLcbCanFrame implements CanFrame {
   // start of OpenLCB messages
 
   void setPCEventReport(EventID eid) {
+    this.setPCEventReport(eid, MessageTypeIdentifier.ProducerConsumerEventReport);
+  }
+
+  void setPCEventReport(EventID eid, MessageTypeIdentifier mti) {
     init(nodeAlias);
-    setOpenLcbMTI(MessageTypeIdentifier.ProducerConsumerEventReport.mti());
+    setOpenLcbMTI(mti.mti());
     length=8;
     loadFromEid(eid);
   }
 
+  void setPCEventReport(EventID eid, MessageTypeIdentifier mti, byte[] data) {
+    this.setPCEventReport(eid, mti);
+    setData(data);
+  }
+
   boolean isPCEventReport() {
-      return isOpenLcbMTI(MessageTypeIdentifier.ProducerConsumerEventReport.mti());
+      return isOpenLcbMTI(MessageTypeIdentifier.ProducerConsumerEventReport.mti())
+                || isOpenLcbMTI(MessageTypeIdentifier.PCERfirst.mti());
   }
 
   void setLearnEvent(EventID eid) {

--- a/src/org/openlcb/can/OpenLcbCanFrame.java
+++ b/src/org/openlcb/can/OpenLcbCanFrame.java
@@ -258,10 +258,12 @@ public class OpenLcbCanFrame implements CanFrame {
 
   // start of OpenLCB messages
 
+  // creates a PCER-only
   void setPCEventReport(EventID eid) {
     this.setPCEventReport(eid, MessageTypeIdentifier.ProducerConsumerEventReport);
   }
 
+  // intended for PCERfirst
   void setPCEventReport(EventID eid, MessageTypeIdentifier mti) {
     init(nodeAlias);
     setOpenLcbMTI(mti.mti());
@@ -269,8 +271,11 @@ public class OpenLcbCanFrame implements CanFrame {
     loadFromEid(eid);
   }
 
-  void setPCEventReport(EventID eid, MessageTypeIdentifier mti, byte[] data) {
-    this.setPCEventReport(eid, mti);
+  // intended for PCERmiddle and PCERlast
+  void setPCEventReport(MessageTypeIdentifier mti, byte[] data) {
+    init(nodeAlias);
+    setOpenLcbMTI(mti.mti());
+    length=data.length;
     setData(data);
   }
 

--- a/test/org/openlcb/ProducerConsumerEventReportMessageTest.java
+++ b/test/org/openlcb/ProducerConsumerEventReportMessageTest.java
@@ -69,6 +69,53 @@ public class ProducerConsumerEventReportMessageTest {
     }
 
     @Test   
+    public void testPayloadHashAndEquals() {
+        ProducerConsumerEventReportMessage mNone = new ProducerConsumerEventReportMessage(
+                                nodeID1, eventID1 );
+        
+        ProducerConsumerEventReportMessage mNull = new ProducerConsumerEventReportMessage(
+                                nodeID1, eventID1, null ); // properly handle null
+        
+        java.util.List<Integer> payload0 = new java.util.ArrayList<Integer>();
+        ProducerConsumerEventReportMessage mEmpty = new ProducerConsumerEventReportMessage(
+                                nodeID1, eventID1, payload0 );
+
+        Assert.assertEquals(mNone.hashCode(), mNull.hashCode());
+        Assert.assertEquals(mNull.hashCode(), mEmpty.hashCode());
+        Assert.assertEquals(mEmpty.hashCode(), mNone.hashCode());
+
+        Assert.assertTrue(mNone.equals(mNull));
+        Assert.assertTrue(mNone.equals(mEmpty));
+        Assert.assertTrue(mNull.equals(mNone));
+        Assert.assertTrue(mEmpty.equals(mNull));
+        Assert.assertTrue(mNull.equals(mNone));
+        Assert.assertTrue(mEmpty.equals(mNull));
+
+        java.util.List<Integer> payload1 = new java.util.ArrayList<Integer>();
+        payload1.add(12);
+        ProducerConsumerEventReportMessage mOne = new ProducerConsumerEventReportMessage(
+                                nodeID1, eventID1, payload1 );
+
+        java.util.List<Integer> payload2 = new java.util.ArrayList<Integer>();
+        payload2.add(13);
+        ProducerConsumerEventReportMessage mAnother = new ProducerConsumerEventReportMessage(
+                                nodeID1, eventID1, payload2 );
+                                
+        Assert.assertNotEquals(mOne.hashCode(), mNone.hashCode());
+        Assert.assertNotEquals(mOne.hashCode(), mAnother.hashCode());
+        
+        Assert.assertFalse(mOne.equals(mAnother));
+
+        Assert.assertFalse(mOne.equals(mNull));
+        Assert.assertFalse(mOne.equals(mEmpty));
+        Assert.assertFalse(mOne.equals(mNone));
+        Assert.assertFalse(mNull.equals(mOne));
+        Assert.assertFalse(mEmpty.equals(mOne));
+        Assert.assertFalse(mNone.equals(mOne));
+
+    }
+
+    @Test   
     public void testHandling() {
         result = false;
         Node n = new Node(){

--- a/test/org/openlcb/ProducerConsumerEventReportMessageTest.java
+++ b/test/org/openlcb/ProducerConsumerEventReportMessageTest.java
@@ -45,6 +45,14 @@ public class ProducerConsumerEventReportMessageTest {
     }
 
     @Test   
+    public void testPayload() {
+        ProducerConsumerEventReportMessage m1 = new ProducerConsumerEventReportMessage(
+                                nodeID1, eventID1 );
+
+        Assert.assertEquals(0, m1.getPayloadSize());
+    }
+
+    @Test   
     public void testHandling() {
         result = false;
         Node n = new Node(){

--- a/test/org/openlcb/ProducerConsumerEventReportMessageTest.java
+++ b/test/org/openlcb/ProducerConsumerEventReportMessageTest.java
@@ -45,27 +45,43 @@ public class ProducerConsumerEventReportMessageTest {
     }
 
     @Test   
-    public void testPayload() {
+    public void testPayloadList() {
         ProducerConsumerEventReportMessage m1 = new ProducerConsumerEventReportMessage(
                                 nodeID1, eventID1 );
 
         Assert.assertEquals(0, m1.getPayloadSize());
-        Assert.assertEquals(0, m1.getPayload().size()); // not null        
+        Assert.assertEquals(0, m1.getPayloadList().size()); // not null        
         
-        java.util.List<Integer> payload1 = new java.util.ArrayList<Integer>();
-        payload1.add(12);
+        java.util.List<Byte> payload1 = new java.util.ArrayList<Byte>();
+        payload1.add((byte)12);
         ProducerConsumerEventReportMessage m2 = new ProducerConsumerEventReportMessage(
                                 nodeID1, eventID1, payload1 );
         
         Assert.assertEquals(1, m2.getPayloadSize());
-        Assert.assertEquals(12, m2.getPayload().get(0));
+        Assert.assertEquals((byte)12, m2.getPayloadList().get(0));
         
         ProducerConsumerEventReportMessage m3 = new ProducerConsumerEventReportMessage(
-                                nodeID1, eventID1, null ); // properly handle null
+                                nodeID1, eventID1, (java.util.List<Byte>) null ); // properly handle null
         
         Assert.assertEquals(0, m3.getPayloadSize());
-        Assert.assertEquals(0, m3.getPayload().size()); // not null        
+        Assert.assertEquals(0, m3.getPayloadList().size()); // not null        
 
+    }
+
+    @Test   
+    public void testPayloadArray() {
+        ProducerConsumerEventReportMessage m1 = new ProducerConsumerEventReportMessage(
+                                nodeID1, eventID1 );
+
+        Assert.assertEquals(0, m1.getPayloadSize());
+        Assert.assertEquals(0, m1.getPayloadArray().length); // not null        
+        
+        byte[] payload1 = new byte[]{12};
+        ProducerConsumerEventReportMessage m2 = new ProducerConsumerEventReportMessage(
+                                nodeID1, eventID1, payload1 );
+        
+        Assert.assertEquals(1, m2.getPayloadSize());
+        Assert.assertEquals(12, m2.getPayloadArray()[0]);
     }
 
     @Test   
@@ -74,9 +90,9 @@ public class ProducerConsumerEventReportMessageTest {
                                 nodeID1, eventID1 );
         
         ProducerConsumerEventReportMessage mNull = new ProducerConsumerEventReportMessage(
-                                nodeID1, eventID1, null ); // properly handle null
+                                nodeID1, eventID1, (java.util.List<Byte>) null ); // properly handle null
         
-        java.util.List<Integer> payload0 = new java.util.ArrayList<Integer>();
+        java.util.List<Byte> payload0 = new java.util.ArrayList<Byte>();
         ProducerConsumerEventReportMessage mEmpty = new ProducerConsumerEventReportMessage(
                                 nodeID1, eventID1, payload0 );
 
@@ -91,13 +107,13 @@ public class ProducerConsumerEventReportMessageTest {
         Assert.assertTrue(mNull.equals(mNone));
         Assert.assertTrue(mEmpty.equals(mNull));
 
-        java.util.List<Integer> payload1 = new java.util.ArrayList<Integer>();
-        payload1.add(12);
+        java.util.List<Byte> payload1 = new java.util.ArrayList<Byte>();
+        payload1.add((byte)12);
         ProducerConsumerEventReportMessage mOne = new ProducerConsumerEventReportMessage(
                                 nodeID1, eventID1, payload1 );
 
-        java.util.List<Integer> payload2 = new java.util.ArrayList<Integer>();
-        payload2.add(13);
+        java.util.List<Byte> payload2 = new java.util.ArrayList<Byte>();
+        payload2.add((byte)13);
         ProducerConsumerEventReportMessage mAnother = new ProducerConsumerEventReportMessage(
                                 nodeID1, eventID1, payload2 );
                                 

--- a/test/org/openlcb/ProducerConsumerEventReportMessageTest.java
+++ b/test/org/openlcb/ProducerConsumerEventReportMessageTest.java
@@ -50,6 +50,22 @@ public class ProducerConsumerEventReportMessageTest {
                                 nodeID1, eventID1 );
 
         Assert.assertEquals(0, m1.getPayloadSize());
+        Assert.assertEquals(0, m1.getPayload().size()); // not null        
+        
+        java.util.List<Integer> payload1 = new java.util.ArrayList<Integer>();
+        payload1.add(12);
+        ProducerConsumerEventReportMessage m2 = new ProducerConsumerEventReportMessage(
+                                nodeID1, eventID1, payload1 );
+        
+        Assert.assertEquals(1, m2.getPayloadSize());
+        Assert.assertEquals(12, m2.getPayload().get(0));
+        
+        ProducerConsumerEventReportMessage m3 = new ProducerConsumerEventReportMessage(
+                                nodeID1, eventID1, null ); // properly handle null
+        
+        Assert.assertEquals(0, m3.getPayloadSize());
+        Assert.assertEquals(0, m3.getPayload().size()); // not null        
+
     }
 
     @Test   

--- a/test/org/openlcb/can/OpenLcbCanFrameTest.java
+++ b/test/org/openlcb/can/OpenLcbCanFrameTest.java
@@ -88,4 +88,27 @@ public class OpenLcbCanFrameTest  {
         Assert.assertTrue(f.isRIM());
     }
     
+    @Test
+    public void testPCERforms() {
+        OpenLcbCanFrame f = new OpenLcbCanFrame(123);
+        f.setPCEventReport(new EventID("1.2.3.4.5.6.7.8"));
+        
+        Assert.assertTrue(f.isPCEventReport());
+        
+        f = new OpenLcbCanFrame(123);
+        f.setPCEventReport(new EventID("1.2.3.4.5.6.7.8"), MessageTypeIdentifier.ProducerConsumerEventReport);
+
+        Assert.assertTrue(f.isPCEventReport());
+
+        f = new OpenLcbCanFrame(123);
+        f.setPCEventReport(new EventID("1.2.3.4.5.6.7.8"), MessageTypeIdentifier.PCERfirst);
+
+        Assert.assertTrue(f.isPCEventReport());
+
+        f = new OpenLcbCanFrame(123);
+        f.setPCEventReport(new EventID("1.2.3.4.5.6.7.8"), MessageTypeIdentifier.PCERlast);
+
+        Assert.assertFalse(f.isPCEventReport());
+    }
+    
 }


### PR DESCRIPTION
This adds a first (but thought to be complete) implementation of the Event-with-payload working note proposal.  

Although not in S&TN status, this is still useful as a test implementation.  This will be in use in JMRI for doing "OpenLCB/LCC Memory" transfers.

N.B: This branch has been around for a long time, so it shows a lot of commits due to merging with master.  There are only seven files changed.

