### PR TITLE
Add control for visibility of groups in CDI display

### DIFF
--- a/sample.xml
+++ b/sample.xml
@@ -16,7 +16,7 @@
 
 <segment origin="0" space="0">
     <link ref="http://openlcb.org">Link to OpenLCB.org documentation</link>
-    <group offset="0" replication="2">
+    <group replication="2">
         <name>Produced Events</name>
         <description>The EventIDs for the producers</description>
         <link ref="http://openlcb.org">Link to OpenLCB.org documentation</link>
@@ -26,8 +26,23 @@
         </hints>
         <eventid/>
         <eventid/>
+        <int size="2"/>
+        <int size="2">
+            <min>1</min>
+            <max>250</max>
+            <default>12</default>
+            <hints>
+                <slider tickSpacing="50" showValue="true"/>
+            </hints>
+        </int>
+        <float size="4"/>
+        <string size="5">
+            <name>Status Field</name>
+            <description>As first string, this content will appear in the tab</description>
+        </string>
+        <string size="100"/>
     </group>
-    <group replication="2">
+    <group offset="0" replication="2">
         <name>Consumed Events</name>
         <description>The EventIDs for the consumers</description>
         <hints>
@@ -137,10 +152,13 @@
             Board must be restarted for this to take effect.
         </description>
         <map>
-            <relation><property>0</property><value>No reset (0)</value></relation>
+            <relation><property>10</property><value>No reset (10)</value></relation>
             <relation><property>85</property><value>Reset just EventIDs to defaults (85)</value></relation>
             <relation><property>170</property><value>Reset all to defaults (170)</value></relation>
         </map>
+        <hints>
+            <radiobutton/>
+        </hints>
     </int>
     <int size="1" offset="-1">
         <name>Reset Directly</name>

--- a/sample.xml
+++ b/sample.xml
@@ -17,23 +17,50 @@
     <group offset="0" replication="2">
         <name>Produced Events</name>
         <description>The EventIDs for the producers</description>
+        <hints>
+        <visibility hideable="yes" hidden="yes" />
+        </hints>
         <eventid/>
         <eventid/>
     </group>
     <group replication="2">
         <name>Consumed Events</name>
         <description>The EventIDs for the consumers</description>
+        <hints>
+        <visibility hideable="yes" hidden="yes" />
+        </hints>
         <eventid/>
         <eventid/>
         <blob size="10" mode="readwrite">
             <name>Blob to see if works in group element</name>
         </blob>
-        <float size="2">
+        <float size="8">
             <name>Float to see if works in group element</name>
         </float>
         <int size="4">
             <name>Int of size 4 so that each group is 32 long</name>
         </int>
+        <group collapsible="yes">
+            <name>Hideable and Hidden Nested Group</name>
+            <hints>
+            <visibility hideable="yes" hidden="true" />
+            </hints>
+            <eventid/>
+            <eventid/>
+        </group>
+        <group collapsible="yes">
+            <name>Hideable and Not Hidden Nested Group</name>
+            <hints>
+            <visibility hideable="yes" hidden="no" />
+            </hints>
+            <eventid/>
+            <eventid/>
+        </group>
+        <group>
+            <name>Non-hideable Nested Group</name>
+            <eventid/>
+            <eventid/>
+        </group>
     </group>
     <int size="2">
         <name>Sample integer variable</name>
@@ -42,14 +69,28 @@
         <max>999</max>
         <default>12</default>
     </int>
+    <float size="2">
+        <name>Sample float variable</name>
+        <description>Doesn't do anything</description>
+        <min>1</min>
+        <max>999</max>
+        <default>12</default>
+    </float>
+    <float size="2" offset="-2">
+        <name>Same float variable</name>
+        <description>Overlaps previous</description>
+        <min>0</min>
+        <max>10000</max>
+        <default>12</default>
+    </float>
     <int size="2">
         <name>Sample integer slider</name>
         <description>Doesn't do anything either</description>
-        <min>0</min>
-        <max>1000</max>
+        <min>1</min>
+        <max>250</max>
         <default>12</default>
         <hints>
