### PR TITLE
control files for 0.3.39

### DIFF
--- a/manifest
+++ b/manifest
@@ -7,6 +7,6 @@ Specification-Title: OpenLCB
 Specification-Version: 0.7.4
 Specification-Vendor: OpenLCB group
 Package-Title: openlcb
-Package-Version: 0.7.37
+Package-Version: 0.7.39
 Package-Vendor: OpenLCB group
  

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.openlcb</groupId>
     <artifactId>openlcb</artifactId>
     <packaging>jar</packaging>
-    <version>0.7.37</version>
+    <version>0.7.39</version>
     <name>OpenLCB</name>
     <description>OpenLCB Java Reference Implementation.</description>
     <url>http://openlcb.github.com/OpenLCB_Java</url>

--- a/src/org/openlcb/Version.java
+++ b/src/org/openlcb/Version.java
@@ -33,7 +33,7 @@ public class Version {
 
     /* Library modifier - updated periodically
      */
-    static final public int libMod = 37;
+    static final public int libMod = 39;
 
     /**
      * Checks if the current specification version is above a specific threshold.


### PR DESCRIPTION
This updates the manifest, Version.java and pom.xml files for the 0.3.39 release number.  

Once it's merged, that 0.3.39 release can be created.

(This is 0.3.39 instead of 0.3.38 because I'm not sure you can recreate a release with the same number, and moving forward one version sounds like a better approach)
