### PR TITLE
Handle value-getting when no namestore configured

### DIFF
--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -2406,8 +2406,12 @@ public class CdiPanel extends JPanel {
         protected void updateDisplayText(@NonNull String value) {
             String retval = "";
             if (!value.isEmpty()) {
-                EventID eid = rep.eventNameStore.getEventID(value);
-                retval = rep.eventNameStore.getEventName(eid);
+                if (rep.eventNameStore != null ) {
+                    EventID eid = rep.eventNameStore.getEventID(value);
+                    retval = rep.eventNameStore.getEventName(eid);
+                } else {
+                    retval = value;
+                }
             }
             textField.setText(retval);
         }


### PR DESCRIPTION
For people using the library without configuring a name store before CDI operations, this skips the name store lookup and directly provides the Event ID