### PR TITLE
Only react to OIR that has our address

### DIFF
--- a/src/org/openlcb/MimicNodeStore.java
+++ b/src/org/openlcb/MimicNodeStore.java
@@ -335,7 +335,7 @@ public class MimicNodeStore extends AbstractConnection {
             if (node != msg.getDestNodeID()) return; // not for us
             if (msg.getRejectMTI() == MessageTypeIdentifier.SimpleNodeIdentInfoRequest.mti()) {
                 // check for temporary error
-                if ((msg.getCode() & 0x1000) == 0) {
+                if ((msg.getCode() & 0x2000) == 0) {
                     // not a temporary error, assume a permanent error
                     String logmsg = "Permanent error geting Simple Node Info "
                             + "for node {0} code 0x{1}";
@@ -352,7 +352,7 @@ public class MimicNodeStore extends AbstractConnection {
             }
             if (msg.getRejectMTI() == MessageTypeIdentifier.ProtocolSupportInquiry.mti()) {
                 // check for temporary error
-                if ((msg.getCode() & 0x1000) == 0) {
+                if ((msg.getCode() & 0x2000) == 0) {
                     // not a temporary error, assume a permanent error
                     String logmsg = "Permanent error geting Protocol Identification information "
                             + "for node {0} code 0x{1}";

--- a/src/org/openlcb/MimicNodeStore.java
+++ b/src/org/openlcb/MimicNodeStore.java
@@ -332,6 +332,7 @@ public class MimicNodeStore extends AbstractConnection {
 
         @Override
         public void handleOptionalIntRejected(OptionalIntRejectedMessage msg, Connection sender){
+            if (node != msg.getDestNodeID()) return; // not for us
             if (msg.getRejectMTI() == MessageTypeIdentifier.SimpleNodeIdentInfoRequest.mti()) {
                 // check for temporary error
                 if ((msg.getCode() & 0x1000) == 0) {

--- a/test/org/openlcb/MimicNodeStoreTest.java
+++ b/test/org/openlcb/MimicNodeStoreTest.java
@@ -200,7 +200,7 @@ public class MimicNodeStoreTest {
         MimicNodeStore.NodeMemo memo = list.iterator().next();
 
         Assert.assertNull(lastMessage);
-        store.put(new OptionalIntRejectedMessage(nid1,src,0x0DE8,0x1000), null);
+        store.put(new OptionalIntRejectedMessage(nid1,src,0x0DE8,0x2000), null);
         Assert.assertNotNull(lastMessage);
         
         Assert.assertEquals(lastMessage, new SimpleNodeIdentInfoRequestMessage(src, nid1) );


### PR DESCRIPTION
The library will retry a PIP or SNIP request that gets a OIR with a temporary error code.  This should only be done if the OIR is directed to this node, so this PR adds a check for that.