### PR TITLE
Fix immediate CDI slider; Switch to tickSpacing attribute for CDI sliders

### DIFF
--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -100,7 +100,7 @@ public interface CdiRep {
         public boolean isSliderHint();
         // Does the slider itself immediately write its value on change?
         public boolean isSliderImmediate();
-        public int getSliderDivisions();
+        public int getSliderTickSpacing();
     }
 
     public static interface BitRep extends Item {

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -456,16 +456,16 @@ public class JdomCdiRep implements CdiRep {
         }
 
         @Override
-        public int getSliderDivisions() {
+        public int getSliderTickSpacing() {
             Element hints = e.getChild("hints");
-            if (hints == null) return 1;
+            if (hints == null) return 0;
             Element slider = hints.getChild("slider");
-            if (slider == null) return 1;
-            Attribute divisions = slider.getAttribute("divisions");
-            if (divisions == null) return 1;
+            if (slider == null) return 0;
+            Attribute tickSpacing = slider.getAttribute("tickSpacing");
+            if (tickSpacing == null) return 0;
             try { 
-                return divisions.getIntValue();
-            } catch (org.jdom2.DataConversionException e) { return 1; }
+                return tickSpacing.getIntValue();
+            } catch (org.jdom2.DataConversionException e) { return 0; }
         }
 
     }

--- a/src/org/openlcb/implementations/DatagramService.java
+++ b/src/org/openlcb/implementations/DatagramService.java
@@ -67,7 +67,7 @@ public class DatagramService extends MessageDecoder {
      */
     public void sendData(DatagramServiceTransmitMemo memo) {
         if (xmtMemo != null) {
-            logger.log(Level.SEVERE, "Overriding datagram transmit memo. old {0} new {1}", new Object[]{xmtMemo, memo}); //log
+            logger.log(Level.SEVERE, "Overriding datagram transmit memo. old {0} new {1}", new Object[]{xmtMemo, memo});
         }
         xmtMemo = memo;
         Message m = new DatagramMessage(here, memo.dest, memo.data);


### PR DESCRIPTION
 - fix the crash when immediate CDI slider is initializing
 - Change from a `divisions` attribute to a `tickSpacing` attribute for slider hints