-            <slider divisions="5" />
+            <slider tickSpacing="50" />
         </hints>
     </int>
     <int size="2">
@@ -59,9 +100,33 @@
         <max>1000</max>
         <default>12</default>
         <hints>
-            <slider divisions="5" immediate="yes" />
+            <slider tickSpacing="200" immediate="yes" />
         </hints>
     </int>
+</segment>
+
+<segment origin="400" space="12">
+    <name>Sample Single Group</name>
+      <group replication='1'>\n\
+        <hints>
+        <visibility hideable="yes" hidden="yes" />
+        </hints>
+        <int size='2'>\n\
+          <name>Output On Period</name>\n\
+        </int>\n\
+        <int size='2'>\n\
+          <name>Output Off Period</name>\n\
+        </int>\n\
+        <int size='1'>\n\
+          <name>Units</name>\n\
+          <default>"xstr(UNITS_DEFAULT)"</default>\n\
+          <map>\n\
+            <relation><property>"xstr(UNITS_MS)"</property><value>Milliseconds (ms)</value></relation>\n\
+            <relation><property>"xstr(UNITS_S)"</property><value>Seconds (s)</value></relation>\n\
+            <relation><property>"xstr(UNITS_M)"</property><value>Minutes (m)</value></relation>\n\
+          </map>\n\
+        </int>\n\
+      </group>\n\
 </segment>
 
 <segment origin="128" space="1">

--- a/sample.xml
+++ b/sample.xml
@@ -8,17 +8,21 @@
     <model>Model 123 Uniblab</model>
     <hardwareVersion>EC 415</hardwareVersion>
     <softwareVersion>1.2.3.4</softwareVersion>
+    <link ref="http://openlcb.org">Link to OpenLCB.org documentation</link>
     <map>
         <relation><property>Size</property><value>8 cm by 12 cm</value></relation>
     </map>
 </identification>
 
 <segment origin="0" space="0">
+    <link ref="http://openlcb.org">Link to OpenLCB.org documentation</link>
     <group offset="0" replication="2">
         <name>Produced Events</name>
         <description>The EventIDs for the producers</description>
+        <link ref="http://openlcb.org">Link to OpenLCB.org documentation</link>
         <hints>
-        <visibility hideable="yes" hidden="yes" />
+            <visibility hideable="yes" hidden="yes" />
+            <readOnly />
         </hints>
         <eventid/>
         <eventid/>
@@ -27,7 +31,7 @@
         <name>Consumed Events</name>
         <description>The EventIDs for the consumers</description>
         <hints>
-        <visibility hideable="yes" hidden="yes" />
+            <visibility hideable="yes" hidden="yes" />
         </hints>
         <eventid/>
         <eventid/>
@@ -40,18 +44,18 @@
         <int size="4">
             <name>Int of size 4 so that each group is 32 long</name>
         </int>
-        <group collapsible="yes">
+        <group>
             <name>Hideable and Hidden Nested Group</name>
             <hints>
-            <visibility hideable="yes" hidden="true" />
+                <visibility hideable="yes" hidden="true" />
             </hints>
             <eventid/>
             <eventid/>
         </group>
-        <group collapsible="yes">
+        <group>
             <name>Hideable and Not Hidden Nested Group</name>
             <hints>
-            <visibility hideable="yes" hidden="no" />
+                <visibility hideable="yes" hidden="no" />
             </hints>
             <eventid/>
             <eventid/>
@@ -103,30 +107,6 @@
             <slider tickSpacing="200" immediate="yes" />
         </hints>
     </int>
-</segment>
-
-<segment origin="400" space="12">
-    <name>Sample Single Group</name>
-      <group replication='1'>\n\
-        <hints>
-        <visibility hideable="yes" hidden="yes" />
-        </hints>
-        <int size='2'>\n\
-          <name>Output On Period</name>\n\
-        </int>\n\
-        <int size='2'>\n\
-          <name>Output Off Period</name>\n\
-        </int>\n\
-        <int size='1'>\n\
-          <name>Units</name>\n\
-          <default>"xstr(UNITS_DEFAULT)"</default>\n\
-          <map>\n\
-            <relation><property>"xstr(UNITS_MS)"</property><value>Milliseconds (ms)</value></relation>\n\
-            <relation><property>"xstr(UNITS_S)"</property><value>Seconds (s)</value></relation>\n\
-            <relation><property>"xstr(UNITS_M)"</property><value>Minutes (m)</value></relation>\n\
-          </map>\n\
-        </int>\n\
-      </group>\n\
 </segment>
 
 <segment origin="128" space="1">

