### PR TITLE
Allow CDI info to be de-cached

### DIFF
--- a/src/org/openlcb/OlcbInterface.java
+++ b/src/org/openlcb/OlcbInterface.java
@@ -239,6 +239,14 @@ public class OlcbInterface {
         return rep;
     }
 
+
+    public synchronized void dropConfigForNode(NodeID remoteNode) {
+        if (nodeConfigs.containsKey(remoteNode)) {
+            nodeConfigs.remove(remoteNode);
+        }
+        return;
+    }
+
     /**
      * Blocks the current thread until the outgoing messages are all sent out. Useful for testing.
      */


### PR DESCRIPTION
This adds a method to the OlcbInterface for removing a CDI entry from the internal cache, thereby forcing a reload the next time it's requested.

This adds a new method to the API, so it requires an OpenLCB_Java release before JMRI can access it.