### PR TITLE
Node naming updates

### DIFF
--- a/src/org/openlcb/EventNameStore.java
+++ b/src/org/openlcb/EventNameStore.java
@@ -25,7 +25,7 @@ public interface EventNameStore {
     public EventID getEventID(String eventName);
     
     /**
-     * @param A valid event ID, not null
+     * @param eventID A valid event ID, not null
      * @return If a name has been associated with this event ID, return that name, 
      *      otherwise an event ID from parsing the eventName as dotted-hex.
      */

--- a/src/org/openlcb/EventNameStore.java
+++ b/src/org/openlcb/EventNameStore.java
@@ -19,14 +19,14 @@ public interface EventNameStore {
     /**
      * @param eventName Either a previously stored event name that is 
      *      is associated to an event ID, or the dotted-hex form of an Event ID
-     * @returns an eventID from tne matching name, if any
+     * @return an eventID from tne matching name, if any
      *          otherwise directly return the doted-hex input.
      */
     public EventID getEventID(String eventName);
     
     /**
-     * @parm A valid event ID, not null
-     * @returns If a name has been associated with this event ID, return that name, 
+     * @param A valid event ID, not null
+     * @return If a name has been associated with this event ID, return that name, 
      *      otherwise an event ID from parsing the eventName as dotted-hex.
      */
     public String getEventName(EventID eventID);

--- a/src/org/openlcb/EventNameStore.java
+++ b/src/org/openlcb/EventNameStore.java
@@ -16,8 +16,19 @@ package org.openlcb;
  */
 public interface EventNameStore {
 
+    /**
+     * @param eventName Either a previously stored event name that is 
+     *      is associated to an event ID, or the dotted-hex form of an Event ID
+     * @returns an eventID from tne matching name, if any
+     *          otherwise directly return the doted-hex input.
+     */
     public EventID getEventID(String eventName);
     
+    /**
+     * @parm A valid event ID, not null
+     * @returns If a name has been associated with this event ID, return that name, 
+     *      otherwise an event ID from parsing the eventName as dotted-hex.
+     */
     public String getEventName(EventID eventID);
     
 }

--- a/src/org/openlcb/cdi/cmd/BackupConfig.java
+++ b/src/org/openlcb/cdi/cmd/BackupConfig.java
@@ -62,7 +62,7 @@ public class BackupConfig {
 
                        @Override
                        public void visitEvent(ConfigRepresentation.EventEntry e) {
-                           writeEntry(finalWriter, e.key, e.getValue());
+                           writeEntry(finalWriter, e.key, e.getNumericalEventValue());
                        }
                    }
         );

--- a/src/org/openlcb/cdi/impl/ConfigRepresentation.java
+++ b/src/org/openlcb/cdi/impl/ConfigRepresentation.java
@@ -776,6 +776,13 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
             if (b == null) return;
             cache.write(origin, b, this);
         }
