### PR TITLE
Refactor deferred end of group processing for flexibility

### DIFF
--- a/src/org/openlcb/Message.java
+++ b/src/org/openlcb/Message.java
@@ -69,6 +69,7 @@ abstract public class Message implements OpenLcb {
 
      /**
       * Get the numerical value of the MTI
+      * @return The MTI as a standard full value
       */
      abstract public int getMTI();
 }

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -3225,6 +3225,7 @@ public class CdiPanel extends JPanel {
          *              this is a {@link GroupPane}.
          */
         public void handleManualPaneEnd(JPanel panel) {
+            handleGroupPaneEnd(pane); // default implementation provides same function
             return;
         }
         

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -3224,7 +3224,7 @@ public class CdiPanel extends JPanel {
          *              representation of the group. In {@link CdiPanel}, 
          *              this is a {@link GroupPane}.
          */
-        public void handleManualPaneEnd(JPanel panel) {
+        public void handleManualPaneEnd(JPanel pane) {
             handleGroupPaneEnd(pane); // default implementation provides same function
             return;
         }

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -359,7 +359,7 @@ public class CdiPanel extends JPanel {
         createHelper.add(lineHelper);
 
         // Calls into JMRI to add the Create Sensor and Create Turnout buttons.
-        factory.handleManualPaneEnd(createHelper);
+        factory.handleManualEnd(createHelper);
         sensorHelperPanel = new CollapsiblePanel("Sensor/Turnout creation", createHelper);
         sensorHelperPanel.setBackground(getForeground());
         sensorHelperPanel.setExpanded(false);
@@ -3204,18 +3204,6 @@ public class CdiPanel extends JPanel {
         }
 
         /**
-         * Called after a group have been constructedd.
-         * Paired with {@link handleGroupPaneStart}.
-         *
-         * @param pane The GUI panel that has been populated with the 
-         *              representation of the group. In {@link CdiPanel}, 
-         *              this is a {@link GroupPane}.
-         */
-        public void handleGroupPaneEnd(JPanel pane) {
-            return;
-        }
-        
-        /**
          * Similar to handleGroupPaneEnd, this asserts that the
          * processing should happen on the current group 
          * which has been manually (e.g. not from CDI) created.
@@ -3224,9 +3212,19 @@ public class CdiPanel extends JPanel {
          *              representation of the group. In {@link CdiPanel}, 
          *              this is a {@link GroupPane}.
          */
-        public void handleManualPaneEnd(JPanel pane) {
+        public void handleManualEnd(JPanel pane) {
             handleGroupPaneEnd(pane); // default implementation provides same function
-            return;
+        }
+        
+        /**
+         * Called after a group have been constructedd.
+         * Paired with {@link handleGroupPaneStart}.
+         *
+         * @param pane The GUI panel that has been populated with the 
+         *              representation of the group. In {@link CdiPanel}, 
+         *              this is a {@link GroupPane}.
+         */
+        public void handleGroupPaneEnd(JPanel pane) {
         }
         
         /**

--- a/src/org/openlcb/cdi/swing/CdiPanel.java
+++ b/src/org/openlcb/cdi/swing/CdiPanel.java
@@ -359,7 +359,7 @@ public class CdiPanel extends JPanel {
         createHelper.add(lineHelper);
 
         // Calls into JMRI to add the Create Sensor and Create Turnout buttons.
-        factory.handleGroupPaneEnd(createHelper);
+        factory.handleManualPaneEnd(createHelper);
         sensorHelperPanel = new CollapsiblePanel("Sensor/Turnout creation", createHelper);
         sensorHelperPanel.setBackground(getForeground());
         sensorHelperPanel.setExpanded(false);
@@ -3212,6 +3212,19 @@ public class CdiPanel extends JPanel {
          *              this is a {@link GroupPane}.
          */
         public void handleGroupPaneEnd(JPanel pane) {
+            return;
+        }
+        
+        /**
+         * Similar to handleGroupPaneEnd, this asserts that the
+         * processing should happen on the current group 
+         * which has been manually (e.g. not from CDI) created.
+         *
+         * @param pane The GUI panel that has been populated with the 
+         *              representation of the group. In {@link CdiPanel}, 
+         *              this is a {@link GroupPane}.
+         */
+        public void handleManualPaneEnd(JPanel panel) {
             return;
         }
         


### PR DESCRIPTION
End-of-group CDI processing is deferred to a class that's eventually populated by JMRI.  This refactors the single call that was used both for CDI groups, and also for the special "group" that does that handles adding a panel at the bottom of the CDI, into two separate function calls. This allows them to be handled separately in JMRI.  

The refactoring leaves the same default behavior in place. Library users that just use the original call will see no change in behavior.