### PR TITLE
Allow TreePane-using code to retry an ordering

### DIFF
--- a/src/org/openlcb/swing/networktree/TreePane.java
+++ b/src/org/openlcb/swing/networktree/TreePane.java
@@ -223,6 +223,8 @@ public class TreePane extends JPanel  {
                         memo.addPropertyChangeListener(resortListener);
                         tree.expandPath(new TreePath(nodes.getPath()));
                     }
+                    // ensure still properly sorted
+                    SwingUtilities.invokeLater(() -> resortTree());
                 } else if (e.getPropertyName().equals(MimicNodeStore.CLEAR_ALL_NODES)) {
                     synchronized (nodes) {
                         nodes.removeAllChildren();

--- a/src/org/openlcb/swing/networktree/TreePane.java
+++ b/src/org/openlcb/swing/networktree/TreePane.java
@@ -314,9 +314,6 @@ public class TreePane extends JPanel  {
      * @param order new order.
      */
     public void setSortOrder(SortOrder order) {
-        if (sortOrder == order) {
-            return;
-        }
         sortOrder = order;
         SwingUtilities.invokeLater(() -> resortTree());
     }


### PR DESCRIPTION
Requesting a re-sorting in TreePane would only act if the ordering had changed.  When restoring JMRI preferences, we want to do that sort even if the default hadn't changed.  This removes the check for the current sort order, so any re-sort request will actually re-sort.