### PR TITLE
Datagram display improved; CDI max & min enforced

### DIFF
--- a/src/org/openlcb/DatagramAcknowledgedMessage.java
+++ b/src/org/openlcb/DatagramAcknowledgedMessage.java
@@ -20,7 +20,7 @@ public class DatagramAcknowledgedMessage extends AddressedPayloadMessage {
     }
 
     public DatagramAcknowledgedMessage(NodeID source, NodeID dest, int flags) {
-        super(source, dest, flags == 0 ? null : new byte[]{(byte)flags});
+        super(source, dest, new byte[]{(byte)flags});
         this.flags = flags;
     }
 
@@ -39,6 +39,14 @@ public class DatagramAcknowledgedMessage extends AddressedPayloadMessage {
      public void applyTo(MessageDecoder decoder, Connection sender) {
         decoder.handleDatagramAcknowledged(this, sender);
      }
+
+    @Override
+    public String toString() {
+        StringBuilder p = new StringBuilder(super.toString());
+        p.append(" flags 0x");
+        p.append(Integer.toHexString(getFlags()).toUpperCase());
+        return p.toString();
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/org/openlcb/DatagramRejectedMessage.java
+++ b/src/org/openlcb/DatagramRejectedMessage.java
@@ -43,6 +43,14 @@ public class DatagramRejectedMessage extends AddressedPayloadMessage {
      }
 
     @Override
+    public String toString() {
+        StringBuilder p = new StringBuilder(super.toString());
+        p.append(" flags 0x");
+        p.append(Integer.toHexString(getCode()).toUpperCase());
+        return p.toString();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (o == null) return false;
         if (! (o instanceof DatagramRejectedMessage))

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -85,8 +85,8 @@ public interface CdiRep {
     }
     public static interface IntegerRep extends Item {
         public int getDefault();
-        public int getMin();
-        public int getMax();
+        public long getMin();
+        public long getMax();
 
         public int getSize();
     }

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -1799,6 +1799,7 @@ public class CdiPanel extends JPanel {
         protected JComponent textComponent;
         private ConfigRepresentation.CdiEntry entry;
         PropertyChangeListener entryListener = null;
+        JButton writeButton;  // reference to this pane's "Write" button
         boolean dirty = false;
         JPanel p3;
 
@@ -1950,14 +1951,14 @@ public class CdiPanel extends JPanel {
             });
             p3.add(b);
 
-            b = factory.handleWriteButton(new JButton("Write"));
-            b.addActionListener(new java.awt.event.ActionListener() {
+            writeButton = factory.handleWriteButton(new JButton("Write"));
+            writeButton.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     writeDisplayTextToNode();
                 }
             });
-            p3.add(b);
+            p3.add(writeButton);
 
             additionalButtons();
 
@@ -1983,8 +1984,19 @@ public class CdiPanel extends JPanel {
             if (oldDirty != dirty) {
                 notifyTabColorRefresh();
             }
+            
+            // and check the value for write button, as needed
+            updateWriteButton();
         }
 
+        /**
+         * For types that control the enable status of the 
+         * write button based on whether the current input value is valid
+         */
+        void updateWriteButton() {
+            // by default, this does nothing
+        }
+        
         boolean isDirty() {
              return dirty;
         }
@@ -2297,7 +2309,9 @@ public class CdiPanel extends JPanel {
                     }
                 };
                 textComponent = textField;
-                textField.setToolTipText("Signed integer value of up to "+entry.size+" bytes");
+                textField.setToolTipText("Signed integer from "
+                        +entry.rep.getMin()+" to "+entry.rep.getMax()
+                        +" ("+entry.size+" bytes)");
             }
 
             init();
@@ -2350,6 +2364,29 @@ public class CdiPanel extends JPanel {
                 s = map.getKey(entry);  
             }
             return s == null ? "" : s;