--- a/sample.xml
+++ b/sample.xml
@@ -94,7 +94,7 @@
         <max>250</max>
         <default>12</default>
         <hints>
-            <slider tickSpacing="50" />
+            <slider tickSpacing="50"/>
         </hints>
     </int>
     <int size="2">
@@ -104,7 +104,27 @@
         <max>1000</max>
         <default>12</default>
         <hints>
-            <slider tickSpacing="200" immediate="yes" />
+            <slider tickSpacing="200" immediate="yes"/>
+        </hints>
+    </int>
+    <int size="2">
+        <name>Sample integer slider with view</name>
+        <description>And another</description>
+        <min>1</min>
+        <max>250</max>
+        <default>12</default>
+        <hints>
+            <slider tickSpacing="50" showValue="true"/>
+        </hints>
+    </int>
+    <int size="2">
+        <name>Immediate-write integer slider with view</name>
+        <description>You guessed it!</description>
+        <min>0</min>
+        <max>1000</max>
+        <default>12</default>
+        <hints>
+            <slider tickSpacing="200" immediate="yes" showValue="1"/>
         </hints>
     </int>
 </segment>

--- a/src/org/openlcb/ProducerConsumerEventReportMessage.java
+++ b/src/org/openlcb/ProducerConsumerEventReportMessage.java
@@ -88,9 +88,19 @@ public class ProducerConsumerEventReportMessage extends EventMessage {
     
     @Override
     public String toString() {
-        return super.toString()
-                +" Producer/Consumer Event Report  "+eventID.toString()
-                +" payload of "+getPayloadSize();     
+        String retval = " Producer/Consumer Event Report  "+eventID.toString();
+        
+        if ( getPayloadSize() > 0 ) {
+            retval = retval + " payload of "+getPayloadSize()+" : ";
+            int n = getPayloadSize();
+            boolean first = true;
+            for (byte data : payload) {
+                if (!first) retval = retval + ".";
+                retval = retval + Integer.toHexString((int)(data&0xFF)).toUpperCase();
+                first = false;
+            }
+        }
+        return retval;    
     }
     
     public boolean equals(Object o) {

--- a/src/org/openlcb/ProtocolIdentification.java
+++ b/src/org/openlcb/ProtocolIdentification.java
@@ -105,7 +105,7 @@ public class ProtocolIdentification {
      * @param protocol enum representing the protocol bit to test
      * @return true if protocol is supported, false otherwise.
      */
-    boolean hasProtocol(Protocol protocol) {
+    public boolean hasProtocol(Protocol protocol) {
         return protocol.supports(value);
     }
 }

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -115,6 +115,8 @@ public interface CdiRep {
         public int getSliderTickSpacing();
         // Optionally specifies if the slider value should be shown in text box
         public boolean isSliderShowValue();
+        // Did the CDI content hint that this value should be presented as a radio button?
+        public boolean isRadioButtonHint();
     }
 
     public static interface FloatRep extends Item {

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -15,6 +15,8 @@ public interface CdiRep {
         public String getModel();
         public String getHardwareVersion();
         public String getSoftwareVersion();
+        public String getLinkText();
+        public String getLinkURL();
         public Map getMap();
     }
 
@@ -29,6 +31,8 @@ public interface CdiRep {
 
         public String getName();
         public String getDescription();
+        public String getLinkText();
+        public String getLinkURL();
         public Map getMap();
         public int getIndexInParent();
     }
@@ -44,9 +48,12 @@ public interface CdiRep {
     public static interface Group extends Item {
         public java.util.List<Item> getItems();
         public int getReplication();
+        public String getLinkText();
+        public String getLinkURL();
         public String getRepName(int index, int replications);
         public boolean isHideable();
         public boolean isHidden();
+        public boolean isReadOnly();
     }
 
     public static interface Map {

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -45,6 +45,8 @@ public interface CdiRep {
         public java.util.List<Item> getItems();
         public int getReplication();
         public String getRepName(int index, int replications);
+        public boolean isHideable();
+        public boolean isHidden();
     }
 
     public static interface Map {

--- a/src/org/openlcb/cdi/CdiRep.java
+++ b/src/org/openlcb/cdi/CdiRep.java
@@ -111,8 +111,10 @@ public interface CdiRep {
         // Should the slider itself immediately write its value on change?
         public boolean isSliderImmediate();
         // Optionally specifies the 'distance' between tick marks on the slider.
-        // If 0 (default value), don't show tick marks.
+        // If 0 (default value) or 1, don't show tick marks.
         public int getSliderTickSpacing();
+        // Optionally specifies if the slider value should be shown in text box
+        public boolean isSliderShowValue();
     }
 
     public static interface FloatRep extends Item {

--- a/src/org/openlcb/cdi/impl/ConfigRepresentation.java
+++ b/src/org/openlcb/cdi/impl/ConfigRepresentation.java
@@ -574,6 +574,15 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
                 }
             }
         }
+        
+        public boolean isHideable() {
+            return group.isHideable();
+        }
+
+        public boolean isHidden() {
+            return group.isHidden();
+        }
+
     }
 
     /**

--- a/src/org/openlcb/cdi/impl/ConfigRepresentation.java
+++ b/src/org/openlcb/cdi/impl/ConfigRepresentation.java
@@ -412,6 +412,10 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
             MemorySpaceCache cache = getCacheForSpace(space);
             cache.reload(origin, size, isNullTerminated());
         }
+        
+        boolean flaggedReadOnly = false;
+        public boolean isFlaggedReadOnly() { return flaggedReadOnly; }
+        public void setFlaggedReadOnly(boolean state) {flaggedReadOnly = state; }
     }
 
     public class Root implements CdiContainer {
@@ -583,6 +587,12 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
             return group.isHidden();
         }
 
+        /**
+         * Does this entry carry the readOnly hint?
+         */
+        public boolean isReadOnlyConfigured() {
+            return group.isReadOnly();
+        }
     }
 
     /**

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import org.jdom2.Attribute;
+import org.jdom2.DataConversionException;
 import org.jdom2.Element;
 import org.openlcb.cdi.CdiRep;
 
@@ -287,6 +288,38 @@ public class JdomCdiRep implements CdiRep {
                 if (a == null) return 0;
                 else return a.getIntValue();
             } catch (org.jdom2.DataConversionException e1) { return 0; }
+        }
+
+        public boolean isHideable() {
+            // defaults to false
+            Element hints = e.getChild("hints");
+            if (hints == null) return false;
+            Element visibility = hints.getChild("visibility");
+            if (visibility == null) return false;
+            Attribute a = visibility.getAttribute("hideable");
+            if (a == null) return false;
+            try {
+                boolean value = a.getBooleanValue();
+                return value;
+            } catch (DataConversionException ex) {
+                return false;
+            }
+        }
+
+        public boolean isHidden() {
+            // defaults to false
+            Element hints = e.getChild("hints");
+            if (hints == null) return false;
+            Element visibility = hints.getChild("visibility");
+            if (visibility == null) return false;
+            Attribute a = visibility.getAttribute("hidden");
+            if (a == null) return false;
+            try {
+                boolean value = a.getBooleanValue();
+                return value;
+            } catch (DataConversionException ex) {
+                return false;
+            }
         }
 
         /**

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -51,6 +51,22 @@ public class JdomCdiRep implements CdiRep {
         }
 
         @Override
+        public String getLinkText() {
+            Element c = id.getChild("link");
+            if (c == null) return null;
+            return c.getText();
+        }
+
+        @Override
+        public String getLinkURL() {
+            Element c = id.getChild("link");
+            if (c == null) return null;
+            Attribute a = c.getAttribute("ref");
+            if (a == null) return null;
+            return a.getValue();
+        }
+
+        @Override
         public Map getMap() {
             return new Map(id.getChild("map"));
         }
@@ -128,6 +144,7 @@ public class JdomCdiRep implements CdiRep {
                     case "repname":
                     case "name":
                     case "description":
+                    case "link":
                     case "hints":
                         break;
                     default:
@@ -166,6 +183,23 @@ public class JdomCdiRep implements CdiRep {
                 else return a.getIntValue();
             } catch (org.jdom2.DataConversionException e1) { return 0; }
         }
+
+        @Override
+        public String getLinkText() {
+            Element c = e.getChild("link");
+            if (c == null) return null;
+            return c.getText();
+        }
+
+        @Override
+        public String getLinkURL() {
+            Element c = e.getChild("link");
+            if (c == null) return null;
+            Attribute a = c.getAttribute("ref");
+            if (a == null) return null;
+            return a.getValue();
+        }
+
     }
 
     public static class Map implements CdiRep.Map {
@@ -291,6 +325,23 @@ public class JdomCdiRep implements CdiRep {
             } catch (org.jdom2.DataConversionException e1) { return 0; }
         }
 
+        @Override
+        public String getLinkText() {
+            Element c = e.getChild("link");
+            if (c == null) return null;
+            return c.getText();
+        }
+
+        @Override
+        public String getLinkURL() {
+            Element c = e.getChild("link");
+            if (c == null) return null;
+            Attribute a = c.getAttribute("ref");
+            if (a == null) return null;
+            return a.getValue();
+        }
+
+        @Override
         public boolean isHideable() {
             // defaults to false
             Element hints = e.getChild("hints");
@@ -307,6 +358,7 @@ public class JdomCdiRep implements CdiRep {
             }
         }
 
+        @Override
         public boolean isHidden() {
             // defaults to false
             Element hints = e.getChild("hints");
@@ -321,6 +373,15 @@ public class JdomCdiRep implements CdiRep {
             } catch (DataConversionException ex) {
                 return false;
             }
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            // defaults to false
+            Element hints = e.getChild("hints");
+            if (hints == null) return false;
+            Element readOnly = hints.getChild("readOnly");
+            return readOnly != null;
         }
 
         /**

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -550,8 +550,12 @@ public class JdomCdiRep implements CdiRep {
             if (slider == null) return false;
             Attribute immediate = slider.getAttribute("immediate");
             if (immediate == null) return false;
-            if (! immediate.getValue().toLowerCase().equals("yes")) return false;
-            return true;
+            try {
+                boolean value = immediate.getBooleanValue();
+                return value;
+            } catch (DataConversionException ex) {
+                return false;
+            }
         }
 
         @Override
@@ -567,6 +571,21 @@ public class JdomCdiRep implements CdiRep {
             } catch (org.jdom2.DataConversionException e) { return 0; }
         }
 
+        @Override
+        public boolean isSliderShowValue() {
+            Element hints = e.getChild("hints");
+            if (hints == null) return false;
+            Element slider = hints.getChild("slider");
+            if (slider == null) return false;
+            Attribute showValue = slider.getAttribute("showValue");
+            if (showValue == null) return false;
+            try {
+                boolean value = showValue.getBooleanValue();
+                return value;
+            } catch (DataConversionException ex) {
+                return false;
+            }
+        }
     }
 
 

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -586,6 +586,16 @@ public class JdomCdiRep implements CdiRep {
                 return false;
             }
         }
+
+        @Override
+        public boolean isRadioButtonHint() {
+            Element hints = e.getChild("hints");
+            if (hints == null) return false;
+            Element radiobutton = hints.getChild("radiobutton");
+            if (radiobutton == null) return false;
+            return true;
+        }
+
     }
 
 

--- a/src/org/openlcb/cdi/jdom/JdomCdiRep.java
+++ b/src/org/openlcb/cdi/jdom/JdomCdiRep.java
@@ -128,6 +128,7 @@ public class JdomCdiRep implements CdiRep {
                     case "repname":
                     case "name":
                     case "description":
+                    case "hints":
                         break;
                     default:
                         list.add(new UnknownRep(element));

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -2090,7 +2090,6 @@ public class CdiPanel extends JPanel {
                 }
  
                 // write button is suppressed if flagged as read only
-                System.out.println("process "+entry.key);
                 if (! entry.isFlaggedReadOnly()) {
                     writeButton = factory.handleWriteButton(new JButton("Write"));
                     writeButton.addActionListener(new java.awt.event.ActionListener() {

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -1909,16 +1909,20 @@ public class CdiPanel extends JPanel {
         protected void additionalButtons() {}
 
         protected void init() {
+            // a panel that may exist below the main component (textComponent)
+            // which, if present, gets the Refresh and Write buttons
+            JPanel subpanel = null;
+            
             if (textComponent instanceof JTextArea) {
-                JPanel lengthPanel = new JPanel();
+                subpanel = new JPanel();
                 
                 // include an auto-updating "remaining characters" field
-                lengthPanel.setLayout(new FlowLayout());
+                subpanel.setLayout(new FlowLayout());
                 JLabel lengthLabel = new JLabel("Remaining characters: ");
-                lengthPanel.add(lengthLabel);
+                subpanel.add(lengthLabel);
                 final JTextField countField = new JTextField(6);
                 countField.setText(""+(entry.size-1));
-                lengthPanel.add(countField);
+                subpanel.add(countField);
                 lengthLabel.setFont(countAreaFont);
                 countField.setFont(countAreaFont);
                 
@@ -1949,7 +1953,7 @@ public class CdiPanel extends JPanel {
                 };
                 spane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
                 combinedPanel.add(spane);
-                combinedPanel.add(lengthPanel);
+                combinedPanel.add(subpanel);
                 
                 p3.add(combinedPanel);
 
@@ -2053,8 +2057,12 @@ public class CdiPanel extends JPanel {
                         entry.reload();
                     }
                 });
-                p3.add(b);
-
+                if (subpanel != null ) {
+                    subpanel.add(b);
+                } else {
+                    p3.add(b);
+                }
+ 
                 writeButton = factory.handleWriteButton(new JButton("Write"));
                 writeButton.addActionListener(new java.awt.event.ActionListener() {
                     @Override
@@ -2062,7 +2070,11 @@ public class CdiPanel extends JPanel {
                         writeDisplayTextToNode();
                     }
                 });
-                p3.add(writeButton);
+                if (subpanel != null ) {
+                    subpanel.add(writeButton);
+                } else {
+                    p3.add(writeButton);
+                }
             }
             
             additionalButtons();

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -1924,15 +1924,31 @@ public class CdiPanel extends JPanel {
                 
                 JPanel combinedPanel = new JPanel();
                 combinedPanel.setLayout(new BoxLayout(combinedPanel, BoxLayout.Y_AXIS));
-                combinedPanel.add(new JScrollPane(textComponent){
+                JScrollPane spane = new JScrollPane(textComponent){
                     // Limit how small the layout will make the field
                     public Dimension getMinimumSize() {
                         Dimension superSize = super.getMinimumSize();
                         int width = superSize.width;
-                        int height = Math.max(superSize.height, 200);
+                        int height = Math.max(superSize.height, 50);
                         return new Dimension(width, height);
                     }
-                });
+                    public Dimension getPreferredSize() {
+                        Dimension superMin = super.getMinimumSize();
+                        Dimension superPref = super.getPreferredSize();
+                        int width = Math.max(superMin.width, superPref.width);
+                        int height = Math.max(superMin.height, superPref.height);
+                        return new Dimension(width, height);
+                    }
+                    public Dimension getMaximumSize() {
+                        Dimension superMax = super.getMaximumSize();
+                        Dimension superPref = super.getPreferredSize();
+                        int width = Math.max(superMax.width, superPref.width);
+                        int height = Math.max(superMax.height, superPref.height);
+                        return new Dimension(width, height);
+                    }
+                };
+                spane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
+                combinedPanel.add(spane);
                 combinedPanel.add(lengthPanel);
                 
                 p3.add(combinedPanel);
@@ -2722,7 +2738,10 @@ public class CdiPanel extends JPanel {
                 textField = jtf;
             } else {
                 // Long string. Show multi-line editor
-                JTextArea jta = new JTextArea(doc, "", Math.min(40, (int)(entry.size / 40)), 80);// line count is heuristic
+                // For character count handling, see EntryPane#init() below
+                JTextArea jta = new JTextArea(doc, "", Math.min(40, (int)(entry.size / 32)), 80);
+                        // Line count estimate is heuristic
+                        // Limited to 40 lines to keep GUI under control
                 jta.setEditable(true);
                 jta.setLineWrap(true);
                 jta.setWrapStyleWord(true);
@@ -2731,7 +2750,7 @@ public class CdiPanel extends JPanel {
                 textField = jta;
             }
             textComponent = textField;
-            textComponent.setToolTipText("String of up to "+entry.size+" characters");
+            textComponent.setToolTipText("String of up to "+(entry.size-1)+" characters"); // -1 for terminating zero in field
             init();
         }
 

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -1101,14 +1101,14 @@ public class CdiPanel extends JPanel {
             super.visitGroup(e);
             factory.handleGroupPaneEnd(groupPane);
 
-            if (groupPane.getComponentCount() > 0) {
-                if (oldPane instanceof SegmentPane) {
-                    // we make toplevel groups collapsible.
+            if (groupPane.getComponentCount() > 0) { // empty groups are not collabsible
+                if (oldPane instanceof SegmentPane || e.isHideable()) { // we only make toplevel groups collapsible unless hint requests
                     groupPane.setBorder(null);
                     CollapsiblePanel cPanel = new CollapsiblePanel(groupPane.getName(), groupPane);
                     // cPanel.setBorder(BorderFactory.createLineBorder(java.awt.Color.RED)); //debugging
                     cPanel.setAlignmentY(Component.TOP_ALIGNMENT);
                     cPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+                    cPanel.setExpanded(!e.isHidden());
                     oldPane.add(cPanel);
                     addNavigationActions(cPanel);
                 } else {

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -1100,12 +1100,15 @@ public class CdiPanel extends JPanel {
             factory.handleGroupPaneStart(groupPane);
             if (e.isReadOnlyConfigured()) {
                 // mark the direct children of these, except groups, as readOnly
+                // when the direct child is a grouprep (repetitions > 1), mark those children
                 for (ConfigRepresentation.CdiEntry entry : e.getEntries()) {
                     if (! (entry instanceof ConfigRepresentation.GroupEntry) ) {
-                        System.out.println("Non Group Entry");
-                        entry.setFlaggedReadOnly(true);
-                    } else {
-                        System.out.println("Group Entry");
+                         entry.setFlaggedReadOnly(true);
+                        if (entry instanceof ConfigRepresentation.GroupRep ) {
+                            for (ConfigRepresentation.CdiEntry subentry : ((ConfigRepresentation.GroupRep)entry).getEntries()) {
+                                subentry.setFlaggedReadOnly(true);
+                            }
+                        }
                     }
                 }
             }
@@ -2087,7 +2090,8 @@ public class CdiPanel extends JPanel {
                 }
  
                 // write button is suppressed if flagged as read only
-                if (entry.isFlaggedReadOnly()) {
+                System.out.println("process "+entry.key);
+                if (! entry.isFlaggedReadOnly()) {
                     writeButton = factory.handleWriteButton(new JButton("Write"));
                     writeButton.addActionListener(new java.awt.event.ActionListener() {
                         @Override

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -115,7 +115,7 @@ import static org.openlcb.implementations.BitProducerConsumer.nullEvent;
  *
  * Works with a CDI reader.
  *
- * @author  Bob Jacobsen   Copyright 2011
+ * @author  Bob Jacobsen   Copyright 2011, 2024
  * @author  Paul Bender Copyright 2016
  * @author  Balazs Racz Copyright 2016
  * @author  Pete Cressman Copyright 2020
@@ -2220,6 +2220,7 @@ public class CdiPanel extends JPanel {
             if (eventTable != null) {
                 add(eventNamesLabel);
             }
+            if (e.isFlaggedReadOnly()) textComponent.setEnabled(false);
         }
 
         /**
@@ -2533,6 +2534,17 @@ public class CdiPanel extends JPanel {
             }
         }
         
+        @Override
+        public void setEnabled(boolean state) {
+            super.setEnabled(state);
+            if (slider != null) {
+                slider.setEnabled(state);
+            }
+            if (textField != null) {
+                textField.setEnabled(state);
+            }
+        }
+        
         // copies the textfield value to the slider, handling errors
         void textToSlider() {
             try {
@@ -2650,6 +2662,7 @@ public class CdiPanel extends JPanel {
             }
 
             init();
+            if (e.isFlaggedReadOnly()) textComponent.setEnabled(false);
         }
 
         @Override
@@ -2786,6 +2799,7 @@ public class CdiPanel extends JPanel {
                 +" ("+entry.size+" bytes)");
 
             init();
+            if (e.isFlaggedReadOnly()) textComponent.setEnabled(false);
         }
 
         @Override
@@ -2906,6 +2920,7 @@ public class CdiPanel extends JPanel {
             textComponent = textField;
             textComponent.setToolTipText("String of up to "+(entry.size-1)+" characters"); // -1 for terminating zero in field
             init();
+            if (e.isFlaggedReadOnly()) textComponent.setEnabled(false);
         }
 
         @Override

--- a/src/org/openlcb/swing/EventIdTextField.java
+++ b/src/org/openlcb/swing/EventIdTextField.java
@@ -64,6 +64,7 @@ public class EventIdTextField extends JFormattedTextField  {
         // Let's size the event ID fields for the longest event ID in pixels.
         retval.setValue("DD.DD.DD.DD.DD.DD.DD.DD");
         retval.setPreferredSize(retval.getPreferredSize());
+        retval.setMinimumSize(retval.getPreferredSize());
         retval.setValue("00.00.00.00.00.00.00.00");
         
         retval.setToolTipText("EventID as eight-byte dotted-hex string, "

--- a/src/org/openlcb/swing/NodeSelector.java
+++ b/src/org/openlcb/swing/NodeSelector.java
@@ -272,5 +272,14 @@ public class NodeSelector extends JComboBox<NodeSelector.ModelEntry>  {
         return me.getNodeID();
     }
 
+    public void setSelectedNodeID(NodeID nodeID) {
+        for (int i = 0; i < model.getSize(); ++i) {
+             if (model.getElementAt(i).getNodeID().equals(nodeID)) {
+                super.setSelectedItem(model.getElementAt(i));
+                break;
+            }
+        }
+    }
+    
     private static final Logger log = Logger.getLogger(NodeSelector.class.getName());
 }

--- a/test/org/openlcb/ProducerConsumerEventReportMessageTest.java
+++ b/test/org/openlcb/ProducerConsumerEventReportMessageTest.java
@@ -85,6 +85,18 @@ public class ProducerConsumerEventReportMessageTest {
     }
 
     @Test   
+    public void testPayloadToString() {
+        ProducerConsumerEventReportMessage m1 = new ProducerConsumerEventReportMessage(
+                                nodeID1, eventID1 );
+        
+        byte[] payload1 = new byte[]{0x12, 0x34};
+        ProducerConsumerEventReportMessage m2 = new ProducerConsumerEventReportMessage(
+                                nodeID1, eventID1, payload1 );
+        
+        Assert.assertEquals(" Producer/Consumer Event Report  EventID:01.00.00.00.00.00.01.00 payload of 2 : 12.34", m2.toString());
+    }
+
+    @Test   
     public void testPayloadHashAndEquals() {
         ProducerConsumerEventReportMessage mNone = new ProducerConsumerEventReportMessage(
                                 nodeID1, eventID1 );


### PR DESCRIPTION
Add control for visibility of groups in CDI display via a hints element

Also fixes
 - Problem with alignment when text field longer then 64 characters
 - Off-by-one error in length listed in String tooltip