+
+        public void setValue(String eventName) {
+            EventID event;
+            if (eventNameStore == null) event = new EventID(eventName);
+            else event = eventNameStore.getEventID(eventName);
+            setValue(event);
+        }
     }
 
     /**

--- a/src/org/openlcb/cdi/impl/ConfigRepresentation.java
+++ b/src/org/openlcb/cdi/impl/ConfigRepresentation.java
@@ -746,7 +746,7 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
         }
 
         /**
-         * @returns if `eventNameStore` exists, return the name of the contained event
+         * @return if `eventNameStore` exists, return the name of the contained event
          *          otherwise return the numerical event ID in dotted-hex form.
          */
         public String getValue() {
@@ -759,7 +759,7 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
         }
 
         /**
-         * @returns the numerical event ID in dotted-hex form,
+         * @return the numerical event ID in dotted-hex form,
          *          ignoring any conversion eventNameStore that might exist
          */
         public String getNumericalEventValue() {

--- a/src/org/openlcb/cdi/impl/ConfigRepresentation.java
+++ b/src/org/openlcb/cdi/impl/ConfigRepresentation.java
@@ -17,6 +17,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openlcb.DefaultPropertyListenerSupport;
 import org.openlcb.EventID;
+import org.openlcb.EventNameStore;
 import org.openlcb.NodeID;
 import org.openlcb.OlcbInterface;
 import org.openlcb.Utilities;
@@ -60,7 +61,7 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
     // Last time the progressbar was updated from the load.
     private long lastProgress;
 
-    public org.openlcb.cdi.swing.CdiPanel.GuiItemFactory factory = null;
+    public EventNameStore eventNameStore;
     
     /**
      * Connects to a node, populates the cache by fetching and parsing the CDI.
@@ -744,13 +745,29 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
             }
         }
 
+        /**
+         * @returns if `eventNameStore` exists, return the name of the contained event
+         *          otherwise return the numerical event ID in dotted-hex form.
+         */
         public String getValue() {
             MemorySpaceCache cache = getCacheForSpace(space);
             byte[] b = cache.read(origin, size);
             if (b == null) return null;
             EventID eid = new EventID(b);
-            if (factory == null) return eid.toShortString();
-            return factory.getStringFromEventID(eid);
+            if (eventNameStore == null) return eid.toShortString();
+            return eventNameStore.getEventName(eid);
+        }
+
+        /**
+         * @returns the numerical event ID in dotted-hex form,
+         *          ignoring any conversion eventNameStore that might exist
+         */
+        public String getNumericalEventValue() {
+            MemorySpaceCache cache = getCacheForSpace(space);
+            byte[] b = cache.read(origin, size);
+            if (b == null) return null;
+            EventID eid = new EventID(b);
+            return eid.toShortString();
         }
 
         public void setValue(EventID event) {

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -226,7 +226,6 @@ public class CdiPanel extends JPanel {
         setAlignmentX(Component.LEFT_ALIGNMENT);
         this.rep = rep;
         this.factory = factory;
-        rep.factory = factory;
         
         contentPanel = new JPanel();
         contentPanel.setLayout(new BoxLayout(contentPanel, BoxLayout.Y_AXIS));
@@ -2328,7 +2327,7 @@ public class CdiPanel extends JPanel {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                     NodeID node = rep.getConnection().getNodeId();
-                    EventID ev = factory.getEventIDFromString(textField.getText());
+                    EventID ev = rep.eventNameStore.getEventID(textField.getText());
                     rep.getConnection().getOutputConnection().put(new ProducerConsumerEventReportMessage(node, ev), rep.getConnection().getOutputConnection());
                 }
             });
@@ -2398,15 +2397,18 @@ public class CdiPanel extends JPanel {
 
         @Override
         protected void writeDisplayTextToNode() {
-            entry.setValue(factory.getEventIDFromString(textField.getText()));
+            entry.setValue(rep.eventNameStore.getEventID(textField.getText()));
             _changeMade = true;
             notifyTabColorRefresh();
         }
 
         @Override
         protected void updateDisplayText(@NonNull String value) {
-            EventID eid = factory.getEventIDFromString(value);
-            String retval = factory.getStringFromEventID(eid);
+            String retval = "";
+            if (!value.isEmpty()) {
+                EventID eid = rep.eventNameStore.getEventID(value);
+                retval = rep.eventNameStore.getEventName(eid);
+            }
             textField.setText(retval);
         }
 
@@ -2431,7 +2433,7 @@ public class CdiPanel extends JPanel {
             
             try {
 //                id = new EventID(s);
-                id = factory.getEventIDFromString(s);
+                id = rep.eventNameStore.getEventID(s);
             } catch (RuntimeException e) {
                 // Event is not in the right format. Ignore.
                 return;
@@ -2460,6 +2462,8 @@ public class CdiPanel extends JPanel {
             eventTableEntryHolder = null;
         }
     }
+
+
 
     // represent a slider with an optional text view
     private class SliderWithView extends JPanel {
@@ -3232,24 +3236,6 @@ public class CdiPanel extends JPanel {
         public JTextArea handleEditorValue(JTextArea value) {
             return value;
         }
-        
-        /** Convert a String into an EventID, doing any additional local
-         * dealiasing required.
-         * @param content Content to convert, e.g. from a text component
-         * @return eventID that represents the content
-         */
-         public EventID getEventIDFromString(String content) {
-            return new EventID(content);
-         }
-
-        /** Convert an EventID into a String, doing any additional local
-         * aliasing required.
-         * @param event EventID to convert, e.g. from reading a node
-         * @return local representation fo that EventID, often just the dotted hex
-         */
-         public String getStringFromEventID(EventID event) {
-            return event.toShortString();  
-         }
     }
     
     /**

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -2432,7 +2432,6 @@ public class CdiPanel extends JPanel {
             EventID id;
             
             try {
-//                id = new EventID(s);
                 id = rep.eventNameStore.getEventID(s);
             } catch (RuntimeException e) {
                 // Event is not in the right format. Ignore.


### PR DESCRIPTION
 - backups now use dotted-hex format for events even if event names are available
 - refactor to make broader access to event names easier
 - some clean up and additional comments
 - Fixed MTI description for EWP MTIs, including test update