### PR TITLE
Update unspecified write timeout to 3 seconds

### DIFF
--- a/src/org/openlcb/implementations/MemoryConfigurationService.java
+++ b/src/org/openlcb/implementations/MemoryConfigurationService.java
@@ -556,8 +556,8 @@ public class MemoryConfigurationService {
                         ((flags & DatagramService.FLAG_REPLY_PENDING) != 0)) {
                     // Leave the memo in the pending, will wait for reply datagram.
                     logger.fine("rcvd RequestWithReplyDatagram with flags "+flags);
-                    int timeout = 1 << (flags & 0x0F);
-                    timeout = timeout * 1000; // to milliseconds
+                    int timeout = 1 << (flags & 0x0F) * 1000; // to msec
+                    if ((flags & 0x0F) == 0) timeout = 3000;  // no timeout specified, 3 seconds is default
                     logger.fine("            and timeout  "+timeout+", restarting");
                     restartTimeout(memo, timeout);
                     return;


### PR DESCRIPTION
Previously, the memory r/w service assumed that a write operation without a specified timeout would respond in 750msec or less, and acted after one second.  The message standard says that unspecified timeouts should not be less than three seconds. This PR updates the write-response behavior to be consistent with that.