### PR TITLE
Better status reporting on initial config load

### DIFF
--- a/src/org/openlcb/cdi/cmd/RestoreConfig.java
+++ b/src/org/openlcb/cdi/cmd/RestoreConfig.java
@@ -40,6 +40,7 @@ public class RestoreConfig {
         try {
             while ((line = reader.readLine()) != null) {
                 if (line.charAt(0) == '#') continue;
+                if (line.isEmpty()) continue;
                 int pos = line.indexOf('=');
                 if (pos < 0) {
                     logger.log(Level.WARNING, "Failed to parse line: {0}", line);

--- a/src/org/openlcb/cdi/impl/ConfigRepresentation.java
+++ b/src/org/openlcb/cdi/impl/ConfigRepresentation.java
@@ -60,6 +60,8 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
     private final Map<String, CdiEntry> variables = new HashMap<>();
     // Last time the progressbar was updated from the load.
     private long lastProgress;
+    
+    private int cacheMemoryRead;
 
     public EventNameStore eventNameStore;
     
@@ -98,10 +100,10 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
             public void progressNotify(long bytesRead, long totalBytes) {
                 lastProgress = new Date().getTime();
                 if (totalBytes > 0) {
-                    setState(String.format("Loading: %.2f%% complete", bytesRead * 100.0 /
+                    setState(String.format("Loading display format: %.2f%% complete", bytesRead * 100.0 /
                             totalBytes));
                 } else {
-                    setState(String.format("Loading: %d bytes complete", bytesRead));
+                    setState(String.format("Loading display format: %d bytes complete", bytesRead));
                 }
             }
 
@@ -139,12 +141,18 @@ public class ConfigRepresentation extends DefaultPropertyListenerSupport {
                     .UPDATE_LOADING_COMPLETE)) {
                 synchronized (this) {
                     if (--pendingCacheFills == 0) {
-                        firePropertyChange(UPDATE_CACHE_COMPLETE, null, null);
+                        firePropertyChange(UPDATE_CACHE_COMPLETE, null, 1);
                         for (MemorySpaceCache sp : spaces.values()) {
                             sp.removePropertyChangeListener(prefillListener);
                         }
                     }
                 }
+            } else if (propertyChangeEvent.getPropertyName().equals(MemorySpaceCache
+                    .LOADING_RANGE)) {
+                cacheMemoryRead += (Integer)propertyChangeEvent.getNewValue();
+                setState(String.format("Loading configuration data: %d bytes complete", cacheMemoryRead));
+                firePropertyChange(UPDATE_STATE, null, cacheMemoryRead);
+                
             }
         }
     };

--- a/src/org/openlcb/cdi/impl/MemorySpaceCache.java
+++ b/src/org/openlcb/cdi/impl/MemorySpaceCache.java
@@ -24,6 +24,8 @@ import org.openlcb.implementations.MemoryConfigurationService;
 public class MemorySpaceCache {
     // This event will be fired when the cache is completely pre-filled.
     public static final String UPDATE_LOADING_COMPLETE = "UPDATE_LOADING_COMPLETE";
+    // This event will be fired as each range is read
+    public static final String LOADING_RANGE = "LOADING_RANGE";
     // This event will be fired on the registered data listeners.
     public static final String UPDATE_DATA = "UPDATE_DATA";
     private static final Logger logger = Logger.getLogger(MemorySpaceCache.class.getName());
@@ -224,6 +226,7 @@ public class MemorySpaceCache {
         if (count > 64) {
             count = 64;
         }
+        firePropertyChange(LOADING_RANGE, null, count);
         final int fcount = count;
         access.doRead(currentRangeNextOffset, space, count,
                 new MemoryConfigurationService.McsReadHandler() {

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -108,6 +108,7 @@ import javax.swing.text.PlainDocument;
 import util.CollapsiblePanel;
 import util.WrapLayout;
 
+import static org.openlcb.cdi.impl.ConfigRepresentation.UPDATE_CACHE_COMPLETE;
 import static org.openlcb.cdi.impl.ConfigRepresentation.UPDATE_ENTRY_DATA;
 import static org.openlcb.cdi.impl.ConfigRepresentation.UPDATE_REP;
 import static org.openlcb.cdi.impl.ConfigRepresentation.UPDATE_STATE;
@@ -670,7 +671,7 @@ public class CdiPanel extends JPanel {
             loadingListener = new PropertyChangeListener() {
                 @Override
                 public void propertyChange(PropertyChangeEvent event) {
-                    if (event.getPropertyName().equals(UPDATE_REP)) {
+                    if (event.getPropertyName().equals(UPDATE_CACHE_COMPLETE)) {
                         displayCdi();
                     } else if (event.getPropertyName().equals(UPDATE_STATE)) {
                         loadingText.setText(rep.getStatus());

--- a/test/org/openlcb/cdi/impl/ConfigRepresentationTest.java
+++ b/test/org/openlcb/cdi/impl/ConfigRepresentationTest.java
@@ -45,7 +45,7 @@ public class ConfigRepresentationTest {
         ConfigRepresentation rep = new ConfigRepresentation(iface, remoteNode);
         // Since all of our memory configuration commands execute inline, the representation will
         // be ready by the time it returns.
-        Assert.assertEquals("Representation complete.", rep.getStatus());
+        Assert.assertEquals("Loading configuration data: 73 bytes complete", rep.getStatus());
         Assert.assertNotNull(rep.getRoot());
 
         ConfigRepresentation.CdiContainer cont = rep.getRoot();


### PR DESCRIPTION
Previously, when you opened a CDI configuration window, the window status would show the CDI loading, but the window would then display while all the configuration values load in the background.  This could lead to various problems if the user interacted with the display before the relevant values were loaded.

With this PR, the window stays in status mode, not fully displaying, until the load of configuration data is complete.  This can be a significant additional delay if loading from a node with a larger configuration memory, but it makes the result much safer.

To do this, additional properties are fired and listened-to.  

In addition, a blank line will now be accepted as a comment when reading a backup file to restore it.