### PR TITLE
Save button enabled when blue

### DIFF
--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -846,7 +846,8 @@ public class CdiPanel extends JPanel {
     private void setSaveInvalid() {
         SwingUtilities.invokeLater(() -> {
             _saveButton.setBackground(COLOR_INVALID);
-            _saveButton.setEnabled(false);
+            // Uncomment the following line to have "Save" button disabled when blue
+            //_saveButton.setEnabled(false);
         });
     }
 


### PR DESCRIPTION
This reverts a previous change where the Save button was disabled if there were any out-of-range (blue) variable values.