### PR TITLE
Improvements to CDI element support

### DIFF
--- a/sample.xml
+++ b/sample.xml
@@ -33,6 +33,16 @@
         <max>999</max>
         <default>12</default>
     </int>
+    <int size="2">
+        <name>Sample integer slider</name>
+        <description>Doesn't do anything either</description>
+        <min>0</min>
+        <max>1000</max>
+        <default>12</default>
+        <hints>
+            <slider divisions="5" />
+        </hints>
+    </int>
 </segment>
 
 <segment origin="128" space="1">

--- a/sample.xml
+++ b/sample.xml
@@ -59,22 +59,23 @@
         </map>
     </int>
     <action size="2">
-        <name>Factory Reset</name>
+        <name>Factory Reset via address 129</name>
         <buttonText>Perform Reset</buttonText>
         <dialogText>Do a factory reset?</dialogText>
         <value>2</value>
     </action>
     <action size="2" offset="-2">
-        <name>Reboot</name>
+        <name>Reboot via address 131</name>
         <buttonText>Perform Reboot</buttonText>
         <dialogText></dialogText> <!-- no dialog -->
         <value>9</value>
     </action>
     <blob size="10" mode="readwrite">
+        <name>Blob defined at address 133</name>
     </blob>
     <int size="1">
         <name>Yet Another Reset</name>
-        <description>This should be stored at address 141.</description>
+        <description>This should be stored at address 143.</description>
     </int>
 </segment>
 

--- a/sample.xml
+++ b/sample.xml
@@ -50,16 +50,23 @@
 
 <segment origin="128" space="1">
     <int size="1">
-        <name>Reset</name>
+        <name>Reset via Map</name>
         <description>
             Controls reloading and clearing node memory. 
             Board must be restarted for this to take effect.
         </description>
         <map>
-            <relation><property>85</property><value>(No reset)</value></relation>
-            <relation><property>0</property><value>Reset all to defaults</value></relation>
-            <relation><property>170</property><value>Reset just EventIDs to defaults</value></relation>
+            <relation><property>0</property><value>No reset (0)</value></relation>
+            <relation><property>85</property><value>Reset just EventIDs to defaults (85)</value></relation>
+            <relation><property>170</property><value>Reset all to defaults (170)</value></relation>
         </map>
+    </int>
+    <int size="1" offset="-1">
+        <name>Reset Directly</name>
+        <description>
+            This accesses the same memory location as the 
+            mapped variable just above.
+        </description>
     </int>
     <action size="2">
         <name>Factory Reset via address 129</name>

--- a/sample.xml
+++ b/sample.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="XSLT/decoder.xsl"?>
-<cdi>
+<cdi xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 	
+    xsi:noNamespaceSchemaLocation="http://openlcb.org/schema/cdi/1/4/cdi.xsd">
 
 <identification>
     <manufacturer>Spacely Sprockets</manufacturer>
@@ -25,10 +26,6 @@
         <eventid/>
         <eventid/>
     </group>
-    <bit>
-        <name>Sample bit variable</name>
-        <description>Doesn't do anything</description>
-    </bit>
     <int size="2">
         <name>Sample integer variable</name>
         <description>Doesn't do anything</description>
@@ -41,12 +38,33 @@
 <segment origin="128" space="1">
     <int size="1">
         <name>Reset</name>
-        <description>Controls reloading and clearing node memory. Board must be restarted for this to take effect.</description>
+        <description>
+            Controls reloading and clearing node memory. 
+            Board must be restarted for this to take effect.
+        </description>
         <map>
             <relation><property>85</property><value>(No reset)</value></relation>
             <relation><property>0</property><value>Reset all to defaults</value></relation>
             <relation><property>170</property><value>Reset just EventIDs to defaults</value></relation>
         </map>
+    </int>
+    <action size="2">
+        <name>Factory Reset</name>
+        <buttonText>Perform Reset</buttonText>
+        <dialogText>Do a factory reset?</dialogText>
+        <value>2</value>
+    </action>
+    <action size="2" offset="-2">
+        <name>Reboot</name>
+        <buttonText>Perform Reboot</buttonText>
+        <dialogText></dialogText> <!-- no dialog -->
+        <value>9</value>
+    </action>
+    <blob size="10" mode="readwrite">
+    </blob>
+    <int size="1">
+        <name>Yet Another Reset</name>
+        <description>This should be stored at address 141.</description>
     </int>
 </segment>
 

