### PR TITLE
Correct order of contents in OIR message

### DIFF
--- a/src/org/openlcb/OptionalIntRejectedMessage.java
+++ b/src/org/openlcb/OptionalIntRejectedMessage.java
@@ -39,8 +39,8 @@ public class OptionalIntRejectedMessage extends AddressedPayloadMessage {
 
     private static byte[] toPayload(int mti, int code) {
         byte[] b = new byte[4];
-        Utilities.HostToNetworkUint16(b, 0, mti);
-        Utilities.HostToNetworkUint16(b, 2, code);
+        Utilities.HostToNetworkUint16(b, 0, code);
+        Utilities.HostToNetworkUint16(b, 2, mti);
         return b;
     }
     


### PR DESCRIPTION
The correct order of contents in the OIR message is the error code, then the reported MTI.  Previously, this was backwards in the code.