### PR TITLE
NodeSelector GUI improvements

### DIFF
--- a/test/org/openlcb/swing/NodeSelectorTest.java
+++ b/test/org/openlcb/swing/NodeSelectorTest.java
@@ -63,8 +63,8 @@ public class NodeSelectorTest  {
 
     String getAllItems() {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < nodeSelector.box.getItemCount(); ++i) {
-            sb.append(nodeSelector.box.getItemAt(i).toString());
+        for (int i = 0; i < nodeSelector.getItemCount(); ++i) {
+            sb.append(nodeSelector.getItemAt(i).toString());
             sb.append(';');
         }
         return sb.toString();


### PR DESCRIPTION
Resolves Issue JMRI/JMRI#13333 about GUI artifacts.  Also resolves similar artifacts in other places NodeSelector is used, e.g. the Send Frame Tool, Memory Tool, etc.

Note: This changes the API, so it will require a new release of OpenLCB_Java before it can be used by JMRI.