--- a/sample.xml
+++ b/sample.xml
@@ -25,6 +25,9 @@
         <description>The EventIDs for the consumers</description>
         <eventid/>
         <eventid/>
+        <blob size="10" mode="readwrite">
+            <name>Blob to see if works in group element</name>
+        </blob>
     </group>
     <int size="2">
         <name>Sample integer variable</name>
@@ -65,17 +68,17 @@
         <value>2</value>
     </action>
     <action size="2" offset="-2">
-        <name>Reboot via address 131</name>
+        <name>Reboot via address 129</name>
         <buttonText>Perform Reboot</buttonText>
         <dialogText></dialogText> <!-- no dialog -->
         <value>9</value>
     </action>
     <blob size="10" mode="readwrite">
-        <name>Blob defined at address 133</name>
+        <name>Blob defined at address 131</name>
     </blob>
     <int size="1">
         <name>Yet Another Reset</name>
-        <description>This should be stored at address 143.</description>
+        <description>This should be stored at address 141.</description>
     </int>
 </segment>
 

--- a/sample2.xml
+++ b/sample2.xml
@@ -35,24 +35,6 @@
       <eventid />
       <eventid />
     </group>
-    <bit>
-      <name>Regular bit variable</name>
-      <description>Demonstrate how a standard bit (boolean) variable can be shown</description>
-    </bit>
-    <bit>
-      <name>Bit variable with named states</name>
-      <description>Demonstrate how a map relabels the states of a bit (boolean) variable</description>
-      <map>
-        <relation>
-          <property>true</property>
-          <value>Lit</value>
-        </relation>
-        <relation>
-          <property>false</property>
-          <value>Not Lit</value>
-        </relation>
-      </map>
-    </bit>
   </segment>
   <segment space="1" origin="128">
     <name>Resets</name>

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -90,6 +90,9 @@ public interface CdiRep {
         public long getMax();
 
         public int getSize();
+        
+        public boolean isSliderHint();
+        public int getSliderDivisions();
     }
 
     public static interface BitRep extends Item {

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -105,7 +105,7 @@ public interface CdiRep {
 
     public static interface ActionButtonRep extends Item {
     
-        public int getValue();
+        public long getValue();
         public String getButtonText();
         public String getDialogText();
 

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -83,6 +83,7 @@ public interface CdiRep {
 
     public static interface EventID extends Item {
     }
+
     public static interface IntegerRep extends Item {
         public int getDefault();
         public long getMin();
@@ -90,12 +91,23 @@ public interface CdiRep {
 
         public int getSize();
     }
+
     public static interface BitRep extends Item {
         public boolean getDefault();
 
         public int getSize();
     }
+
     public static interface StringRep extends Item {  // "String" causes too many name conflicts
+
+        public int getSize();
+    }
+
+    public static interface ActionButtonRep extends Item {
+    
+        public int getValue();
+        public String getButtonText();
+        public String getDialogText();
 
         public int getSize();
     }

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -79,6 +79,12 @@ public interface CdiRep {
          * @return a list of all user-visible values.
          */
         public java.util.List<String> getValues();
+        
+        /**
+         * Add an item to the map.  Useful if e.g. a non-mapped
+         * value is found in a location.
+         */
+        public void addItemToMap(String key, String entry);
     }
 
     public static interface EventID extends Item {

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -101,6 +101,12 @@ public interface CdiRep {
         public int getSize();
     }
 
+    public static interface UnknownRep extends Item {
+        public boolean getDefault();
+
+        public int getSize();
+    }
+
     public static interface StringRep extends Item {  // "String" causes too many name conflicts
 
         public int getSize();

--- a/src/org/openlcb/cdi/impl/ConfigRepresentation.java
+++ b/src/org/openlcb/cdi/impl/ConfigRepresentation.java
@@ -253,6 +253,8 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
                 entry = new EventEntry(name, (CdiRep.EventID) it, segment, origin);
             } else if (it instanceof CdiRep.StringRep) {
                 entry = new StringEntry(name, (CdiRep.StringRep) it, segment, origin);
+            } else if (it instanceof CdiRep.ActionButtonRep) {
+                entry = new ActionButtonEntry(name, (CdiRep.ActionButtonRep) it, segment, origin);
             } else {
                 logger.log(Level.SEVERE, "could not process CDI entry type of {0}", it);
             }
@@ -303,6 +305,8 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
                 visitInt((IntegerEntry) e);
             } else if (e instanceof EventEntry) {
                 visitEvent((EventEntry) e);
+            } else if (e instanceof ActionButtonEntry) {
+                visitActionButton((ActionButtonEntry) e);
             } else if (e instanceof GroupRep) {
                 visitGroupRep((GroupRep) e);
             } else if (e instanceof GroupEntry) {
@@ -328,6 +332,10 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
         }
 
         public void visitEvent(EventEntry e) {
+            visitLeaf(e);
+        }
+
+        public void visitActionButton(ActionButtonEntry e) {
             visitLeaf(e);
         }
 
@@ -675,6 +683,53 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
         @Override
         public boolean isNullTerminated() {
             return size > 64;
+        }
+
+        public String getValue() {
+            MemorySpaceCache cache = getCacheForSpace(space);
+            byte[] b = cache.read(origin, size);
+            if (b == null) return null;
+            // We search for a terminating null byte and clip the string there.
+            int len = 0;
+            while (len < b.length && b[len] != 0) ++len;
+            byte[] rep = new byte[len];
+            System.arraycopy(b, 0, rep, 0, len);
+            String ret = new String(rep, UTF8);
+            return ret;
+        }
+
+        public void setValue(String value) {
+            MemorySpaceCache cache = getCacheForSpace(space);
+            byte[] f;
+            f = value.getBytes(UTF8);
+            byte[] b = new byte[Math.min(size, f.length + 1)];
+            System.arraycopy(f, 0, b, 0, Math.min(f.length, b.length - 1));
+            cache.write(this.origin, b, this);
+        }
+    }
+
+    /**
+     * Represents an action button variable.
+     */
+    public class ActionButtonEntry extends CdiEntry {
+        public CdiRep.ActionButtonRep rep;
+
+        ActionButtonEntry(String name, CdiRep.ActionButtonRep rep, int segment, long origin) {
+            this.key = name;
+            this.space = segment;
+            this.origin = origin;
+            this.rep = rep;
+            this.size = rep.getSize();
+        }
+
+        @Override
+        public CdiRep.Item getCdiItem() {
+            return rep;
+        }
+
+        @Override
+        protected void updateVisibleValue() {
+            lastVisibleValue = getValue();
         }
 
         public String getValue() {

--- a/src/org/openlcb/cdi/impl/ConfigRepresentation.java
+++ b/src/org/openlcb/cdi/impl/ConfigRepresentation.java
@@ -255,6 +255,8 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
                 entry = new StringEntry(name, (CdiRep.StringRep) it, segment, origin);
             } else if (it instanceof CdiRep.ActionButtonRep) {
                 entry = new ActionButtonEntry(name, (CdiRep.ActionButtonRep) it, segment, origin);
+            } else if (it instanceof CdiRep.UnknownRep) {
+                entry = new UnknownEntry(name, (CdiRep.UnknownRep) it, segment, origin);
             } else {
                 logger.log(Level.SEVERE, "could not process CDI entry type of {0}", it);
             }
@@ -313,6 +315,8 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
                 visitGroup((GroupEntry) e);
             } else if (e instanceof SegmentEntry) {
                 visitSegment((SegmentEntry) e);
+            } else if (e instanceof UnknownEntry) {
+                visitUnknown((UnknownEntry) e);
             } else if (e instanceof CdiContainer) {
                 visitContainer((CdiContainer) e);
             } else {
@@ -349,6 +353,10 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
 
         public void visitSegment(SegmentEntry e) {
             visitContainer(e);
+        }
+
+        public void visitUnknown(UnknownEntry e) {
+            visitLeaf(e);
         }
 
         public void visitContainer(CdiContainer c) {
@@ -663,6 +671,58 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
         public CdiRep.StringRep rep;
 
         StringEntry(String name, CdiRep.StringRep rep, int segment, long origin) {
+            this.key = name;
+            this.space = segment;
+            this.origin = origin;
+            this.rep = rep;
+            this.size = rep.getSize();
+        }
+
+        @Override
+        public CdiRep.Item getCdiItem() {
+            return rep;
+        }
+
+        @Override
+        protected void updateVisibleValue() {
+            lastVisibleValue = getValue();
+        }
+
+        @Override
+        public boolean isNullTerminated() {
+            return size > 64;
+        }
+
+        public String getValue() {
+            MemorySpaceCache cache = getCacheForSpace(space);
+            byte[] b = cache.read(origin, size);
+            if (b == null) return null;
+            // We search for a terminating null byte and clip the string there.
+            int len = 0;
+            while (len < b.length && b[len] != 0) ++len;
+            byte[] rep = new byte[len];
+            System.arraycopy(b, 0, rep, 0, len);
+            String ret = new String(rep, UTF8);
+            return ret;
+        }
+
+        public void setValue(String value) {
+            MemorySpaceCache cache = getCacheForSpace(space);
+            byte[] f;
+            f = value.getBytes(UTF8);
+            byte[] b = new byte[Math.min(size, f.length + 1)];
+            System.arraycopy(f, 0, b, 0, Math.min(f.length, b.length - 1));
+            cache.write(this.origin, b, this);
+        }
+    }
+
+    /**
+     * Represents an unknown variable, perhaps due to a more-recent schema
+     */
+    public class UnknownEntry extends CdiEntry {
+        public CdiRep.UnknownRep rep;
+
+        UnknownEntry(String name, CdiRep.UnknownRep rep, int segment, long origin) {
             this.key = name;
             this.space = segment;
             this.origin = origin;

--- a/src/org/openlcb/cdi/impl/ConfigRepresentation.java
+++ b/src/org/openlcb/cdi/impl/ConfigRepresentation.java
@@ -729,29 +729,23 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
 
         @Override
         protected void updateVisibleValue() {
-            lastVisibleValue = getValue();
+            // does nothing in this class
         }
 
-        public String getValue() {
-            MemorySpaceCache cache = getCacheForSpace(space);
-            byte[] b = cache.read(origin, size);
-            if (b == null) return null;
-            // We search for a terminating null byte and clip the string there.
-            int len = 0;
-            while (len < b.length && b[len] != 0) ++len;
-            byte[] rep = new byte[len];
-            System.arraycopy(b, 0, rep, 0, len);
-            String ret = new String(rep, UTF8);
-            return ret;
+        public long getValue() {
+            // should not be called
+            logger.log(Level.SEVERE, "ActionButtonEntry.getValue should not be called");
+            return -1;
         }
 
-        public void setValue(String value) {
+        public void setValue(long value) {
             MemorySpaceCache cache = getCacheForSpace(space);
-            byte[] f;
-            f = value.getBytes(UTF8);
-            byte[] b = new byte[Math.min(size, f.length + 1)];
-            System.arraycopy(f, 0, b, 0, Math.min(f.length, b.length - 1));
-            cache.write(this.origin, b, this);
+            byte[] b = new byte[size];
+            for (int i = size - 1; i >= 0; --i) {
+                b[i] = (byte)(value & 0xff);
+                value >>= 8;
+            }
+            cache.write(origin, b, this);
         }
     }
 

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -401,6 +401,29 @@ public class JdomCdiRep implements CdiRep {
                 else return a.getIntValue();
             } catch (org.jdom2.DataConversionException e1) { return 0; }
         }
+
+        @Override
+        public boolean isSliderHint() {
+            Element hints = e.getChild("hints");
+            if (hints == null) return false;
+            Element slider = hints.getChild("slider");
+            if (slider == null) return false;
+            return true;
+        }
+
+        @Override
+        public int getSliderDivisions() {
+            Element hints = e.getChild("hints");
+            if (hints == null) return 1;
+            Element slider = hints.getChild("slider");
+            if (slider == null) return 1;
+            Attribute divisions = slider.getAttribute("divisions");
+            if (divisions == null) return 1;
+            try { 
+                return divisions.getIntValue();
+            } catch (org.jdom2.DataConversionException e) { return 1; }
+        }
+
     }
     
     public static class BitRep extends Item implements CdiRep.BitRep {

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -447,7 +447,7 @@ public class JdomCdiRep implements CdiRep {
         }
 
         @Override
-        public int getValue() {
+        public long getValue() {
             Element target = e.getChild("value");
             if (target != null) {
                 String text = target.getTextNormalize();

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -107,6 +107,7 @@ public class JdomCdiRep implements CdiRep {
                 else if ("int".equals(element.getName())) list.add(new IntRep(element));
                 else if ("eventid".equals(element.getName())) list.add(new EventID(element));
                 else if ("string".equals(element.getName())) list.add(new StringRep(element));
+                else if ("action".equals(element.getName())) list.add(new ActionButtonRep(element));
             }
             return list;
         }
@@ -430,6 +431,57 @@ public class JdomCdiRep implements CdiRep {
                 else return a.getIntValue();
             } catch (org.jdom2.DataConversionException e1) { return 0; }
         }
+    }
+
+    public static class ActionButtonRep extends Item implements CdiRep.ActionButtonRep {
+
+        ActionButtonRep(Element e) { super(e); }
+        
+        @Override
+        public int getSize() { 
+            Attribute a = e.getAttribute("size");
+            try {
+                if (a == null) return 1;
+                else return a.getIntValue();
+            } catch (org.jdom2.DataConversionException e1) { return 0; }
+        }
+
+        @Override
+        public int getValue() {
+            Element target = e.getChild("value");
+            if (target != null) {
+                String text = target.getTextNormalize();
+                try {
+                    return Integer.valueOf(text);
+                } catch (NumberFormatException ex) {
+                    logger.severe("Invalid content for value element: "+text);
+                    // and return the default value from length
+                }
+            }
+            // otherwise, return default value of 0
+            return 0;
+        }
+
+        @Override
+        public String getButtonText() {
+            Element target = e.getChild("buttonText");
+            if (target != null) {
+                return target.getTextNormalize();
+            }
+            // otherwise, return empty value
+            return "";
+        }
+
+        @Override
+        public String getDialogText() {
+            Element target = e.getChild("dialogText");
+            if (target != null) {
+                return target.getTextNormalize();
+            }
+            // otherwise, return empty value
+            return "";
+        }
+
     }
 
     Element root;

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -102,12 +102,32 @@ public class JdomCdiRep implements CdiRep {
             for (int i = 0; i<elements.size(); i++) {
                 // some elements aren't contained items
                 Element element = (Element)elements.get(i);
-                if ("group".equals(element.getName())) list.add(new Group(element));
-                else if ("bit".equals(element.getName())) list.add(new BitRep(element));
-                else if ("int".equals(element.getName())) list.add(new IntRep(element));
-                else if ("eventid".equals(element.getName())) list.add(new EventID(element));
-                else if ("string".equals(element.getName())) list.add(new StringRep(element));
-                else if ("action".equals(element.getName())) list.add(new ActionButtonRep(element));
+                switch (element.getName()) {
+                    case "group":
+                        list.add(new Group(element));
+                        break;
+                    case "bit":
+                        list.add(new BitRep(element));
+                        break;
+                    case "int":
+                        list.add(new IntRep(element));
+                        break;
+                    case "eventid":
+                        list.add(new EventID(element));
+                        break;
+                    case "string":
+                        list.add(new StringRep(element));
+                        break;
+                    case "action":
+                        list.add(new ActionButtonRep(element));
+                        break;
+                    case "name":
+                    case "description":
+                        break;
+                    default:
+                        list.add(new UnknownRep(element));
+                        break;
+                }
             }
             return list;
         }
@@ -230,7 +250,6 @@ public class JdomCdiRep implements CdiRep {
         public int getIndexInParent() {
             return e.getParent().indexOf(e);
         }
-
     }
 
     public static class Group extends Nested implements CdiRep.Group {
@@ -424,6 +443,22 @@ public class JdomCdiRep implements CdiRep {
             } catch (org.jdom2.DataConversionException e) { return 1; }
         }
 
+    }
+
+    public static class UnknownRep extends Item implements CdiRep.UnknownRep {
+        UnknownRep(Element e) { super(e); }
+        
+        @Override
+        public boolean getDefault() { return false; }
+
+        @Override
+        public int getSize() { 
+            Attribute a = e.getAttribute("size");
+            try {
+                if (a == null) return 1;
+                else return a.getIntValue();
+            } catch (org.jdom2.DataConversionException e1) { return 0; }
+        }
     }
     
     public static class BitRep extends Item implements CdiRep.BitRep {

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -210,7 +210,19 @@ public class JdomCdiRep implements CdiRep {
             }
             return list;
         }
-        
+
+        public void addItemToMap(String key, String entry) {
+            Element relation = new Element("relation");
+            Element property = new Element("property");
+            Element value    = new Element("value");
+            
+            property.addContent(key);
+            value.addContent(entry);
+            relation.addContent(property);
+            relation.addContent(value);
+            map.addContent(relation);
+        }
+      
         Element map;
     }
 

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -121,6 +121,7 @@ public class JdomCdiRep implements CdiRep {
                     case "action":
                         list.add(new ActionButtonRep(element));
                         break;
+                    case "repname":
                     case "name":
                     case "description":
                         break;
@@ -467,7 +468,9 @@ public class JdomCdiRep implements CdiRep {
         public int getSize() { 
             Attribute a = e.getAttribute("size");
             try {
-                if (a == null) return 1;
+                // the `size` attribute is required to allocate space, so the 
+                // default value set here is zero
+                if (a == null) return 0;
                 else return a.getIntValue();
             } catch (org.jdom2.DataConversionException e1) { return 0; }
         }

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -2351,7 +2351,7 @@ public class CdiPanel extends JPanel {
 
     private class IntPane extends EntryPane {
         JTextField textField = null;
-        JComboBox box = null;
+        JComboBox<String> box = null;
         JSlider slider = null;
         CdiRep.Map map = null;
         private final ConfigRepresentation.IntegerEntry entry;
@@ -2446,12 +2446,15 @@ public class CdiPanel extends JPanel {
             if (box != null) { 
                 // check to see if item exists
                 box.setSelectedItem(value);
-                if (box.getSelectedItem() != value) {
-                    // need to add it
+                if (! box.getSelectedItem().equals(value)) {
+                    // not present per-se, see if need to add as reserved?
                     String newValue = "Reserved value: "+value;
-                    box.addItem(newValue);
                     box.setSelectedItem(newValue);
-                    map.addItemToMap(newValue, value);
+                    if ( ! box.getSelectedItem().equals(newValue)) {
+                        box.addItem(newValue);
+                        box.setSelectedItem(newValue);
+                        map.addItemToMap(newValue, value);
+                    }
                 }
             }
         }
@@ -2524,7 +2527,8 @@ public class CdiPanel extends JPanel {
         textAreaFont = new Font(Font.MONOSPACED, Font.PLAIN, size);
     }
     
-    private class StringPane extends EntryPane {
+    static final int MAX_SINGLE_LINE_ENTRY = 64; // somewhat arbitrary max length of single-line entry
+        private class StringPane extends EntryPane {
         JTextComponent textField;
         private final ConfigRepresentation.StringEntry entry;
 
@@ -2542,8 +2546,8 @@ public class CdiPanel extends JPanel {
                 }
             };
 
-            if (entry.size <= 64) { // somewhat arbitrary maximum length of single-line entry
-                            
+            if (entry.size <= MAX_SINGLE_LINE_ENTRY) { 
+                // This case is a single line in a JTextField
                 JTextField jtf = new JTextField(doc, "", entry.size-1) { // -1 for trailing zero
                     public Dimension getMaximumSize() {
                         return getPreferredSize();
@@ -2551,6 +2555,7 @@ public class CdiPanel extends JPanel {
                 };
                 jtf.setFont(textAreaFont);
                 jtf = factory.handleStringValue(jtf);
+                jtf.getDocument().putProperty("filterNewlines", Boolean.FALSE); // needed so 0x0A doesn't become space
                    
                 textField = jtf;
             } else {

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -2555,7 +2555,8 @@ public class CdiPanel extends JPanel {
         @Override
         protected void writeDisplayTextToNode() {
             if (entry.rep.getDialogText() == null || entry.rep.getDialogText().isEmpty()) {
-                entry.setValue(""+entry.rep.getValue());
+                entry.setValue((long)(entry.rep.getValue()));
+                System.out.println(entry.rep.getValue());
                 _changeMade = true;
                 notifyTabColorRefresh();
             } else {
@@ -2564,7 +2565,8 @@ public class CdiPanel extends JPanel {
                     entry.rep.getDialogText(),"",javax.swing.JOptionPane.OK_CANCEL_OPTION);
                 // if not OK, silently skip; if OK, act
                 if (result == 0) {
-                    entry.setValue(""+entry.rep.getValue());
+                    entry.setValue((long)(entry.rep.getValue()));
+                    System.out.println(entry.rep.getValue());
                     _changeMade = true;
                     notifyTabColorRefresh();
                 }

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -2443,7 +2443,17 @@ public class CdiPanel extends JPanel {
         protected void updateDisplayText(@NonNull String value) {
             if (textField != null) textField.setText(value);
             if (slider != null) slider.setValue(Integer.parseInt(value));
-            if (box != null) box.setSelectedItem(value);
+            if (box != null) { 
+                // check to see if item exists
+                box.setSelectedItem(value);
+                if (box.getSelectedItem() != value) {
+                    // need to add it
+                    String newValue = "Reserved value: "+value;
+                    box.addItem(newValue);
+                    box.setSelectedItem(newValue);
+                    map.addItemToMap(newValue, value);
+                }
+            }
         }
 
         @NonNull

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -2370,12 +2370,15 @@ public class CdiPanel extends JPanel {
                 if (entry.rep.isSliderHint()) {
                     // display a slider
                     slider = new JSlider((int)entry.rep.getMin(), (int)entry.rep.getMax());
-                    int divisionSpacing = 
-                        ((int)entry.rep.getMax()-(int)entry.rep.getMin())/entry.rep.getSliderDivisions();
-                    slider.setMajorTickSpacing(divisionSpacing);
-                    slider.setLabelTable(slider.createStandardLabels(divisionSpacing));
-                    slider.setPaintTicks(true);
-                    slider.setPaintLabels(true);
+                    if (entry.rep.getSliderDivisions() > 1) {
+                        // display divisions on the slider
+                        int divisionSpacing = 
+                            ((int)(entry.rep.getMax()-entry.rep.getMin()))/entry.rep.getSliderDivisions();
+                        slider.setMajorTickSpacing(divisionSpacing);
+                        slider.setLabelTable(slider.createStandardLabels(divisionSpacing));
+                        slider.setPaintTicks(true);
+                        slider.setPaintLabels(true);
+                    }
                     textComponent = slider;
                     if (entry.rep.getMin() < 0) {
                         slider.setToolTipText("Signed integer from "

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -1378,6 +1378,12 @@ public class CdiPanel extends JPanel {
         }
 
         @Override
+        public void visitUnknown(ConfigRepresentation.UnknownEntry e) {
+            currentLeaf = new UnknownPane(e);
+            super.visitUnknown(e);
+        }
+
+        @Override
         public void visitInt(ConfigRepresentation.IntegerEntry e) {
             currentLeaf = new IntPane(e);
             super.visitInt(e);
@@ -1990,7 +1996,8 @@ public class CdiPanel extends JPanel {
             });
             entry.fireUpdate();
 
-            if (! (textComponent instanceof JButton )) { // Buttons write themselves
+            if (! (textComponent instanceof JButton ) // Buttons write themselves
+                 && ! (textComponent instanceof JLabel ) ) { // labels don't need to write
                 JButton b;
                 b = factory.handleReadButton(new JButton("Refresh")); // was: read
                 b.addActionListener(new java.awt.event.ActionListener() {
@@ -2571,6 +2578,33 @@ public class CdiPanel extends JPanel {
         }
     }
 
+    private class UnknownPane extends EntryPane {
+        private final ConfigRepresentation.UnknownEntry entry;
+
+        UnknownPane(ConfigRepresentation.UnknownEntry e) {
+            super(e, "Unknown");
+            this.entry = e;
+
+            textComponent = new JLabel("Unknown Entry in the CDI Information");
+            textComponent.setToolTipText("Unknown element, perhaps from a later version of the CDI format?");
+            init();
+        }
+
+        @Override
+        protected void writeDisplayTextToNode() {
+        }
+
+        @Override
+        protected void updateDisplayText(@NonNull String value) {
+        }
+
+        @NonNull
+        @Override
+        protected String getDisplayText() {
+            return "Unknown Element";
+        }
+    }
+
     private class ActionButtonPane extends EntryPane {
         JButton actionButton;
         private final ConfigRepresentation.ActionButtonEntry entry;
@@ -2596,7 +2630,6 @@ public class CdiPanel extends JPanel {
         protected void writeDisplayTextToNode() {
             if (entry.rep.getDialogText() == null || entry.rep.getDialogText().isEmpty()) {
                 entry.setValue((long)(entry.rep.getValue()));
-                System.out.println(entry.rep.getValue());
                 _changeMade = true;
                 notifyTabColorRefresh();
             } else {


### PR DESCRIPTION
 - Implements the `<action>` element to (optionally) provide a button on the CD/CDI panel.
 - Implements display hints to recommend that a integer variable be displayed as a slider
 - Improve how out-of-range variable are displayed for integer maps
 - Fixes a bug in how short `<string>` variables containing 0x0A newline characters are handled

I'm also working on a `<blob>` element in overlapping code, so it would be good to get this merged when possible.