### PR TITLE
Handle Verify Node Addressed

### DIFF
--- a/src/org/openlcb/MessageDecoder.java
+++ b/src/org/openlcb/MessageDecoder.java
@@ -62,11 +62,19 @@ public class MessageDecoder extends AbstractConnection {
         defaultHandler(msg, sender);
     }
     /**
-     * Handle "Verify Node ID Number" message
+     * Handle "Verify Node ID Number" global message
      * @param msg       message to handle
      * @param sender    connection where it came from
      */
-    public void handleVerifyNodeIDNumber(VerifyNodeIDNumberMessage msg, Connection sender){
+    public void handleVerifyNodeIDNumberGlobal(VerifyNodeIDNumberGlobalMessage msg, Connection sender){
+        defaultHandler(msg, sender);
+    }
+    /**
+     * Handle "Verify Node ID Number" addressed message
+     * @param msg       message to handle
+     * @param sender    connection where it came from
+     */
+    public void handleVerifyNodeIDNumberAddressed(VerifyNodeIDNumberAddressedMessage msg, Connection sender){
         defaultHandler(msg, sender);
     }
     /**

--- a/src/org/openlcb/MimicNodeStore.java
+++ b/src/org/openlcb/MimicNodeStore.java
@@ -93,7 +93,7 @@ public class MimicNodeStore extends AbstractConnection {
     public void refresh() {
         map.clear();
         pcs.firePropertyChange(CLEAR_ALL_NODES, null, null);
-        connection.put(new VerifyNodeIDNumberMessage(node), this);
+        connection.put(new VerifyNodeIDNumberGlobalMessage(node), this);
     }
 
     public NodeMemo addNode(NodeID id) {
@@ -120,7 +120,7 @@ public class MimicNodeStore extends AbstractConnection {
         }
         
         // create and send targeted request
-        connection.put(new VerifyNodeIDNumberMessage(node, id), null);
+        connection.put(new VerifyNodeIDNumberGlobalMessage(node, id), null);
         return null;
     }
     

--- a/src/org/openlcb/OpenLcb.java
+++ b/src/org/openlcb/OpenLcb.java
@@ -19,11 +19,11 @@ public interface OpenLcb {
     static final int MTI_OPT_INT_REJECTED            = 0x30C0;
     
     static final int MTI_IDENTIFY_CONSUMERS          = 0x1242;
-    static final int MTI_CONSUMER_RANGE_IDENTIFIED    = 0x3252;
+    static final int MTI_CONSUMER_RANGE_IDENTIFIED   = 0x3252;
     static final int MTI_CONSUMER_IDENTIFIED         = 0x3263;
     
     static final int MTI_IDENTIFY_PRODUCERS          = 0x1282;
-    static final int MTI_PRODUCER_RANGE_IDENTIFIED    = 0x3292;
+    static final int MTI_PRODUCER_RANGE_IDENTIFIED   = 0x3292;
     static final int MTI_PRODUCER_IDENTIFIED         = 0x32A3;
     
     static final int MTI_IDENTIFY_EVENTS             = 0x12B4;

--- a/src/org/openlcb/VerifyNodeIDNumberAddressedMessage.java
+++ b/src/org/openlcb/VerifyNodeIDNumberAddressedMessage.java
@@ -1,0 +1,67 @@
+package org.openlcb;
+
+// For annotations
+import net.jcip.annotations.*; 
+import edu.umd.cs.findbugs.annotations.*; 
+
+/**
+ * Verify Node ID Number message implementation.
+ * 
+ * Addressed form
+ *
+ * @author  Bob Jacobsen   Copyright 2009, 2010, 2024
+ */
+@Immutable
+@ThreadSafe
+public class VerifyNodeIDNumberAddressedMessage extends AddressedMessage {
+    
+    public VerifyNodeIDNumberAddressedMessage(NodeID source, NodeID destination) {
+        super(source, destination);
+        this.content = null;
+    }
+
+    public VerifyNodeIDNumberAddressedMessage(NodeID source, NodeID destination, NodeID content) {
+        this(source, destination);
+        this.content = content;
+    }
+    
+    NodeID content;
+    
+    public NodeID getContent() { return content; }
+    
+     /**
+      * To be equal, messages have to have the
+      * same type and content
+      */
+     public boolean equals(Object o) {
+        if (! (o instanceof VerifyNodeIDNumberAddressedMessage))
+            return false;
+        VerifyNodeIDNumberAddressedMessage msg = (VerifyNodeIDNumberAddressedMessage) o;
+        if (this.content != null) {
+            if (msg.content == null || (! this.content.equals(msg.content)))
+                return false;
+        } else {
+            if (msg.content != null) return false;
+        }
+        return super.equals(o);
+     }
+
+    /**
+     * Implement message-type-specific
+     * processing when this message
+     * is received by a node.
+     *<p>
+     * Default is to do nothing.
+     */
+     @Override
+     public void applyTo(MessageDecoder decoder, Connection sender) {
+        decoder.handleVerifyNodeIDNumberAddressed(this, sender);
+     }
+
+    public String toString() {
+        return super.toString()
+                +" Verify Node ID Number Addressed";    
+    }
+
+    public int getMTI() { return MTI_VERIFY_NID; }
+}

--- a/src/org/openlcb/VerifyNodeIDNumberGlobalMessage.java
+++ b/src/org/openlcb/VerifyNodeIDNumberGlobalMessage.java
@@ -15,14 +15,14 @@ import edu.umd.cs.findbugs.annotations.*;
  */
 @Immutable
 @ThreadSafe
-public class VerifyNodeIDNumberMessage extends Message {
+public class VerifyNodeIDNumberGlobalMessage extends Message {
     
-    public VerifyNodeIDNumberMessage(NodeID source) {
+    public VerifyNodeIDNumberGlobalMessage(NodeID source) {
         super(source);
         this.content = null;
     }
 
-    public VerifyNodeIDNumberMessage(NodeID source, NodeID content) {
+    public VerifyNodeIDNumberGlobalMessage(NodeID source, NodeID content) {
         this(source);
         this.content = content;
     }
@@ -36,9 +36,9 @@ public class VerifyNodeIDNumberMessage extends Message {
       * same type and content
       */
      public boolean equals(Object o) {
-        if (! (o instanceof VerifyNodeIDNumberMessage))
+        if (! (o instanceof VerifyNodeIDNumberGlobalMessage))
             return false;
-        VerifyNodeIDNumberMessage msg = (VerifyNodeIDNumberMessage) o;
+        VerifyNodeIDNumberGlobalMessage msg = (VerifyNodeIDNumberGlobalMessage) o;
         if (this.content != null) {
             if (msg.content == null || (! this.content.equals(msg.content)))
                 return false;
@@ -57,12 +57,12 @@ public class VerifyNodeIDNumberMessage extends Message {
      */
      @Override
      public void applyTo(MessageDecoder decoder, Connection sender) {
-        decoder.handleVerifyNodeIDNumber(this, sender);
+        decoder.handleVerifyNodeIDNumberGlobal(this, sender);
      }
 
     public String toString() {
         return super.toString()
-                +" Verify Node ID Number: "
+                +" Verify Node ID Number Global: "
                 + ((content != null) ? (content+" only") : ("all nodes"));    
     }
 

--- a/src/org/openlcb/can/AliasMap.java
+++ b/src/org/openlcb/can/AliasMap.java
@@ -33,9 +33,12 @@ public class AliasMap {
     public void processFrame(OpenLcbCanFrame f) {
         // check type
         if (f.isInitializationComplete() || f.isVerifiedNID() || f.isAliasMapDefinition()) {
-            Integer alias = Integer.valueOf(f.getSourceAlias());
-            NodeID nid = f.getNodeID();
-            insert(alias, nid);
+            // some nodes don't properly send their NodeID in the data part, so we armour against that.
+            if (f.data.length >= 6) {
+                Integer alias = Integer.valueOf(f.getSourceAlias());
+                NodeID nid = f.getNodeID();
+                insert(alias, nid);
+            }
         } else if (f.isAliasMapReset()) {
             Integer alias = Integer.valueOf(f.getSourceAlias());
             remove(alias);

--- a/src/org/openlcb/can/MessageBuilder.java
+++ b/src/org/openlcb/can/MessageBuilder.java
@@ -236,15 +236,26 @@ public class MessageBuilder implements AliasMap.Watcher {
             case InitializationComplete:
                 retlist.add(new InitializationCompleteMessage(source));
                 return retlist;
+            case VerifyNodeIdAddressed:
+                // check for content
+                if (data.length >= 6) {
+                    NodeID node = new NodeID(data);
+                    retlist.add(new VerifyNodeIDNumberAddressedMessage(source, dest, node));
+                } else {
+                    retlist.add(new VerifyNodeIDNumberAddressedMessage(source, dest));
+                }
+                return retlist;
+            
             case VerifyNodeIdGlobal:
                 // check for content
                 if (data.length >= 6) {
                     NodeID node = new NodeID(data);
-                    retlist.add(new VerifyNodeIDNumberMessage(source, node));
+                    retlist.add(new VerifyNodeIDNumberGlobalMessage(source, node));
                 } else {
-                    retlist.add(new VerifyNodeIDNumberMessage(source));
+                    retlist.add(new VerifyNodeIDNumberGlobalMessage(source));
                 }
                 return retlist;
+                            
             case VerifiedNodeId:
                 retlist.add(new VerifiedNodeIDNumberMessage(source));
                 return retlist;
@@ -615,9 +626,9 @@ public class MessageBuilder implements AliasMap.Watcher {
             // We don't know the destination alias.
 
             // Sends a node id verify message.
-            VerifyNodeIDNumberMessage om = new VerifyNodeIDNumberMessage(m.getSourceNodeID(),
+            VerifyNodeIDNumberGlobalMessage om = new VerifyNodeIDNumberGlobalMessage(m.getSourceNodeID(),
                     ((AddressedMessage) m).getDestNodeID());
-            handleVerifyNodeIDNumber(om, null);
+            handleVerifyNodeIDNumberGlobal(om, null);
 
             // Enqueues the outgoing message.
             synchronized (blockedMessages) {
@@ -709,7 +720,7 @@ public class MessageBuilder implements AliasMap.Watcher {
          * Handle "Verify Node ID Number" message
          */
         @Override
-        public void handleVerifyNodeIDNumber(VerifyNodeIDNumberMessage msg, Connection sender){
+        public void handleVerifyNodeIDNumberGlobal(VerifyNodeIDNumberGlobalMessage msg, Connection sender){
             OpenLcbCanFrame f = new OpenLcbCanFrame(0x00);
             f.setVerifyNID(msg.getSourceNodeID());
             f.setSourceAlias(map.getAlias(msg.getSourceNodeID()));

--- a/src/org/openlcb/protocols/VerifyNodeIdHandler.java
+++ b/src/org/openlcb/protocols/VerifyNodeIdHandler.java
@@ -6,7 +6,8 @@ import org.openlcb.MessageDecoder;
 import org.openlcb.NodeID;
 import org.openlcb.OlcbInterface;
 import org.openlcb.VerifiedNodeIDNumberMessage;
-import org.openlcb.VerifyNodeIDNumberMessage;
+import org.openlcb.VerifyNodeIDNumberGlobalMessage;
+import org.openlcb.VerifyNodeIDNumberAddressedMessage;
 
 /**
  * Handler for verify node ID requests to the local node.
@@ -30,15 +31,25 @@ public class VerifyNodeIdHandler extends MessageDecoder {
     }
 
     @Override
-    public void handleVerifyNodeIDNumber(VerifyNodeIDNumberMessage msg, Connection sender) {
+    public void handleVerifyNodeIDNumberGlobal(VerifyNodeIDNumberGlobalMessage msg, Connection sender) {
         /* This is the Verify Node ID number "global" message.
         *
-        * TODO: we need to add VerifyNode ID number "addressed" message to the list of
-        * supported MTIs et al.
         */
 
         // Only reply if requesting all nodes or one node where the ID is this specific node.
         if (msg.getContent() == null || msg.getContent().equals(id)) {
+            Message omsg = new VerifiedNodeIDNumberMessage(id);
+            iface.getOutputConnection().put(omsg, this);
+        }
+    }
+
+    @Override
+    public void handleVerifyNodeIDNumberAddressed(VerifyNodeIDNumberAddressedMessage msg, Connection sender) {
+        /* This is the Verify Node ID number "addressed" message.
+        *
+        */
+        // Only reply if addressed to this node
+        if (msg.getDestNodeID().equals(id)) {
             Message omsg = new VerifiedNodeIDNumberMessage(id);
             iface.getOutputConnection().put(omsg, this);
         }

--- a/src/org/openlcb/swing/networktree/TreePane.java
+++ b/src/org/openlcb/swing/networktree/TreePane.java
@@ -42,7 +42,7 @@ import org.openlcb.Connection;
 import org.openlcb.MimicNodeStore;
 import org.openlcb.NodeID;
 import org.openlcb.SimpleNodeIdent;
-import org.openlcb.VerifyNodeIDNumberMessage;
+import org.openlcb.VerifyNodeIDNumberGlobalMessage;
 
 /**
  * Pane for monitoring an entire OpenLCB network as a logical tree
@@ -256,7 +256,7 @@ public class TreePane extends JPanel  {
             @Override
             public void connectionActive(Connection c) {
                 // load the alias field
-                connection.put(new VerifyNodeIDNumberMessage(node), null);
+                connection.put(new VerifyNodeIDNumberGlobalMessage(node), null);
             }
         };
         if (connection != null) {

--- a/test/org/openlcb/MimicNodeStoreTest.java
+++ b/test/org/openlcb/MimicNodeStoreTest.java
@@ -211,7 +211,7 @@ public class MimicNodeStoreTest {
         MimicNodeStore.NodeMemo retval = store.findNode(nid1);
 
         Assert.assertTrue(retval == null);
-        Assert.assertTrue(lastMessage.equals(new VerifyNodeIDNumberMessage(src, nid1)));
+        Assert.assertTrue(lastMessage.equals(new VerifyNodeIDNumberGlobalMessage(src, nid1)));
         
     }
     
@@ -252,7 +252,7 @@ public class MimicNodeStoreTest {
 
         // And a verify node ID message going out.
         Assert.assertNotNull(lastMessage);
-        Assert.assertTrue(lastMessage instanceof VerifyNodeIDNumberMessage);
+        Assert.assertTrue(lastMessage instanceof VerifyNodeIDNumberGlobalMessage);
 
         // As well as the node tree being clear now.
         Assert.assertEquals(0, store.getNodeMemos().size());

--- a/test/org/openlcb/VerifyNodeIDNumberAddressedMessageTest.java
+++ b/test/org/openlcb/VerifyNodeIDNumberAddressedMessageTest.java
@@ -1,0 +1,93 @@
+package org.openlcb;
+
+import org.junit.*;
+
+/**
+ * @author  Bob Jacobsen   Copyright 2009, 2024
+ */
+public class VerifyNodeIDNumberAddressedMessageTest  {
+    boolean result;
+    
+    @Test
+    public void testEqualsSame() {
+        Message m1 = new VerifyNodeIDNumberAddressedMessage(
+                                            new NodeID(new byte[]{1,2,3,4,5,6}),
+                                            new NodeID(new byte[]{9,8,7,6,5,4}) );
+        Message m2 = new VerifyNodeIDNumberAddressedMessage(
+                                            new NodeID(new byte[]{1,2,3,4,5,6}),
+                                            new NodeID(new byte[]{9,8,7,6,5,4}) );
+    
+        Assert.assertTrue(m1.equals(m2));
+    }
+
+    @Test
+    public void testEqualsSameWithContent() {
+        Message m1 = new VerifyNodeIDNumberAddressedMessage(
+                                            new NodeID(new byte[]{1,2,3,4,5,6}), 
+                                            new NodeID(new byte[]{9,8,7,6,5,4}),
+                                            new NodeID(new byte[]{1,2,3,4,5,6}));
+        Message m2 = new VerifyNodeIDNumberAddressedMessage(
+                                            new NodeID(new byte[]{1,2,3,4,5,6}), 
+                                            new NodeID(new byte[]{9,8,7,6,5,4}),
+                                            new NodeID(new byte[]{1,2,3,4,5,6}) );
+    
+        Assert.assertTrue(m1.equals(m2));
+    }
+
+    @Test
+    public void testNotEqualsDifferent1() {
+        Message m1 = new VerifyNodeIDNumberAddressedMessage(
+                                            new NodeID(new byte[]{1,2,3,4,5,6}),
+                                            new NodeID(new byte[]{9,8,7,6,5,4}) );
+        Message m2 = new VerifyNodeIDNumberAddressedMessage(
+                                            new NodeID(new byte[]{10,2,3,4,5,6}),
+                                            new NodeID(new byte[]{9,8,7,6,5,4}) );
+    
+        Assert.assertTrue( ! m1.equals(m2));
+    }
+
+    @Test
+    public void testNotEqualsDifferent2() {
+        Message m1 = new VerifyNodeIDNumberAddressedMessage(
+                                            new NodeID(new byte[]{1,2,3,4,5,6}),
+                                            new NodeID(new byte[]{9,8,7,6,5,4}) );
+        Message m2 = new VerifyNodeIDNumberAddressedMessage(
+                                            new NodeID(new byte[]{1,2,3,4,5,6}),
+                                            new NodeID(new byte[]{19,8,7,6,5,4}) );
+    
+        Assert.assertTrue( ! m1.equals(m2));
+    }
+
+    @Test
+    public void testEqualsContentMatters() {
+        Message m1 = new VerifyNodeIDNumberAddressedMessage(
+                                            new NodeID(new byte[]{1,2,3,4,5,6}), 
+                                            new NodeID(new byte[]{9,8,7,6,5,4}),
+                                            new NodeID(new byte[]{1,2,3,4,5,6}) );
+        Message m2 = new VerifyNodeIDNumberAddressedMessage(
+                                            new NodeID(new byte[]{1,2,3,4,5,6}),
+                                            new NodeID(new byte[]{9,8,7,6,5,4}),
+                                            new NodeID(new byte[]{1,2,3,4,5,0}) );
+    
+        Assert.assertTrue( ! m1.equals(m2));
+    }
+
+    @Test
+    public void testHandling() {
+        result = false;
+        Node n = new Node(){
+            @Override
+            public void handleVerifyNodeIDNumberAddressed(VerifyNodeIDNumberAddressedMessage msg, Connection sender){
+                result = true;
+            }
+        };
+        Message m = new VerifyNodeIDNumberAddressedMessage(
+                                            new NodeID(new byte[]{1,2,3,4,5,6}),
+                                            new NodeID(new byte[]{9,8,7,6,5,4}) );
+        
+        n.put(m, null);
+        
+        Assert.assertTrue(result);
+    }
+    
+}

--- a/test/org/openlcb/VerifyNodeIDNumberMessageTest.java
+++ b/test/org/openlcb/VerifyNodeIDNumberMessageTest.java
@@ -10,9 +10,9 @@ public class VerifyNodeIDNumberMessageTest  {
     
     @Test
     public void testEqualsSame() {
-        Message m1 = new VerifyNodeIDNumberMessage(
+        Message m1 = new VerifyNodeIDNumberGlobalMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}) );
-        Message m2 = new VerifyNodeIDNumberMessage(
+        Message m2 = new VerifyNodeIDNumberGlobalMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}) );
     
         Assert.assertTrue(m1.equals(m2));
@@ -20,9 +20,9 @@ public class VerifyNodeIDNumberMessageTest  {
 
     @Test
     public void testEqualsSameWithContent() {
-        Message m1 = new VerifyNodeIDNumberMessage(
+        Message m1 = new VerifyNodeIDNumberGlobalMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}), new NodeID(new byte[]{1,2,3,4,5,6}));
-        Message m2 = new VerifyNodeIDNumberMessage(
+        Message m2 = new VerifyNodeIDNumberGlobalMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}), new NodeID(new byte[]{1,2,3,4,5,6}) );
     
         Assert.assertTrue(m1.equals(m2));
@@ -30,9 +30,9 @@ public class VerifyNodeIDNumberMessageTest  {
 
     @Test
     public void testNotEqualsDifferent() {
-        Message m1 = new VerifyNodeIDNumberMessage(
+        Message m1 = new VerifyNodeIDNumberGlobalMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}) );
-        Message m2 = new VerifyNodeIDNumberMessage(
+        Message m2 = new VerifyNodeIDNumberGlobalMessage(
                                             new NodeID(new byte[]{1,3,3,4,5,6}) );
     
         Assert.assertTrue( ! m1.equals(m2));
@@ -40,9 +40,9 @@ public class VerifyNodeIDNumberMessageTest  {
 
     @Test
     public void testEqualsContentMatters() {
-        Message m1 = new VerifyNodeIDNumberMessage(
+        Message m1 = new VerifyNodeIDNumberGlobalMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}), new NodeID(new byte[]{1,2,3,4,5,6}) );
-        Message m2 = new VerifyNodeIDNumberMessage(
+        Message m2 = new VerifyNodeIDNumberGlobalMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}), new NodeID(new byte[]{1,2,3,4,5,0}) );
     
         Assert.assertTrue( ! m1.equals(m2));
@@ -53,11 +53,11 @@ public class VerifyNodeIDNumberMessageTest  {
         result = false;
         Node n = new Node(){
             @Override
-            public void handleVerifyNodeIDNumber(VerifyNodeIDNumberMessage msg, Connection sender){
+            public void handleVerifyNodeIDNumberGlobal(VerifyNodeIDNumberGlobalMessage msg, Connection sender){
                 result = true;
             }
         };
-        Message m = new VerifyNodeIDNumberMessage(
+        Message m = new VerifyNodeIDNumberGlobalMessage(
                                             new NodeID(new byte[]{1,2,3,4,5,6}) );
         
         n.put(m, null);

--- a/test/org/openlcb/can/MessageBuilderTest.java
+++ b/test/org/openlcb/can/MessageBuilderTest.java
@@ -28,7 +28,7 @@ import org.openlcb.StreamInitiateReplyMessage;
 import org.openlcb.StreamInitiateRequestMessage;
 import org.openlcb.Utilities;
 import org.openlcb.VerifiedNodeIDNumberMessage;
-import org.openlcb.VerifyNodeIDNumberMessage;
+import org.openlcb.VerifyNodeIDNumberGlobalMessage;
 import org.openlcb.implementations.DatagramUtils;
 import org.openlcb.messages.TractionControlReplyMessage;
 import org.openlcb.messages.TractionControlRequestMessage;
@@ -83,7 +83,7 @@ public class MessageBuilderTest  {
 
     @Test
     public void testVerifyNodeIDNumberMessageEmpty() {
-        Message m = new VerifyNodeIDNumberMessage(source);
+        Message m = new VerifyNodeIDNumberGlobalMessage(source);
         MessageBuilder b = new MessageBuilder(map);
 
         List<OpenLcbCanFrame> list = b.processMessage(m);
@@ -100,7 +100,7 @@ public class MessageBuilderTest  {
 
     @Test
     public void testVerifyNodeIDNumberMessageWithContent() {
-        Message m = new VerifyNodeIDNumberMessage(source, source);
+        Message m = new VerifyNodeIDNumberGlobalMessage(source, source);
         MessageBuilder b = new MessageBuilder(map);
 
         List<OpenLcbCanFrame> list = b.processMessage(m);
@@ -551,8 +551,8 @@ public class MessageBuilderTest  {
         Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
 
-        Assert.assertTrue(msg instanceof VerifyNodeIDNumberMessage);
-        Assert.assertEquals(new VerifyNodeIDNumberMessage(source), msg);
+        Assert.assertTrue(msg instanceof VerifyNodeIDNumberGlobalMessage);
+        Assert.assertEquals(new VerifyNodeIDNumberGlobalMessage(source), msg);
     }
 
     @Test
@@ -568,8 +568,8 @@ public class MessageBuilderTest  {
         Assert.assertEquals("count", 1, list.size());
         Message msg = list.get(0);
 
-        Assert.assertTrue(msg instanceof VerifyNodeIDNumberMessage);
-        Assert.assertEquals(new VerifyNodeIDNumberMessage(source, source), msg);
+        Assert.assertTrue(msg instanceof VerifyNodeIDNumberGlobalMessage);
+        Assert.assertEquals(new VerifyNodeIDNumberGlobalMessage(source, source), msg);
     }
 
     @Test

--- a/test/org/openlcb/implementations/throttle/ThrottleImplementationTest.java
+++ b/test/org/openlcb/implementations/throttle/ThrottleImplementationTest.java
@@ -54,8 +54,8 @@ public class ThrottleImplementationTest {
         t.start();
         
         Assert.assertEquals(messagesReceived.size(), 1);
-        Assert.assertTrue(messagesReceived.get(0) instanceof VerifyNodeIDNumberMessage);
-        VerifyNodeIDNumberMessage v = (VerifyNodeIDNumberMessage)messagesReceived.get(0);
+        Assert.assertTrue(messagesReceived.get(0) instanceof VerifyNodeIDNumberGlobalMessage);
+        VerifyNodeIDNumberGlobalMessage v = (VerifyNodeIDNumberGlobalMessage)messagesReceived.get(0);
         
         Assert.assertEquals(new NodeID(new byte[]{0x06, 0x01, 0,0, (byte)(1234/256 | 0xC0), (byte)(1234&0xFF)}), v.getContent());
 


### PR DESCRIPTION
This adds support for the Verify Node Addressed message.

As part of that, it renames the various internal references to VerifyNode to be VerifyNodeGlobal

Also armors against AMR messages that don't have a Node ID as content.  The Standard says this is required, but some nodes don't send it in response to a collision.