+        }
+        
+        /**
+         * check that the current (String) value is 
+         * valid and within the min and max range.
+         * Disable/Enable write button as appropriate.
+         */
+        @Override
+        void updateWriteButton() {
+            if (writeButton == null) {
+                // skip these until the write button has been created
+                return;
+            }
+            try {
+                int value = Integer.valueOf(getCurrentValue());
+                if (value >= entry.rep.getMin() && value <= entry.rep.getMax() ) {
+                    writeButton.setEnabled(true);
+                } else {
+                    writeButton.setEnabled(false);
+                }
+            } catch (NumberFormatException ex) {
+                writeButton.setEnabled(false);
+            }
         }
 
     }

--- a/test/org/openlcb/DatagramAcknowledgedMessageTest.java
+++ b/test/org/openlcb/DatagramAcknowledgedMessageTest.java
@@ -20,8 +20,26 @@ public class DatagramAcknowledgedMessageTest {
         NodeID id2 = new NodeID(new byte[]{1, 1, 0, 0, 4, 4});
         DatagramAcknowledgedMessage t = new DatagramAcknowledgedMessage(id1,id2);
         Assert.assertNotNull("exists",t);
+    }    
+    
+    @Test
+    public void testToString() {
+        NodeID id1 = new NodeID(new byte[]{1, 1, 0, 0, 0, 4});
+        NodeID id2 = new NodeID(new byte[]{1, 1, 0, 0, 4, 4});
+        DatagramAcknowledgedMessage t = new DatagramAcknowledgedMessage(id1,id2, 0x80);
+
+        Assert.assertEquals("01.01.00.00.00.04 - 01.01.00.00.04.04 DatagramReceivedOK with payload 80 flags 0x80", t.toString());
     }
 
+    @Test
+    public void testToStringZeroFlag() {
+        NodeID id1 = new NodeID(new byte[]{1, 1, 0, 0, 0, 4});
+        NodeID id2 = new NodeID(new byte[]{1, 1, 0, 0, 4, 4});
+        DatagramAcknowledgedMessage t = new DatagramAcknowledgedMessage(id1,id2, 0x00);
+
+        Assert.assertEquals("01.01.00.00.00.04 - 01.01.00.00.04.04 DatagramReceivedOK with payload 00 flags 0x0", t.toString());
+    }
+    
     // The minimal setup for log4J
     @Before
     public void setUp() {

--- a/test/org/openlcb/DatagramRejectedMessageTest.java
+++ b/test/org/openlcb/DatagramRejectedMessageTest.java
@@ -22,6 +22,15 @@ public class DatagramRejectedMessageTest {
         Assert.assertNotNull("exists",t);
     }
 
+    @Test
+    public void testToString() {
+        NodeID id1 = new NodeID(new byte[]{1, 1, 0, 0, 0, 4});
+        NodeID id2 = new NodeID(new byte[]{1, 1, 0, 0, 4, 4});
+        DatagramRejectedMessage t = new DatagramRejectedMessage(id1,id2,1);
+
+        Assert.assertEquals("01.01.00.00.00.04 - 01.01.00.00.04.04 DatagramRejected with payload 00 01 flags 0x1", t.toString());
+    }
+    
     // The minimal setup for log4J
     @Before
     public void setUp() {

--- a/test/org/openlcb/can/MessageBuilderTest.java
+++ b/test/org/openlcb/can/MessageBuilderTest.java
@@ -432,7 +432,7 @@ public class MessageBuilderTest  {
         Assert.assertEquals("count", 1, list.size());
         CanFrame f0 = list.get(0);
         Assert.assertEquals("header", toHexString(0x19A28123), toHexString(f0.getHeader()));
-        compareContent(new byte[]{0x03, 0x21}, f0);
+        compareContent(new byte[]{0x03, 0x21, 0}, f0);
 
         testDecoding(m, list);
     }


### PR DESCRIPTION
 - improve how the payload of DatagramAcknowledged and DatagramRejected messages are handled and displayed
 - enforce the max and min elements when doing integer input via CDI
   - added max and min values to the tooltips
   - changed getMax and getMin methods to return a long to allow for unsigned 4-byte values
   - "Write" button disabled if input is out of range
