### PR TITLE
Add context menu to event ID selector

### DIFF
--- a/sample.xml
+++ b/sample.xml
@@ -28,6 +28,12 @@
         <blob size="10" mode="readwrite">
             <name>Blob to see if works in group element</name>
         </blob>
+        <float size="2">
+            <name>Float to see if works in group element</name>
+        </float>
+        <int size="4">
+            <name>Int of size 4 so that each group is 32 long</name>
+        </int>
     </group>
     <int size="2">
         <name>Sample integer variable</name>

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -2246,6 +2246,18 @@ public class CdiPanel extends JPanel {
             });
             addButtonToEventidMoreFunctions(bAS);
 
+            eventidMoreMenu.add(
+                EventIdTextField.makeWellKnownEventMenu(textField)
+            );
+            
+            eventidMoreMenu.add(
+                EventIdTextField.makeClockEventMenuItem(textField)
+            );
+            
+            eventidMoreMenu.add(
+                EventIdTextField.makeDccAccessoryEventMenuItem(textField)
+            );
+            
             p3.add(Box.createHorizontalStrut(5));
             addCopyPasteButtons(p3, textField);
             p3.add(Box.createHorizontalStrut(5));

--- a/src/org/openlcb/swing/EventIdTextField.java
+++ b/src/org/openlcb/swing/EventIdTextField.java
@@ -2,19 +2,45 @@
 
 package org.openlcb.swing;
 
+import java.awt.FlowLayout;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.ClipboardOwner;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.swing.JButton;
 import javax.swing.JComponent;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JFormattedTextField;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.TransferHandler;
+import javax.swing.text.DefaultEditorKit;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.MaskFormatter;
+
+import org.openlcb.EventID;
 
 /**
  * Text field for entry of forced-valid EventID string.
@@ -39,13 +65,219 @@ public class EventIdTextField extends JFormattedTextField  {
         retval.setValue("DD.DD.DD.DD.DD.DD.DD.DD");
         retval.setPreferredSize(retval.getPreferredSize());
         retval.setValue("00.00.00.00.00.00.00.00");
+        
         retval.setToolTipText("EventID as eight-byte dotted-hex string, "
-                + "e.g. 01.02.0A.AB.34.56.78.00");
+                + "e.g. 01.02.0A.AB.34.56.78.00 "
+                + "You can drag&drop or ctrl-click for more options");
+                
         retval.setDragEnabled(true);
         retval.setTransferHandler(new CustomTransferHandler());
         
+        configurePopUp(retval);
+
         return retval;
     }
+    
+    private static void configurePopUp(JFormattedTextField textfield) {
+                
+        // JMRI's apps.Apps.java line 330 adds cut/copy/paste to all JTextComponents
+        //  (Also serves as example of cut/copy/paste code)
+        
+        JPopupMenu popup = createPopupMenu(textfield);
+        //textfield.add(popup);
+        textfield.setComponentPopupMenu(popup);
+        textfield.setInheritsPopupMenu(false);
+    }
+    
+    private static void checkAndShowPopup(JFormattedTextField textfield, MouseEvent event) {
+        if ( event.isPopupTrigger() ) {
+            // user requested the popup menu
+            JPopupMenu popup = createPopupMenu(textfield);
+            popup.show(textfield, event.getX(), event.getY());
+        }
+    }
+    
+    private static JPopupMenu createPopupMenu(JFormattedTextField textfield) {
+        JPopupMenu popup = new JPopupMenu();
+        
+        // add the usual copy and paste operators
+        // TODO: see CdiPanel line 1633 for how to properly copy and paste
+        
+        JMenuItem menuItem = new JMenuItem("Copy");
+        popup.add(menuItem);
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                String s = textfield.getText();
+                SwingUtilities.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        textfield.selectAll();
+                    }
+                });
+                StringSelection eventToCopy = new StringSelection(s);
+                Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                clipboard.setContents(eventToCopy, new ClipboardOwner() {
+                    @Override
+                    public void lostOwnership(Clipboard clipboard, Transferable transferable) {
+                    }
+                });
+            }
+        });
+
+        menuItem = new JMenuItem("Paste");
+        popup.add(menuItem);
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                Clipboard systemClipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                DataFlavor dataFlavor = DataFlavor.stringFlavor;
+
+                Object text = null;
+                try {
+                    text = systemClipboard.getData(dataFlavor);
+                } catch (UnsupportedFlavorException | IOException e1) {
+                    return;
+                }
+                String pasteValue = (String) text;
+                if (pasteValue != null) {
+                    textfield.setText(pasteValue);
+                }
+            }
+        });
+             
+        // create a submenu for well-known events
+        JMenu wkeMenu = new JMenu("Insert well-known event");
+        popup.add(wkeMenu);
+        wkeMenu.add(new EventIdInserter(
+            "Emergency off (de-energize)",           "01.00.00.00.05.00.FF.FF", textfield));
+        wkeMenu.add(new EventIdInserter(
+            "Clear emergency off (energize)",        "01.00.00.00.00.00.FF.FE", textfield));
+        wkeMenu.add(new EventIdInserter(
+            "Emergency stop of all operations",      "01.00.00.00.05.00.FF.FD", textfield));
+        wkeMenu.add(new EventIdInserter(
+            "Clear emergency stop of all operations","01.00.00.00.00.00.FF.FC", textfield));
+        
+        // Add the time events
+        menuItem = new JMenuItem("Clock event...");
+        popup.add(menuItem);
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                JDialog dialog = new JDialog();
+                dialog.setTitle("Select Clock Settings");
+
+                JPanel innerPanel = new JPanel(new FlowLayout());
+                JComboBox<String> clockBox = new JComboBox<String>(
+                        new String[]{
+                            "Default Fast Clock",
+                            "Default Real-Time Clock",
+                            "Alternate Clock 1",
+                            "Alternate Clock 2"
+                });
+                innerPanel.add(clockBox);
+                util.com.toedter.calendar.JHourMinuteChooser chooser = new util.com.toedter.calendar.JHourMinuteChooser();
+                innerPanel.add(chooser);
+                JButton setButton = new JButton("Set");
+                innerPanel.add(setButton);
+                setButton.addActionListener(new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        String prefix = "01.01.00.00.01.0"+clockBox.getSelectedIndex();
+                        int minute = Integer.parseInt(chooser.getMinute());
+                        int hour = Integer.parseInt(chooser.getHour());
+                        if (! chooser.getMeridian().equals("AM")) hour = hour+12;
+                        textfield.setText(prefix+String.format(".%02X.%02X", hour, minute));
+                        dialog.dispatchEvent(new WindowEvent(dialog, WindowEvent.WINDOW_CLOSING));
+                    }
+                });
+        
+                dialog.add(innerPanel);
+                dialog.setModal(true);
+                dialog.pack();
+                dialog.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        
+                dialog.setVisible(true);
+            }
+        });
+
+        // Add the accessory decoder events
+        menuItem = new JMenuItem("DCC accessory decoder events ...");
+        popup.add(menuItem);
+        menuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                JDialog dialog = new JDialog();
+                dialog.setTitle("Select DCC Accessory Decoder");
+
+                JPanel innerPanel = new JPanel(new FlowLayout());
+
+                JTextField number = new JTextField(12);
+                number.setText("1");
+                innerPanel.add(number);
+
+                JComboBox<String> onOffBox = new JComboBox<String>(
+                        new String[]{
+                            "Reversed/Inactive/Off",
+                            "Normal/Active/On"
+                });
+                innerPanel.add(onOffBox);
+
+                JButton setButton = new JButton("Set");
+                innerPanel.add(setButton);
+                setButton.addActionListener(new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        int from = Integer.parseInt(number.getText().strip());
+                        
+                        // See JMRI OlcnAddress line 89 for Event ID coding
+                        int DD = (from-1) & 0x3;
+                        int aaaaaa = (( (from-1) >> 2)+1 ) & 0x3F;
+                        int AAA = ( (from) >> 8) & 0x7;
+                        long event = 0x0101020000FF0000L | (AAA << 9) | (aaaaaa << 3) | (DD << 1);
+                        event |= onOffBox.getSelectedIndex();
+ 
+                        EventID id = new EventID(String.format("%016X", event));
+                        textfield.setText(id.toShortString());
+                        dialog.dispatchEvent(new WindowEvent(dialog, WindowEvent.WINDOW_CLOSING));
+                    }
+                });
+        
+                dialog.add(innerPanel);
+                dialog.setModal(true);
+                dialog.pack();
+                dialog.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        
+                dialog.setVisible(true);
+            }
+        });
+
+        
+        // popup.add("Extended DCC accessory decoder events ...");
+        // popup.add("DCC turnout feedback events ...");
+        // popup.add("DCC system sensor feedback events ...");
+        
+        return popup;
+    }
+    
+    private static class EventIdInserter extends JMenuItem {
+        public EventIdInserter(String name, String value, JFormattedTextField target) {
+            super(name);
+            this.value = value;
+            this.target = target;
+            
+            addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    target.setText(value);
+                }
+            });
+        }
+        final String value;
+        final JFormattedTextField target;
+        
+    }
+    
     
     private static MaskFormatter createFormatter(String s) {
         MaskFormatter formatter = null;

--- a/src/org/openlcb/swing/EventIdTextField.java
+++ b/src/org/openlcb/swing/EventIdTextField.java
@@ -147,8 +147,23 @@ public class EventIdTextField extends JFormattedTextField  {
         });
              
         // create a submenu for well-known events
+        popup.add(makeWellKnownEventMenu(textfield));
+        
+        // Add the time events
+        popup.add( makeClockEventMenuItem(textfield));
+
+        // Add the accessory decoder events
+        popup.add(makeDccAccessoryEventMenuItem(textfield));
+        
+        // popup.add("Extended DCC accessory decoder events ...");
+        // popup.add("DCC turnout feedback events ...");
+        // popup.add("DCC system sensor feedback events ...");
+        
+        return popup;
+    }
+    
+    public static JMenu makeWellKnownEventMenu(JFormattedTextField textfield) {
         JMenu wkeMenu = new JMenu("Insert well-known event");
-        popup.add(wkeMenu);
         wkeMenu.add(new EventIdInserter(
             "Emergency off (de-energize)",           "01.00.00.00.05.00.FF.FF", textfield));
         wkeMenu.add(new EventIdInserter(
@@ -157,10 +172,11 @@ public class EventIdTextField extends JFormattedTextField  {
             "Emergency stop of all operations",      "01.00.00.00.05.00.FF.FD", textfield));
         wkeMenu.add(new EventIdInserter(
             "Clear emergency stop of all operations","01.00.00.00.00.00.FF.FC", textfield));
-        
-        // Add the time events
-        menuItem = new JMenuItem("Clock event...");
-        popup.add(menuItem);
+        return wkeMenu;
+    }
+    
+    public static JMenuItem makeClockEventMenuItem(JFormattedTextField textfield) {
+        JMenuItem menuItem = new JMenuItem("Insert Clock event...");
         menuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -200,10 +216,11 @@ public class EventIdTextField extends JFormattedTextField  {
                 dialog.setVisible(true);
             }
         });
+        return menuItem;
+    }
 
-        // Add the accessory decoder events
-        menuItem = new JMenuItem("DCC accessory decoder events ...");
-        popup.add(menuItem);
+    public static JMenuItem makeDccAccessoryEventMenuItem(JFormattedTextField textfield) {
+        JMenuItem menuItem = new JMenuItem("Insert DCC accessory decoder events ...");
         menuItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -251,15 +268,9 @@ public class EventIdTextField extends JFormattedTextField  {
                 dialog.setVisible(true);
             }
         });
-
-        
-        // popup.add("Extended DCC accessory decoder events ...");
-        // popup.add("DCC turnout feedback events ...");
-        // popup.add("DCC system sensor feedback events ...");
-        
-        return popup;
+        return menuItem;
     }
-    
+  
     private static class EventIdInserter extends JMenuItem {
         public EventIdInserter(String name, String value, JFormattedTextField target) {
             super(name);

--- a/src/org/openlcb/swing/EventIdTextField.java
+++ b/src/org/openlcb/swing/EventIdTextField.java
@@ -100,9 +100,7 @@ public class EventIdTextField extends JFormattedTextField  {
     private static JPopupMenu createPopupMenu(JFormattedTextField textfield) {
         JPopupMenu popup = new JPopupMenu();
         
-        // add the usual copy and paste operators
-        // TODO: see CdiPanel line 1633 for how to properly copy and paste
-        
+        // add the usual copy and paste operators        
         JMenuItem menuItem = new JMenuItem("Copy");
         popup.add(menuItem);
         menuItem.addActionListener(new ActionListener() {

--- a/src/org/openlcb/swing/EventIdTextField.java
+++ b/src/org/openlcb/swing/EventIdTextField.java
@@ -228,7 +228,7 @@ public class EventIdTextField extends JFormattedTextField  {
                 setButton.addActionListener(new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        int from = Integer.parseInt(number.getText().strip());
+                        int from = Integer.parseInt(number.getText().trim());
                         
                         // See JMRI OlcnAddress line 89 for Event ID coding
                         int DD = (from-1) & 0x3;

--- a/src/org/openlcb/swing/EventIdTextField.java
+++ b/src/org/openlcb/swing/EventIdTextField.java
@@ -166,10 +166,17 @@ public class EventIdTextField extends JFormattedTextField  {
             "Emergency off (de-energize)",           "01.00.00.00.05.00.FF.FF", textfield));
         wkeMenu.add(new EventIdInserter(
             "Clear emergency off (energize)",        "01.00.00.00.00.00.FF.FE", textfield));
+
         wkeMenu.add(new EventIdInserter(
             "Emergency stop of all operations",      "01.00.00.00.05.00.FF.FD", textfield));
         wkeMenu.add(new EventIdInserter(
             "Clear emergency stop of all operations","01.00.00.00.00.00.FF.FC", textfield));
+
+        wkeMenu.add(new EventIdInserter(
+            "Start Default Fast Clock",              "01.01.00.00.01.00.F0.02", textfield));
+        wkeMenu.add(new EventIdInserter(
+            "Stop Default Fast Clock",               "01.01.00.00.01.00.F0.01", textfield));
+            
         return wkeMenu;
     }
     

--- a/src/util/com/toedter/calendar/JHourMinuteChooser.java
+++ b/src/util/com/toedter/calendar/JHourMinuteChooser.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2019 Ruslan Lopez Carro.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+ 
+// from https://github.com/javatlacati/jcalendar/blob/master/jcalendar/src/main/java/com/toedter/calendar/JHourMinuteChooser.java
+
+package util.com.toedter.calendar;
+
+import java.text.DecimalFormat;
+import java.util.Date;
+import java.util.logging.Logger;
+
+/**
+ *
+ * @author Ruslan López Carro
+ */
+public final class JHourMinuteChooser extends javax.swing.JPanel {
+
+    private Date currentTime;
+    private static final Logger LOGGER = Logger.getLogger(JHourMinuteChooser.class.getName());
+    // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JSpinner hourSpin;
+    private javax.swing.JSpinner meridianSpin;
+    private javax.swing.JSpinner minuteSpin;
+    // End of variables declaration//GEN-END:variables
+
+
+    /**
+     * Creates a Hour and Minute Chooser with the specified values.
+     *
+     * @param hour 24 hour format hour
+     * @param minute minutes
+     */
+    public JHourMinuteChooser(int hour, int minute) {
+        setName("JHourMinuteChooser");
+        initComponents();
+        currentTime = new Date();
+        currentTime.setHours(hour);
+        currentTime.setMinutes(minute);
+        updateCurrentTimeInGUI();
+    }
+
+    /**
+     * Creates a Hour and Minute Chooser with the current time set.
+     */
+    public JHourMinuteChooser() {
+        setName("JHourMinuteChooser");
+        initComponents();
+        setCurrentTime();
+    }
+
+    @Override
+    public void setEnabled(boolean enable) {
+        hourSpin.setEnabled(enable);
+        minuteSpin.setEnabled(enable);
+        meridianSpin.setEnabled(enable);
+    }
+
+    public void setCurrentTime() {
+        currentTime = new Date();
+        updateCurrentTimeInGUI();
+    }
+
+    public void setTimeFromString(String toBeParsed){
+        if(toBeParsed.matches("\\d{1,2}\\s*\\:\\s*\\d{2}\\s+[AP]M")){
+            String[] splitted = toBeParsed.split("\\:");
+            currentTime = new Date();
+            int hour=Integer.parseInt(splitted[0]);
+            if("PM".equals(splitted[2])){
+                hour+=12;
+            }
+            currentTime.setHours(hour);
+            int minutes=Integer.parseInt(splitted[1]);
+            currentTime.setMinutes(minutes);
+        }
+        updateCurrentTimeInGUI();
+    }
+
+    private void updateCurrentTimeInGUI() {
+        LOGGER.finest(currentTime.toString());
+        if (currentTime.getHours() >= 0 && currentTime.getHours() < 12) {
+            if (currentTime.getHours() == 0) {
+                hourSpin.setValue(12);
+            } else {
+                hourSpin.setValue(currentTime.getHours());
+            }
+            meridianSpin.setValue("AM");
+        } else if (currentTime.getHours() >= 12 && currentTime.getHours() <= 23) {
+            if (currentTime.getHours() == 12) {
+                hourSpin.setValue(12);
+            } else {
+                hourSpin.setValue(currentTime.getHours() - 12);
+            }
+            meridianSpin.setValue("PM");
+        }
+
+        // System.out.println("minutes"+currentTime.getMinutes());
+        minuteSpin.setValue(numberFormat(currentTime.getMinutes(), "##"));
+    }
+
+    public static String numberFormat(long src, String fmt) {//Format : ###.####
+        DecimalFormat df = new DecimalFormat(fmt.replaceAll("#", "0"));
+        return df.format(src);
+    }
+
+    public String getHour() {
+        return numberFormat(Integer.parseInt(hourSpin.getValue().toString().trim()), "##");
+    }
+
+    public String getMinute() {
+        return numberFormat(Integer.parseInt(minuteSpin.getValue().toString().trim()), "##");
+    }
+
+    public String getMeridian() {
+        return meridianSpin.getValue().toString();
+    }
+
+    public String getTime() {
+        return numberFormat(Integer.parseInt(hourSpin.getValue().toString().trim()), "##") + ":" + numberFormat(Integer.parseInt(minuteSpin.getValue().toString().trim()), "##") + " " + meridianSpin.getValue().toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
+    private void initComponents() {
+
+        hourSpin = new javax.swing.JSpinner();
+        minuteSpin = new javax.swing.JSpinner();
+        meridianSpin = new javax.swing.JSpinner();
+
+        setLayout(new java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 3, 0));
+
+        hourSpin.setFont(new java.awt.Font("Tahoma", 1, 11)); // NOI18N
+        hourSpin.setModel(new javax.swing.SpinnerNumberModel(1, 1, 12, 1));
+        add(hourSpin);
+
+        minuteSpin.setFont(new java.awt.Font("Tahoma", 1, 11)); // NOI18N
+        minuteSpin.setModel(new javax.swing.SpinnerListModel(new String[] {"00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59"}));
+        add(minuteSpin);
+
+        meridianSpin.setFont(new java.awt.Font("Tahoma", 1, 11)); // NOI18N
+        meridianSpin.setModel(new javax.swing.SpinnerListModel(new String[] {"AM", "PM"}));
+        add(meridianSpin);
+    }// </editor-fold>//GEN-END:initComponents
+
+
+    public Date getCurrentTime() {
+        return new Date(currentTime.getTime());
+    }
+}


### PR DESCRIPTION
Adds a context menu to the Event ID selector that allows you to 
  - select a well-known event to include
  - define a time-of-day event
  - define a DCC accessory decoder event

These are also added under the "More..." button on event ID entries in the CDI window.